### PR TITLE
Show episode watched on thumbnail; allow release date on mobile

### DIFF
--- a/lib/screens/season_detail_screen.dart
+++ b/lib/screens/season_detail_screen.dart
@@ -225,8 +225,6 @@ class _EpisodeCard extends StatelessWidget {
   });
 
   Widget _buildEpisodeMetaRow(BuildContext context) {
-    final isMobile = PlatformDetector.isMobile(context);
-
     return Row(
       children: [
         if (episode.duration != null)
@@ -234,7 +232,7 @@ class _EpisodeCard extends StatelessWidget {
             formatDurationTimestamp(Duration(milliseconds: episode.duration!)),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(color: tokens(context).textMuted, fontSize: 12),
           ),
-        if (!isMobile && episode.originallyAvailableAt != null) ...[
+        if (episode.originallyAvailableAt != null) ...[
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 6),
             child: Text(
@@ -244,20 +242,6 @@ class _EpisodeCard extends StatelessWidget {
           ),
           Text(
             formatFullDate(episode.originallyAvailableAt!),
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: tokens(context).textMuted, fontSize: 12),
-          ),
-        ],
-        // Hide watch status when offline (not tracked)
-        if (!isOffline && episode.duration != null && episode.isWatched) ...[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 6),
-            child: Text(
-              '•',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: tokens(context).textMuted, fontSize: 12),
-            ),
-          ),
-          Text(
-            '${t.discover.watched} ✓',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(color: tokens(context).textMuted, fontSize: 12),
           ),
         ],
@@ -360,6 +344,21 @@ class _EpisodeCard extends StatelessWidget {
                             backgroundColor: tokens(context).outline,
                             minHeight: 3,
                           ),
+                        ),
+                      ),
+
+                    if (episode.isWatched)
+                      Positioned(
+                        top: 4,
+                        right: 4,
+                        child: Container(
+                          padding: const EdgeInsets.all(4),
+                          decoration: BoxDecoration(
+                            color: tokens(context).text,
+                            shape: BoxShape.circle,
+                            boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.3), blurRadius: 4)],
+                          ),
+                          child: AppIcon(Symbols.check_rounded, fill: 1, color: tokens(context).bg, size: 12),
                         ),
                       ),
                   ],


### PR DESCRIPTION
Based on the idea from https://github.com/edde746/plezy/pull/326#issuecomment-3793338229, I have updated the watched indicator on TV show episodes from being a full word `Watched` (and taking up quite some space) to just being an icon on top of the thumbnail. This matches how Plezy represents watched movies as well.

Also as a result of this change, I allowed the episode release date to be shown on mobile, since we now have enough horizontal screen real estate.

|        | Plex  | Plezy |
|--------|-------|-------|
| **Desktop**| <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/d2924da1-2ad7-4651-a776-8e0ca6d39f0f" /> | <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/fc4775a7-42f0-4bea-bcbe-c23a6197b2e8" /> |
| **Mobile** | <img width="398" height="862" alt="image" src="https://github.com/user-attachments/assets/8addd326-6511-4f32-8660-0285fc78b3c1" /> | <img width="398" height="862" alt="image" src="https://github.com/user-attachments/assets/30f74ac8-eb05-4350-8415-5ac76a179719" /> |