### PR TITLE
Fix media poster aspect ratio

### DIFF
--- a/lib/widgets/plex_optimized_image.dart
+++ b/lib/widgets/plex_optimized_image.dart
@@ -298,7 +298,6 @@ class PlexOptimizedImage extends StatelessWidget {
           filterQuality: filterQuality,
           alignment: alignment,
           fadeInDuration: fadeInDuration,
-          memCacheWidth: memWidth,
           memCacheHeight: memHeight,
           cacheKey: effectiveCacheKey,
           placeholder: placeholder != null ? placeholder! : (context, url) => _buildPlaceholder(context),


### PR DESCRIPTION
This PR fixes an issue where poster thumbnails that aren't vertical were being stretched instead of preserving the original aspect ratio.

### Background

I watch a lot of YouTube videos in Plex, and for the show poster I use the YouTube channel thumbnail, which is always square. The Plex apps correctly display the thumbnail, by filling the poster and letting the extra sides get cropped off. However, Plezy currently stretches the square image to fit the vertical poster, which does not preserve the aspect ratio.

### Fix

When creating the image widget via `CachedNetworkImage`, I am setting *only* `memCacheHeight`, not `memCacheWidth`. This allows us to keep the cached image size for memory/performance savings, without forcing the image to fit into a different aspect ratio.

> Note: Removing either height or width seemed to fix the issue. But removing height caused the images to be very blurry (I guess it was scaling up a smaller image), so I went with removing width.

### Screenshots

For this demo, we will use the channel Simon Wilson.

Here is the channel thumbnail from YouTube.

![](https://yt3.googleusercontent.com/ytc/AIdro_nTkE3ECEYjR8I-GDNnWe0bqBOuhTv7iVhVhxc-7dwpIdc=s160-c-k-c0x00ffffff-no-rj)

Here is how it renders in the Plex app.

![](https://i.imgur.com/PfXIFHR.png)

#### Before

Here is how it previously rendered in Plezy on the Home screen. You can see it's somewhat squished.

![](https://i.imgur.com/mstoqyg.png)

And here it is in the Library screen (even more squished!).

![](https://i.imgur.com/xuW6nHg.png)

#### After

And here are the same two views with this PR's fix applied.

![](https://i.imgur.com/BBoVMCU.png)

![](https://i.imgur.com/I0suVSY.png)

---

P.S. This might be only one way to fix the issue. If there is a better fix, I am happy to defer! I will be happy to test any other possible fixes as well.