### PR TITLE
Fix filter display names not being shown

### DIFF
--- a/lib/screens/libraries/filters_bottom_sheet.dart
+++ b/lib/screens/libraries/filters_bottom_sheet.dart
@@ -32,7 +32,7 @@ class _FiltersBottomSheetState extends State<FiltersBottomSheet> {
   List<PlexFilterValue> _filterValues = [];
   bool _isLoadingValues = false;
   final Map<String, String> _tempSelectedFilters = {};
-  final Map<String, String> _filterDisplayNames = {}; // Cache for display names
+  static final Map<String, String> _filterDisplayNames = {}; // Cache for display names
   late List<PlexFilter> _sortedFilters;
   late final FocusNode _initialFocusNode;
 


### PR DESCRIPTION
This PR changes the filter display name cache to be static. I found that we were getting a new instance of the bottom sheet every time it was opened, and as result, the cache was empty and the ID (instead of display name) was being shown for the filters. Now the static cache should survive among any instance of the sheet.

#### Notes
- The cache is still unpopulated after a restart of the app, so there is still a scenario where we show the ID instead of the display name.