### PR TITLE
feat: add library reordering functionality (#6)

### DIFF
--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -9,6 +9,7 @@ class StorageService {
   static const String _keyClientId = 'client_identifier';
   static const String _keySelectedLibraryIndex = 'selected_library_index';
   static const String _keyLibraryFilters = 'library_filters';
+  static const String _keyLibraryOrder = 'library_order';
   static const String _keyUserProfile = 'user_profile';
   static const String _keyCurrentUserUUID = 'current_user_uuid';
   static const String _keyHomeUsersCache = 'home_users_cache';
@@ -167,7 +168,26 @@ class StorageService {
     await Future.wait([
       _prefs.remove(_keySelectedLibraryIndex),
       _prefs.remove(_keyLibraryFilters),
+      _prefs.remove(_keyLibraryOrder),
     ]);
+  }
+
+  // Library Order (stored as JSON list of library keys)
+  Future<void> saveLibraryOrder(List<String> libraryKeys) async {
+    final jsonString = json.encode(libraryKeys);
+    await _prefs.setString(_keyLibraryOrder, jsonString);
+  }
+
+  List<String>? getLibraryOrder() {
+    final jsonString = _prefs.getString(_keyLibraryOrder);
+    if (jsonString == null) return null;
+
+    try {
+      final decoded = json.decode(jsonString) as List<dynamic>;
+      return decoded.map((e) => e.toString()).toList();
+    } catch (e) {
+      return null;
+    }
   }
 
   // User Profile (stored as JSON string)


### PR DESCRIPTION
- Add reorder mode toggle button in Libraries screen app bar
- Implement drag & drop reordering for library chips
- Persist library order to local storage using SharedPreferences
- Restore saved library order on app launch
- Update selected library index when libraries are reordered
- Add visual feedback with drag handle icon in reorder mode

Fixes #6