### PR TITLE
New: Click Series/Movie Title to be Redirected to the Appropriate Page

### DIFF
--- a/lib/models/plex_metadata.dart
+++ b/lib/models/plex_metadata.dart
@@ -327,8 +327,7 @@ class PlexMetadata with MultiServerFields {
     }
 
     // For movies/shows in mixed hub context with episode thumbnail mode, use art (16:9)
-    if (mixedHubContext && mode == EpisodePosterMode.episodeThumbnail &&
-        (itemType == 'movie' || itemType == 'show')) {
+    if (mixedHubContext && mode == EpisodePosterMode.episodeThumbnail && (itemType == 'movie' || itemType == 'show')) {
       return art ?? thumb;
     }
 
@@ -344,7 +343,8 @@ class PlexMetadata with MultiServerFields {
       return true;
     }
     // Movies, shows, and seasons use 16:9 in mixed hubs with episode thumbnail mode
-    if (mixedHubContext && mode == EpisodePosterMode.episodeThumbnail &&
+    if (mixedHubContext &&
+        mode == EpisodePosterMode.episodeThumbnail &&
         (itemType == 'movie' || itemType == 'show' || itemType == 'season')) {
       return true;
     }

--- a/lib/screens/hub_detail_screen.dart
+++ b/lib/screens/hub_detail_screen.dart
@@ -253,10 +253,8 @@ class _HubDetailScreenState extends State<HubDetailScreen> with Refreshable {
               final episodePosterMode = context.watch<SettingsProvider>().episodePosterMode;
 
               // Determine hub content type for layout decisions
-              final hasEpisodes = _filteredItems.any((item) =>
-                  item.usesWideAspectRatio(episodePosterMode));
-              final hasNonEpisodes = _filteredItems.any((item) =>
-                  !item.usesWideAspectRatio(episodePosterMode));
+              final hasEpisodes = _filteredItems.any((item) => item.usesWideAspectRatio(episodePosterMode));
+              final hasNonEpisodes = _filteredItems.any((item) => !item.usesWideAspectRatio(episodePosterMode));
 
               // Mixed hub = has both episodes AND non-episodes
               final isMixedHub = hasEpisodes && hasNonEpisodes;
@@ -265,8 +263,8 @@ class _HubDetailScreenState extends State<HubDetailScreen> with Refreshable {
               final isEpisodeOnlyHub = hasEpisodes && !hasNonEpisodes;
 
               // Use 16:9 for episode-only hubs OR mixed hubs (with episode thumbnail mode)
-              final useWideLayout = episodePosterMode == EpisodePosterMode.episodeThumbnail &&
-                  (isEpisodeOnlyHub || isMixedHub);
+              final useWideLayout =
+                  episodePosterMode == EpisodePosterMode.episodeThumbnail && (isEpisodeOnlyHub || isMixedHub);
 
               return MediaGridSliver(
                 items: _filteredItems,

--- a/lib/screens/libraries/libraries_screen.dart
+++ b/lib/screens/libraries/libraries_screen.dart
@@ -1115,9 +1115,7 @@ class _LibrariesScreenState extends State<LibrariesScreen>
                   controller: _tabController,
                   // Disable swipe on desktop - trackpad scrolling triggers accidental tab switches
                   // See: https://github.com/flutter/flutter/issues/11132
-                  physics: PlatformDetector.isDesktop(context)
-                      ? const NeverScrollableScrollPhysics()
-                      : null,
+                  physics: PlatformDetector.isDesktop(context) ? const NeverScrollableScrollPhysics() : null,
                   children: [
                     LibraryRecommendedTab(
                       key: _recommendedTabKey,

--- a/lib/services/data_aggregation_service.dart
+++ b/lib/services/data_aggregation_service.dart
@@ -148,29 +148,32 @@ class DataAggregationService {
 
         // Filter out items from hidden libraries if specified
         if (hiddenLibraryKeys != null && hiddenLibraryKeys.isNotEmpty) {
-          return hubs.map((hub) {
-            final filteredItems = hub.items.where((item) {
-              // Build the global key for the item's library section
-              final librarySectionId = item.librarySectionID;
-              if (librarySectionId == null) return true; // Keep if no section ID
-              final globalKey = '$serverId:$librarySectionId';
-              return !hiddenLibraryKeys.contains(globalKey);
-            }).toList();
+          return hubs
+              .map((hub) {
+                final filteredItems = hub.items.where((item) {
+                  // Build the global key for the item's library section
+                  final librarySectionId = item.librarySectionID;
+                  if (librarySectionId == null) return true; // Keep if no section ID
+                  final globalKey = '$serverId:$librarySectionId';
+                  return !hiddenLibraryKeys.contains(globalKey);
+                }).toList();
 
-            if (filteredItems.isEmpty) return null;
+                if (filteredItems.isEmpty) return null;
 
-            return PlexHub(
-              hubKey: hub.hubKey,
-              title: hub.title,
-              type: hub.type,
-              hubIdentifier: hub.hubIdentifier,
-              size: filteredItems.length,
-              more: hub.more,
-              items: filteredItems,
-              serverId: hub.serverId,
-              serverName: hub.serverName,
-            );
-          }).whereType<PlexHub>().toList();
+                return PlexHub(
+                  hubKey: hub.hubKey,
+                  title: hub.title,
+                  type: hub.type,
+                  hubIdentifier: hub.hubIdentifier,
+                  size: filteredItems.length,
+                  more: hub.more,
+                  items: filteredItems,
+                  serverId: hub.serverId,
+                  serverName: hub.serverName,
+                );
+              })
+              .whereType<PlexHub>()
+              .toList();
         }
 
         return hubs;

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -1252,10 +1252,7 @@ class PlexClient {
   /// This matches the official Plex client's home page layout.
   Future<List<PlexHub>> getGlobalHubs({int limit = 10}) async {
     try {
-      final response = await _dio.get(
-        '/hubs',
-        queryParameters: {'count': limit, 'includeGuids': 1},
-      );
+      final response = await _dio.get('/hubs', queryParameters: {'count': limit, 'includeGuids': 1});
 
       final container = _getMediaContainer(response);
       if (container != null && container['Hub'] != null) {

--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -1277,7 +1277,8 @@ class _PlexVideoControlsState extends State<PlexVideoControls> with WindowListen
                 children: [
                   // Keep-alive: 1px widget that continuously repaints to prevent
                   // Flutter animations from freezing when the frame clock goes idle
-                  if (Platform.isLinux || Platform.isWindows) const Positioned(top: 0, left: 0, child: _LinuxKeepAlive()),
+                  if (Platform.isLinux || Platform.isWindows)
+                    const Positioned(top: 0, left: 0, child: _LinuxKeepAlive()),
                   // Invisible tap detector that always covers the full area
                   // Also handles long-press for 2x speed
                   Positioned.fill(
@@ -1383,119 +1384,119 @@ class _PlexVideoControlsState extends State<PlexVideoControls> with WindowListen
                           opacity: _showControls ? 1.0 : 0.0,
                           duration: const Duration(milliseconds: 200),
                           child: LayoutBuilder(
-                              builder: (context, constraints) {
-                                return GestureDetector(
-                                  onTapUp: (details) => _handleControlsOverlayTap(details, constraints),
-                                  onLongPressStart: (_) => _handleLongPressStart(),
-                                  onLongPressEnd: (_) => _handleLongPressEnd(),
-                                  onLongPressCancel: _handleLongPressCancel,
-                                  behavior: HitTestBehavior.deferToChild,
-                                  child: ValueListenableBuilder<bool>(
-                                    valueListenable: widget.hasFirstFrame ?? ValueNotifier(true),
-                                    builder: (context, hasFrame, child) {
-                                      return Container(
-                                        decoration: BoxDecoration(
-                                          // Use solid black when loading, gradient when loaded
-                                          color: hasFrame ? null : Colors.black,
-                                          gradient: hasFrame
-                                              ? LinearGradient(
-                                                  begin: Alignment.topCenter,
-                                                  end: Alignment.bottomCenter,
-                                                  colors: [
-                                                    Colors.black.withValues(alpha: 0.7),
-                                                    Colors.transparent,
-                                                    Colors.transparent,
-                                                    Colors.black.withValues(alpha: 0.7),
-                                                  ],
-                                                  stops: const [0.0, 0.2, 0.8, 1.0],
-                                                )
-                                              : null,
-                                        ),
-                                        child: child,
-                                      );
-                                    },
-                                    child: isMobile
-                                        ? Listener(
-                                            behavior: HitTestBehavior.translucent,
-                                            onPointerDown: (_) => _restartHideTimerIfPlaying(),
-                                            child: MobileVideoControls(
-                                              player: widget.player,
-                                              metadata: widget.metadata,
-                                              chapters: _chapters,
-                                              chaptersLoaded: _chaptersLoaded,
-                                              seekTimeSmall: _seekTimeSmall,
-                                              trackChapterControls: _buildTrackChapterControlsWidget(),
-                                              onSeek: _throttledSeek,
-                                              onSeekEnd: _finalizeSeek,
-                                              onSeekCompleted: widget.onSeekCompleted,
-                                              onPlayPause: () {}, // Not used, handled internally
-                                              onCancelAutoHide: () => _hideTimer?.cancel(),
-                                              onStartAutoHide: _startHideTimer,
-                                              onBack: widget.onBack,
-                                              onNext: widget.onNext,
-                                              onPrevious: widget.onPrevious,
-                                              canControl: widget.canControl,
-                                              hasFirstFrame: widget.hasFirstFrame,
-                                            ),
-                                          )
-                                        : Listener(
-                                            behavior: HitTestBehavior.translucent,
-                                            onPointerDown: (_) => _restartHideTimerIfPlaying(),
-                                            child: DesktopVideoControls(
-                                              key: _desktopControlsKey,
-                                              player: widget.player,
-                                              metadata: widget.metadata,
-                                              onNext: widget.onNext,
-                                              onPrevious: widget.onPrevious,
-                                              chapters: _chapters,
-                                              chaptersLoaded: _chaptersLoaded,
-                                              seekTimeSmall: _seekTimeSmall,
-                                              onSeekToPreviousChapter: _seekToPreviousChapter,
-                                              onSeekToNextChapter: _seekToNextChapter,
-                                              onSeek: _throttledSeek,
-                                              onSeekEnd: _finalizeSeek,
-                                              getReplayIcon: getReplayIcon,
-                                              getForwardIcon: getForwardIcon,
-                                              onFocusActivity: _restartHideTimerIfPlaying,
-                                              onHideControls: _hideControlsFromKeyboard,
-                                              // Track chapter controls data
-                                              availableVersions: widget.availableVersions,
-                                              selectedMediaIndex: widget.selectedMediaIndex,
-                                              boxFitMode: widget.boxFitMode,
-                                              audioSyncOffset: _audioSyncOffset,
-                                              subtitleSyncOffset: _subtitleSyncOffset,
-                                              isFullscreen: _isFullscreen,
-                                              isAlwaysOnTop: _isAlwaysOnTop,
-                                              onTogglePIPMode: (_isPipSupported && Platform.isAndroid)
-                                                  ? widget.onTogglePIPMode
-                                                  : null,
-                                              onCycleBoxFitMode: widget.onCycleBoxFitMode,
-                                              onToggleFullscreen: _toggleFullscreen,
-                                              onToggleAlwaysOnTop: _toggleAlwaysOnTop,
-                                              onSwitchVersion: _switchMediaVersion,
-                                              onAudioTrackChanged: widget.onAudioTrackChanged,
-                                              onSubtitleTrackChanged: widget.onSubtitleTrackChanged,
-                                              onLoadSeekTimes: () async {
-                                                if (mounted) {
-                                                  await _loadSeekTimes();
-                                                }
-                                              },
-                                              onCancelAutoHide: () => _hideTimer?.cancel(),
-                                              onStartAutoHide: _startHideTimer,
-                                              serverId: widget.metadata.serverId ?? '',
-                                              onBack: widget.onBack,
-                                              canControl: widget.canControl,
-                                              hasFirstFrame: widget.hasFirstFrame,
-                                            ),
+                            builder: (context, constraints) {
+                              return GestureDetector(
+                                onTapUp: (details) => _handleControlsOverlayTap(details, constraints),
+                                onLongPressStart: (_) => _handleLongPressStart(),
+                                onLongPressEnd: (_) => _handleLongPressEnd(),
+                                onLongPressCancel: _handleLongPressCancel,
+                                behavior: HitTestBehavior.deferToChild,
+                                child: ValueListenableBuilder<bool>(
+                                  valueListenable: widget.hasFirstFrame ?? ValueNotifier(true),
+                                  builder: (context, hasFrame, child) {
+                                    return Container(
+                                      decoration: BoxDecoration(
+                                        // Use solid black when loading, gradient when loaded
+                                        color: hasFrame ? null : Colors.black,
+                                        gradient: hasFrame
+                                            ? LinearGradient(
+                                                begin: Alignment.topCenter,
+                                                end: Alignment.bottomCenter,
+                                                colors: [
+                                                  Colors.black.withValues(alpha: 0.7),
+                                                  Colors.transparent,
+                                                  Colors.transparent,
+                                                  Colors.black.withValues(alpha: 0.7),
+                                                ],
+                                                stops: const [0.0, 0.2, 0.8, 1.0],
+                                              )
+                                            : null,
+                                      ),
+                                      child: child,
+                                    );
+                                  },
+                                  child: isMobile
+                                      ? Listener(
+                                          behavior: HitTestBehavior.translucent,
+                                          onPointerDown: (_) => _restartHideTimerIfPlaying(),
+                                          child: MobileVideoControls(
+                                            player: widget.player,
+                                            metadata: widget.metadata,
+                                            chapters: _chapters,
+                                            chaptersLoaded: _chaptersLoaded,
+                                            seekTimeSmall: _seekTimeSmall,
+                                            trackChapterControls: _buildTrackChapterControlsWidget(),
+                                            onSeek: _throttledSeek,
+                                            onSeekEnd: _finalizeSeek,
+                                            onSeekCompleted: widget.onSeekCompleted,
+                                            onPlayPause: () {}, // Not used, handled internally
+                                            onCancelAutoHide: () => _hideTimer?.cancel(),
+                                            onStartAutoHide: _startHideTimer,
+                                            onBack: widget.onBack,
+                                            onNext: widget.onNext,
+                                            onPrevious: widget.onPrevious,
+                                            canControl: widget.canControl,
+                                            hasFirstFrame: widget.hasFirstFrame,
                                           ),
-                                  ),
-                                );
-                              },
-                            ),
+                                        )
+                                      : Listener(
+                                          behavior: HitTestBehavior.translucent,
+                                          onPointerDown: (_) => _restartHideTimerIfPlaying(),
+                                          child: DesktopVideoControls(
+                                            key: _desktopControlsKey,
+                                            player: widget.player,
+                                            metadata: widget.metadata,
+                                            onNext: widget.onNext,
+                                            onPrevious: widget.onPrevious,
+                                            chapters: _chapters,
+                                            chaptersLoaded: _chaptersLoaded,
+                                            seekTimeSmall: _seekTimeSmall,
+                                            onSeekToPreviousChapter: _seekToPreviousChapter,
+                                            onSeekToNextChapter: _seekToNextChapter,
+                                            onSeek: _throttledSeek,
+                                            onSeekEnd: _finalizeSeek,
+                                            getReplayIcon: getReplayIcon,
+                                            getForwardIcon: getForwardIcon,
+                                            onFocusActivity: _restartHideTimerIfPlaying,
+                                            onHideControls: _hideControlsFromKeyboard,
+                                            // Track chapter controls data
+                                            availableVersions: widget.availableVersions,
+                                            selectedMediaIndex: widget.selectedMediaIndex,
+                                            boxFitMode: widget.boxFitMode,
+                                            audioSyncOffset: _audioSyncOffset,
+                                            subtitleSyncOffset: _subtitleSyncOffset,
+                                            isFullscreen: _isFullscreen,
+                                            isAlwaysOnTop: _isAlwaysOnTop,
+                                            onTogglePIPMode: (_isPipSupported && Platform.isAndroid)
+                                                ? widget.onTogglePIPMode
+                                                : null,
+                                            onCycleBoxFitMode: widget.onCycleBoxFitMode,
+                                            onToggleFullscreen: _toggleFullscreen,
+                                            onToggleAlwaysOnTop: _toggleAlwaysOnTop,
+                                            onSwitchVersion: _switchMediaVersion,
+                                            onAudioTrackChanged: widget.onAudioTrackChanged,
+                                            onSubtitleTrackChanged: widget.onSubtitleTrackChanged,
+                                            onLoadSeekTimes: () async {
+                                              if (mounted) {
+                                                await _loadSeekTimes();
+                                              }
+                                            },
+                                            onCancelAutoHide: () => _hideTimer?.cancel(),
+                                            onStartAutoHide: _startHideTimer,
+                                            serverId: widget.metadata.serverId ?? '',
+                                            onBack: widget.onBack,
+                                            canControl: widget.canControl,
+                                            hasFirstFrame: widget.hasFirstFrame,
+                                          ),
+                                        ),
+                                ),
+                              );
+                            },
                           ),
                         ),
                       ),
                     ),
+                  ),
                   // Visual feedback overlay for double-tap
                   if (isMobile && _showDoubleTapFeedback)
                     Positioned.fill(


### PR DESCRIPTION
First PR here, found this project not too long ago and very much like it. It has some pain points for me so figured I would go ahead and try and fix some. This is my first time in Flutter/Dart so if there are any inconsistencies please feel free to let me know. I am very thick skinned and have no problem being educated. 

Problem: 
Currently the card clickable zone is the entire preview+ title area. This means that I am unable to click the series name and be taken to the series details page (same for movies). If I want to go to that series I have to go to my tv library then scroll for it. 

Solution: Make the card limits smaller to encompass only the image preview. This means the user can still click the image to play the scene but now it frees up space to do other things. I went ahead and made the series title clickable. When you click it will then take the user to the series details page. Eventually I would like to expand this to the episode details page (when added) and then bring in season and episode data (separate PR). These changes also apply to movies and have the same effects except it takes you to the movies details page.

UI Screenshots (Hard to see)

Not hovering:
<img width="361" height="253" alt="Screenshot 2026-01-14 at 21 43 33" src="https://github.com/user-attachments/assets/dae3eb04-4f0d-4e22-a89a-4b9fa1ec9754" />


Hovering  
<img width="353" height="235" alt="Screenshot 2026-01-14 at 21 41 53" src="https://github.com/user-attachments/assets/8e607f14-1f91-4d09-a54b-4171fc34b2d2" />

Hover over series name:
<img width="386" height="262" alt="Screenshot 2026-01-14 at 21 42 06" src="https://github.com/user-attachments/assets/8a019f98-8b45-4846-aa85-99768c386125" />


