### PR TITLE
Fix content rating display to remove country prefixes

### DIFF
--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -19,6 +19,7 @@ import '../mixins/item_updatable.dart';
 import '../utils/app_logger.dart';
 import '../utils/provider_extensions.dart';
 import '../utils/video_player_navigation.dart';
+import '../utils/content_rating_formatter.dart';
 import 'auth_screen.dart';
 
 class DiscoverScreen extends StatefulWidget {
@@ -798,7 +799,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                               if (heroItem.rating != null)
                                 '★ ${(heroItem.rating! / 10).toStringAsFixed(1)}',
                               if (heroItem.contentRating != null)
-                                heroItem.contentRating!,
+                                formatContentRating(heroItem.contentRating!),
                               if (heroItem.year != null)
                                 heroItem.year.toString(),
                             ].join(' • '),

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/media_context_menu.dart';
 import '../utils/app_logger.dart';
 import '../utils/provider_extensions.dart';
 import '../utils/video_player_navigation.dart';
+import '../utils/content_rating_formatter.dart';
 import '../theme/theme_helper.dart';
 import 'season_detail_screen.dart';
 
@@ -461,7 +462,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen> {
                                       borderRadius: BorderRadius.circular(6),
                                     ),
                                     child: Text(
-                                      metadata.contentRating!,
+                                      formatContentRating(metadata.contentRating!),
                                       style: const TextStyle(
                                         color: Colors.white,
                                         fontSize: 13,
@@ -715,7 +716,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen> {
                     const SizedBox(height: 12),
                   ],
                   if (metadata.contentRating != null) ...[
-                    _buildInfoRow('Rating', metadata.contentRating!),
+                    _buildInfoRow('Rating', formatContentRating(metadata.contentRating!)),
                     const SizedBox(height: 12),
                   ],
                 ],

--- a/lib/utils/content_rating_formatter.dart
+++ b/lib/utils/content_rating_formatter.dart
@@ -1,0 +1,17 @@
+/// Utility function to format content ratings by removing country prefixes
+String formatContentRating(String? contentRating) {
+  if (contentRating == null || contentRating.isEmpty) {
+    return '';
+  }
+
+  // Remove common country prefixes like "gb/", "us/", "de/", etc.
+  // The pattern matches: lowercase letters followed by a forward slash
+  final regex = RegExp(r'^[a-z]{2,3}/(.+)$', caseSensitive: false);
+  final match = regex.firstMatch(contentRating);
+
+  if (match != null && match.groupCount >= 1) {
+    return match.group(1) ?? contentRating;
+  }
+
+  return contentRating;
+}


### PR DESCRIPTION
- Add formatContentRating utility function to strip country codes (gb/, us/, de/, etc.)
- Apply formatter in discover_screen.dart hero section
- Apply formatter in media_detail_screen.dart (badge and info row)
- Ratings now display as '12', 'PG', 'PG-13' instead of 'gb/12', 'us/PG-13'
- Fixes #10