### PR TITLE
Fix double-click to toggle fullscreen on desktop

### DIFF
--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -926,11 +926,29 @@ class _PlexVideoControlsState extends State<PlexVideoControls> with WindowListen
     final isMobile = PlatformDetector.isMobile(context);
 
     if (!isMobile) {
+      final DateTime now = DateTime.now();
+
+      // Always perform the single-click behavior immediately
       if (widget.canControl && _clickVideoTogglesPlayback) {
         widget.player.playOrPause();
       } else {
         _toggleControls();
       }
+
+      // Detect double-click
+      final bool isDoubleClick = _lastSkipTapTime != null && now.difference(_lastSkipTapTime!).inMilliseconds < 250;
+
+      if (isDoubleClick) {
+        _lastSkipTapTime = null;
+
+        // Perform desktop double-click action: toggle fullscreen
+        _toggleFullscreen();
+
+        return;
+      }
+
+      // Record this click as a candidate for double-click detection
+      _lastSkipTapTime = now;
       return;
     }
 


### PR DESCRIPTION
This PR fixes double-click to toggle fullscreen on desktop. Based on the code and the behavior I experienced, it previously only worked when the controls were hidden (meaning you would have to start playback, leave your mouse over the player but don't move it, wait for the overlay to auto-hide, and then double-click without moving the house). Now it should work even if the controls are visible.

### Notes
In my experience, there are two ways to implement double-click features on top of single-click features.
 - Option 1: Have a timeout between clicks and only perform the single-click action when the double-click timeout occurs.
	 - Pros: Behavior is always predictable/"normal".
	 - Cons: Single-click action can feel laggy.
 - Option 2: Always perform the single-click action, even if the user is also doing a double-click.
	 - Pros: Single-click action is never delayed, feels super snappy.
	 - Cons: Behavior is a little unusual (e.g., single-click toggles playback, then double-click toggles fullscreen and un-toggles playback); but you do always end up in the right state

It looks like you implemented the double-tap to skip forward/backward on mobile via option 1. I decided to try option 2 for double-click to fullscreen, mainly to maintain the snappiness of click to play/pause which I've been really enjoying compared to the official app. But I'm open to feedback on this approach!

### Demo

https://github.com/user-attachments/assets/d660d20a-e32a-446e-b71a-58b2f416d2f5


