### PR TITLE
Fix: Android TV-only Manage Libraries dialog with focus scroll support

### DIFF
--- a/lib/screens/libraries/libraries_screen.dart
+++ b/lib/screens/libraries/libraries_screen.dart
@@ -1433,11 +1433,11 @@ class _LibraryManagementSheetState extends State<_LibraryManagementSheet> {
       return Dialog(
         child: Scaffold(
           appBar: AppBar(
-            title: const Row(
+            title: Row(
               children: [
-                AppIcon(Symbols.edit_rounded, fill: 1),
-                SizedBox(width: 12),
-                Text('Manage Libraries'),
+                const AppIcon(Symbols.edit_rounded, fill: 1),
+                const SizedBox(width: 12),
+                Text(t.libraries.manageLibraries),
               ],
             ),
             automaticallyImplyLeading: false,


### PR DESCRIPTION
- Use Dialog + Scaffold for TV to improve library visibility and keyboard navigation
- Added _ensureFocusedVisible() to scroll focused library into view on D-pad movement
- Maintained DraggableScrollableSheet for non-TV platforms (unchanged behavior)
- Only affects Android TV; Windows/desktop/mobile use original modal bottomsheet
- Preserves all existing functionality (reordering, visibility toggle, options menu)