### PR TITLE
Add Android Automotive OS (AAOS) support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,10 +22,14 @@
     <!-- Touchscreen not required for TV -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
 
+    <!-- Android Automotive OS support -->
+    <uses-feature android:name="android.hardware.type.automotive" android:required="false" />
+
     <application
         android:label="Plezy"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:appCategory="video">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary

  Adds support for Android Automotive OS (AAOS), enabling Plezy to run on vehicles like Polestar 2, Volvo EX90, etc.

  ## Changes

  - Add `android:appCategory="video"` to declare app as a video player
  - Add `uses-feature` for `android.hardware.type.automotive` (optional, not required)

  ## How it works

  AAOS automatically handles driving restrictions for apps with `appCategory="video"`. The system blocks the app while driving and shows its standard 'not available while driving' screen. No custom code required.

  ## Testing

  Tested on:
  - AAOS emulator (API 33)
  - Driving restriction behavior verified

  ## Notes

  - No impact on other platforms (Android phones, Android TV, iOS, desktop)
  - Purely additive changes to manifest
  - No new dependencies