### PR TITLE
Workaround for Discord Screensharing on Windows

### DIFF
--- a/windows/runner/mpv/mpv_container.cpp
+++ b/windows/runner/mpv/mpv_container.cpp
@@ -30,12 +30,14 @@ HWND MpvContainer::Create() {
   ::RegisterClassExW(&window_class);
 
   // Use WS_POPUP for a borderless window without title bar.
-  // Use WS_EX_TOOLWINDOW | WS_EX_NOREDIRECTIONBITMAP to prevent shadow and DWM effects.
   handle_ = ::CreateWindowExW(
-      WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_NOREDIRECTIONBITMAP,
+      WS_EX_APPWINDOW,
       kClassName, kWindowName, WS_POPUP,
       0, 0, 100, 100, nullptr, nullptr,
       GetModuleHandle(nullptr), nullptr);
+
+  // Set the window to be fully opaque. This forces a redirection surface.
+  ::SetLayeredWindowAttributes(handle_, 0, 255, LWA_ALPHA);
 
   // Disable DWM animations on the container.
   auto disable_window_transitions = TRUE;

--- a/windows/runner/mpv/mpv_container.h
+++ b/windows/runner/mpv/mpv_container.h
@@ -37,7 +37,7 @@ class MpvContainer {
   ITaskbarList3* taskbar_ = nullptr;
 
   static constexpr wchar_t kClassName[] = L"MPV_CONTAINER";
-  static constexpr wchar_t kWindowName[] = L"";
+  static constexpr wchar_t kWindowName[] = L"Plezy Video Stream";
 
   static std::unique_ptr<MpvContainer> instance_;
 };


### PR DESCRIPTION
Since the mpv player implementation in version 1.9.0, Discord screenshares/live streams on Windows machines have been appearing to have black video screens.

These changes (after so much back in forth with Gemini 3 Pro and filtering out non-essential changes) is the minimum workaround to allow Discord to get window capture while still allowing normal playback on the client (some changes suggested by Gemini would cause the video stream to go transparent or black or is completely unnecessary to get the end result).

Note that this creates a separate "window instance" that the discord user needs to select. The original window instance still shows up as a black video stream, which is why I call it a workaround than an actual fix.

<img width="872" height="284" alt="image" src="https://github.com/user-attachments/assets/66cb0ad6-ceef-4218-a2db-286b92e47cdf" />

This is one of my first open source PR, so please give me any feedback as needed and adjust the PR title.

Related Issue: #201 