### PR TITLE
Add 'Latest Episode Air Date' sort option for TV show libraries

### DIFF
--- a/lib/client/plex_client.dart
+++ b/lib/client/plex_client.dart
@@ -796,7 +796,7 @@ class PlexClient {
       return fallbackSorts;
     } catch (e) {
       appLogger.e('Failed to get library sorts: $e');
-      // Return minimal fallback sort options on error
+      // Return fallback sort options on error
       return [
         PlexSort(key: 'titleSort', title: 'Title', defaultDirection: 'asc'),
         PlexSort(


### PR DESCRIPTION
- Add conditional sort option for TV show libraries that sorts by the most recent episode's original air date
- Uses 'episode.originallyAvailableAt' field to track when the latest episode aired
- Only appears for TV show libraries, not movies or other media types
- Defaults to descending order to show recently aired episodes first
- Perfect for tracking seasonal anime/shows with new episodes

Fixes #31