### PR TITLE
bug: fix language detection in track match

### DIFF
--- a/lib/services/track_selection_service.dart
+++ b/lib/services/track_selection_service.dart
@@ -125,7 +125,7 @@ class TrackSelectionService {
 
       for (var track in availableTracks) {
         final trackLang = track.language?.toLowerCase();
-        if (trackLang != null && languageVariations.contains(trackLang)) {
+        if (trackLang != null && languageVariations.any((lang) => trackLang.startsWith(lang))) {
           appLogger.d(
             'Found audio track matching profile language "$preferredLanguage" (matched: "$trackLang"): ${track.title ?? "Track ${track.id}"}',
           );
@@ -260,7 +260,7 @@ class TrackSelectionService {
 
       for (var track in candidateTracks) {
         final trackLang = track.language?.toLowerCase();
-        if (trackLang != null && languageVariations.contains(trackLang)) {
+        if (trackLang != null && languageVariations.any((lang) => trackLang.startsWith(lang))) {
           appLogger.d(
             'Found subtitle matching profile language "$preferredLanguage" (matched: "$trackLang"): ${track.title ?? "Track ${track.id}"}',
           );


### PR DESCRIPTION
In findBestTrackMatch when checking the language of the track, it was incorrectly checking if it was contained in the language variations
but trackLang can be e.g. "en-US" and languageVariations can be "en", "eng", which will never work
With this fix, we check if one of the variations is present in trackLang

Now the user preference is correctly taken in account when the code is selecting a subtitle

There are two remaining issues that I will try to fix in separate PR because I'm still trying to understand the system
1. Preferred Subtitle (priority 1) does not work when playing a media where subtitle is set by user. I don't know if this is how it is supposed to work, so maybe this is the expected behaviour. Idk yet where preferredSubtitleTrack is coming from.

2. second priority, per-media language preference doesn't seem to work as metadata.subtitleLanguage is null. I think it may not exist in the metadata and maybe we need to extract it from the media metadata (there is a "selected" attribute on the subtitle track that is selected in the media data)
