### PR TITLE
Fix rating display showing 0.7 instead of 7.0

### DIFF
--- a/lib/models/plex_metadata.dart
+++ b/lib/models/plex_metadata.dart
@@ -12,7 +12,7 @@ class PlexMetadata {
   final String title;
   final String? contentRating;
   final String? summary;
-  final int? rating;
+  final double? rating;
   final int? year;
   final String? thumb;
   final String? art;

--- a/lib/models/plex_metadata.g.dart
+++ b/lib/models/plex_metadata.g.dart
@@ -15,7 +15,7 @@ PlexMetadata _$PlexMetadataFromJson(Map<String, dynamic> json) => PlexMetadata(
   title: json['title'] as String,
   contentRating: json['contentRating'] as String?,
   summary: json['summary'] as String?,
-  rating: (json['rating'] as num?)?.toInt(),
+  rating: (json['rating'] as num?)?.toDouble(),
   year: (json['year'] as num?)?.toInt(),
   thumb: json['thumb'] as String?,
   art: json['art'] as String?,

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -796,7 +796,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                             [
                               contentTypeLabel,
                               if (heroItem.rating != null)
-                                '★ ${(heroItem.rating! / 10).toStringAsFixed(1)}',
+                                '★ ${heroItem.rating!.toStringAsFixed(1)}',
                               if (heroItem.contentRating != null)
                                 heroItem.contentRating!,
                               if (heroItem.year != null)


### PR DESCRIPTION
Fixes #7

- Changed rating field type from int to double in PlexMetadata model
- Removed incorrect division by 10 in discover screen rating display
- Regenerated JSON serialization to properly parse rating as double
- Rating now displays correctly (e.g., 7.0 instead of 0.7)