### PR TITLE
Blank UI during desktop window shutdown

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,8 @@ void _absorbZeroOffsetPointerEvent(PointerEvent event) {
   }
 }
 
+final ValueNotifier<bool> appClosing = ValueNotifier<bool>(false);
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   _installZeroOffsetPointerGuard(); // Workaround for iPadOS 26.1+ modal dismissal bug
@@ -255,6 +257,17 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
                 darkTheme: themeProvider.darkTheme,
                 themeMode: themeProvider.materialThemeMode,
                 navigatorObservers: [routeObserver],
+                builder: (context, child) {
+                  return ValueListenableBuilder<bool>(
+                    valueListenable: appClosing,
+                    builder: (context, closing, _) {
+                      if (!closing) {
+                        return child ?? const SizedBox.shrink();
+                      }
+                      return const SizedBox.expand(child: ColoredBox(color: Colors.black));
+                    },
+                  );
+                },
                 home: const OrientationAwareSetup(),
               ),
             ),


### PR DESCRIPTION
This pull request introduces a mechanism to handle app closure more gracefully on desktop platforms (Linux, Windows, macOS). It prevents abrupt closure by displaying a black overlay before the app window is destroyed, ensuring a smoother user experience. The changes include platform-specific window event handling and UI updates during the closing process.

**Desktop app closing experience improvements:**

* Added a `ValueNotifier<bool>` called `appClosing` to signal when the app is in the process of closing, and updated the app builder to display a fullscreen black overlay when closing is initiated (`lib/main.dart`). [[1]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R60-R61) [[2]](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608R260-R270)
* Implemented the `WindowListener` interface in `MainScreen`, registering and deregistering the listener on desktop platforms, and preventing the window from closing immediately (`lib/screens/main_screen.dart`). [[1]](diffhunk://#diff-bd133be018e34ae83777c8dc99e8d7b05d957eb227800110bdb4de0238b4c91bR1-R7) [[2]](diffhunk://#diff-bd133be018e34ae83777c8dc99e8d7b05d957eb227800110bdb4de0238b4c91bL67-R71) [[3]](diffhunk://#diff-bd133be018e34ae83777c8dc99e8d7b05d957eb227800110bdb4de0238b4c91bR104-R108) [[4]](diffhunk://#diff-bd133be018e34ae83777c8dc99e8d7b05d957eb227800110bdb4de0238b4c91bR289-R312)

These changes ensure the app provides visual feedback during shutdown on supported desktop platforms, improving perceived stability and user experience.