### PR TITLE
Add mouse scroll wheel support for volume control

### DIFF
--- a/lib/widgets/video_controls/widgets/volume_control.dart
+++ b/lib/widgets/video_controls/widgets/volume_control.dart
@@ -211,6 +211,7 @@ class _VolumeControlState extends State<VolumeControl> {
           // Scroll up (negative delta) = increase volume, scroll down = decrease
           final volumeChange = -delta / 20; // Adjust sensitivity (higher = less sensitive)
           _adjustVolume(volumeChange);
+          widget.onFocusActivity?.call();
         }
       },
       child: SizedBox(


### PR DESCRIPTION
Add mouse scroll wheel support for volume control
Allows users to adjust volume by scrolling the mouse wheel while hovering over the volume slider.
Fixes #289 