### PR TITLE
fix: update instructions for adding new language JSON files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ This project uses `slang` for internationalization with JSON files.
 
 ### Adding New Languages
 
-1. Create new JSON file: `lib/i18n/strings_[locale].i18n.json`
-2. Copy structure from `strings.i18n.json` and translate values
+1. Create new JSON file: `lib/i18n/[locale].i18n.json`
+2. Copy structure from `en.i18n.json` and translate values
 3. Run `dart run slang` to regenerate files
 
 ### Guidelines


### PR DESCRIPTION
This pull request updates the documentation for adding new languages to clarify file naming conventions and translation sources for internationalization.

Documentation improvements:

* Updated the instructions in `CONTRIBUTING.md` to specify that new translation files should follow the `[locale].i18n.json` naming convention and use `en.i18n.json` as the template for structure and translation, instead of the previous `strings_[locale].i18n.json` and `strings.i18n.json`.