### PR TITLE
Add tooltip showing target time when hovering or dragging the playback slider

### DIFF
--- a/lib/widgets/video_controls/widgets/timeline_slider.dart
+++ b/lib/widgets/video_controls/widgets/timeline_slider.dart
@@ -60,7 +60,7 @@ class _TimelineSliderState extends State<TimelineSlider> {
     final left = (pixelX - tooltipWidth / 2).clamp(0.0, sliderWidth - tooltipWidth);
     return Positioned(
       left: left,
-      top: -26,
+      top: -16,
       child: IgnorePointer(
         child: Container(
           width: tooltipWidth,


### PR DESCRIPTION
This PR adds a tooltip for when the user hovers over or drags the playback bar so that they can see what timestamp in the video that they will jump to.

### Notes
 - This is supported on desktop (when hovering with the mouse or dragging) and mobile (when dragging the slider).
 - I can see this mechanism also being expanded in the future to support [preview thumbnails](sliderPadding).
 - Please review with whitespace off for a more accurate representation of the changes.

### Demo

https://github.com/user-attachments/assets/d0fda702-f7ab-4c3a-9607-e50718b65607

https://github.com/user-attachments/assets/d58e70ae-f816-46f5-bb93-fd3a11ed0c05