### PR TITLE
feat: Add native Windows ARM64 build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -332,6 +332,68 @@ jobs:
           name: windows-installer
           path: plezy-windows-installer.exe
 
+  build-windows-arm64:
+    runs-on: windows-11-arm
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      # Flutter ARM64 Windows support requires the master channel.
+      # TODO: Switch to stable once Flutter stable adds ARM64 Windows support.
+      - name: Setup Flutter (Master Channel for ARM64)
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "master"
+          cache: true
+
+      - name: Cache Pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\AppData\Local\Pub\Cache
+          key: ${{ runner.os }}-arm64-pub-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-arm64-pub-
+
+      - name: Use ARM64 CMakeLists
+        run: Copy-Item windows/CMakeLists.arm64.txt windows/CMakeLists.txt -Force
+
+      # windows-11-arm runner doesn't have 7-Zip pre-installed (unlike windows-latest)
+      # CMake needs it to extract the MPV .7z dependency
+      - name: Install 7-Zip
+        run: choco install 7zip -y
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Build Windows ARM64
+        run: flutter build windows --release --dart-define=ENABLE_UPDATE_CHECK=true
+
+      - name: Build Windows ARM64 Installer
+        run: .\windows\build-installer-arm64.ps1
+
+      - name: Attest Windows ARM64 artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            plezy-windows-arm64-portable.7z
+            plezy-windows-arm64-installer.exe
+
+      - name: Upload ARM64 Portable Archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64-portable
+          path: plezy-windows-arm64-portable.7z
+
+      - name: Upload ARM64 Installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-arm64-installer
+          path: plezy-windows-arm64-installer.exe
+
   build-linux:
     runs-on: ubuntu-latest
     permissions:
@@ -409,7 +471,7 @@ jobs:
             plezy-linux.pkg.tar.zst
 
   create-release:
-    needs: [build-android, build-ios, build-macos, build-windows, build-linux]
+    needs: [build-android, build-ios, build-macos, build-windows, build-windows-arm64, build-linux]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -433,6 +495,8 @@ jobs:
             artifacts/macos-dmg/plezy-macos.dmg
             artifacts/windows-portable/plezy-windows-portable.7z
             artifacts/windows-installer/plezy-windows-installer.exe
+            artifacts/windows-arm64-portable/plezy-windows-arm64-portable.7z
+            artifacts/windows-arm64-installer/plezy-windows-arm64-installer.exe
             artifacts/linux-app/plezy-linux.tar.gz
             artifacts/linux-packages/*
           draft: true

--- a/windows/CMakeLists.arm64.txt
+++ b/windows/CMakeLists.arm64.txt
@@ -1,0 +1,157 @@
+# Project-level configuration for Windows ARM64
+cmake_minimum_required(VERSION 3.14)
+project(plezy LANGUAGES CXX)
+
+# Download and extract mpv-dev for ARM64
+# Note: Unlike windows-latest (x64), windows-11-arm runner doesn't have 7-Zip pre-installed.
+# CMake's FetchContent relies on libarchive which doesn't support the LZMA2 codec in .7z files.
+# Solution: Use file(DOWNLOAD) + external 7z.exe (installed via choco in workflow).
+
+set(MPV_ARCHIVE_NAME "mpv-dev-aarch64-20260207-git-9ccd889.7z")
+set(MPV_DOWNLOAD_URL "https://github.com/shinchiro/mpv-winbuild-cmake/releases/download/20260207/${MPV_ARCHIVE_NAME}")
+set(MPV_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/_deps/mpv_dev")
+set(MPV_ARCHIVE_PATH "${MPV_DOWNLOAD_DIR}/${MPV_ARCHIVE_NAME}")
+
+# Create download directory
+file(MAKE_DIRECTORY "${MPV_DOWNLOAD_DIR}")
+
+# Download MPV archive if not already present
+if(NOT EXISTS "${MPV_ARCHIVE_PATH}")
+  message(STATUS "Downloading MPV ARM64 library...")
+  file(DOWNLOAD
+    "${MPV_DOWNLOAD_URL}"
+    "${MPV_ARCHIVE_PATH}"
+    SHOW_PROGRESS
+    STATUS download_status
+  )
+  list(GET download_status 0 status_code)
+  list(GET download_status 1 status_message)
+  if(NOT status_code EQUAL 0)
+    message(FATAL_ERROR "Failed to download MPV: ${status_message}")
+  endif()
+endif()
+
+# Extract using 7z.exe if not already extracted
+if(NOT EXISTS "${MPV_DOWNLOAD_DIR}/include")
+  message(STATUS "Extracting MPV ARM64 with 7z...")
+  execute_process(
+    COMMAND "C:/Program Files/7-Zip/7z.exe" x "${MPV_ARCHIVE_PATH}" "-o${MPV_DOWNLOAD_DIR}" -y
+    RESULT_VARIABLE extract_result
+  )
+  if(NOT extract_result EQUAL 0)
+    message(FATAL_ERROR "7z extraction failed. Ensure 7-Zip is installed.")
+  endif()
+endif()
+
+set(MPV_INCLUDE_DIR "${MPV_DOWNLOAD_DIR}/include")
+set(MPV_LIB_DIR "${MPV_DOWNLOAD_DIR}")
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "plezy")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(VERSION 3.14...3.25)
+
+# Define build configuration option.
+get_property(IS_MULTICONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(IS_MULTICONFIG)
+  set(CMAKE_CONFIGURATION_TYPES "Debug;Profile;Release"
+    CACHE STRING "" FORCE)
+else()
+  if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE
+      STRING "Flutter build mode" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+      "Debug" "Profile" "Release")
+  endif()
+endif()
+# Define settings for the Profile build mode.
+set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+set(CMAKE_SHARED_LINKER_FLAGS_PROFILE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
+set(CMAKE_C_FLAGS_PROFILE "${CMAKE_C_FLAGS_RELEASE}")
+set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
+
+# Use Unicode for all projects.
+add_definitions(-DUNICODE -D_UNICODE)
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_17)
+  target_compile_options(${TARGET} PRIVATE /W4 /WX /wd"4100")
+  target_compile_options(${TARGET} PRIVATE /EHsc)
+  target_compile_definitions(${TARGET} PRIVATE "_HAS_EXCEPTIONS=0")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<CONFIG:Debug>:_DEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# Support files are copied into place next to the executable, so that it can
+# run in place. This is done instead of making a separate bundle (as on Linux)
+# so that building and running from within Visual Studio will work.
+set(BUILD_BUNDLE_DIR "$<TARGET_FILE_DIR:${BINARY_NAME}>")
+# Make the "install" step default, as it's required to run.
+set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
+endif()
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+if(PLUGIN_BUNDLED_LIBRARIES)
+  install(FILES "${PLUGIN_BUNDLED_LIBRARIES}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  CONFIGURATIONS Profile;Release
+  COMPONENT Runtime)
+
+# Install mpv DLL
+install(FILES "${MPV_LIB_DIR}/libmpv-2.dll"
+  DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)

--- a/windows/build-installer-arm64.ps1
+++ b/windows/build-installer-arm64.ps1
@@ -1,0 +1,143 @@
+#!/usr/bin/env pwsh
+# Windows ARM64 Installer Build Script
+# This script creates both a portable archive and an installer for the Windows ARM64 build
+
+param(
+    [string]$OutputDir = ".",
+    [string]$Version = "1.0.0"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building Windows ARM64 installer packages..." -ForegroundColor Cyan
+
+# Ensure we're in the project root
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+Set-Location $ProjectRoot
+
+# Define paths - ARM64 builds go to arm64 directory
+$BuildDir = "build\windows\arm64\runner\Release"
+$PortableZip = Join-Path (Resolve-Path $OutputDir) "plezy-windows-arm64-portable.7z"
+$InstallerExe = Join-Path (Resolve-Path $OutputDir) "plezy-windows-arm64-installer.exe"
+$SetupScript = "setup-arm64.iss"
+
+# Check if build exists
+if (-not (Test-Path $BuildDir)) {
+    Write-Error "Build directory not found at $BuildDir. Please run 'flutter build windows --release --target-arch=arm64' first."
+    exit 1
+}
+
+Write-Host "Found ARM64 build at: $BuildDir" -ForegroundColor Green
+
+# Check for 7-Zip
+Write-Host "`nChecking for 7-Zip..." -ForegroundColor Cyan
+if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
+    Write-Host "7-Zip not found in PATH. Installing via Chocolatey..." -ForegroundColor Yellow
+
+    if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+        Write-Error "Chocolatey is not installed. Please install it from https://chocolatey.org/install"
+        exit 1
+    }
+
+    choco install 7zip -y
+    refreshenv
+
+    if (-not (Get-Command 7z -ErrorAction SilentlyContinue)) {
+        Write-Error "Failed to install 7-Zip"
+        exit 1
+    }
+}
+
+# Create Portable Archive
+Write-Host "`nCreating ARM64 portable archive..." -ForegroundColor Cyan
+Push-Location $BuildDir
+try {
+    if (Test-Path $PortableZip) {
+        Remove-Item $PortableZip -Force
+    }
+    7z a -mx=9 $PortableZip *
+    Write-Host "Created: $PortableZip" -ForegroundColor Green
+} finally {
+    Pop-Location
+}
+
+# Create Inno Setup Script for ARM64
+Write-Host "`nGenerating Inno Setup script for ARM64..." -ForegroundColor Cyan
+@"
+#define Name "Plezy"
+#define Version "$Version"
+#define Publisher "edde746"
+#define ExeName "plezy.exe"
+
+[Setup]
+AppId={{4213385e-f7be-4f2b-95f9-54082a28bb8f}
+AppName={#Name}
+AppVersion={#Version}
+AppPublisher={#Publisher}
+DefaultDirName={autopf}\{#Name}
+DefaultGroupName={#Name}
+AllowNoIcons=yes
+OutputDir=.
+OutputBaseFilename=plezy-windows-arm64-installer
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+; ARM64-specific architecture settings
+ArchitecturesAllowed=arm64
+ArchitecturesInstallIn64BitMode=arm64
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "build\windows\arm64\runner\Release\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#Name}"; Filename: "{app}\{#ExeName}"
+Name: "{group}\{cm:UninstallProgram,{#Name}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#Name}"; Filename: "{app}\{#ExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#ExeName}"; Description: "{cm:LaunchProgram,{#Name}}"; Flags: nowait postinstall skipifsilent
+"@ | Out-File -FilePath $SetupScript -Encoding ASCII
+
+Write-Host "Created: $SetupScript" -ForegroundColor Green
+
+# Check for Inno Setup
+Write-Host "`nChecking for Inno Setup..." -ForegroundColor Cyan
+$InnoSetupPath = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+
+if (-not (Test-Path $InnoSetupPath)) {
+    Write-Host "Inno Setup not found. Installing via Chocolatey..." -ForegroundColor Yellow
+
+    # Check if choco is available
+    if (-not (Get-Command choco -ErrorAction SilentlyContinue)) {
+        Write-Error "Chocolatey is not installed. Please install it from https://chocolatey.org/install"
+        exit 1
+    }
+
+    choco install innosetup -y
+
+    if (-not (Test-Path $InnoSetupPath)) {
+        Write-Error "Failed to install Inno Setup"
+        exit 1
+    }
+}
+
+# Build Installer
+Write-Host "`nBuilding ARM64 installer with Inno Setup..." -ForegroundColor Cyan
+& $InnoSetupPath $SetupScript
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Inno Setup compilation failed"
+    exit 1
+}
+
+Write-Host "`nARM64 build complete!" -ForegroundColor Green
+Write-Host "Portable archive: $PortableZip" -ForegroundColor White
+Write-Host "Installer: $InstallerExe" -ForegroundColor White


### PR DESCRIPTION
## Summary

Adds native Windows ARM64 build support to the GitHub Actions CI/CD pipeline.

## Changes

### New Files
- `windows/CMakeLists.arm64.txt` - ARM64-specific CMake configuration with MPV dependency handling
- `windows/build-installer-arm64.ps1` - ARM64 installer packaging script

### Modified Files
- `.github/workflows/build.yml`:
  - Added `build-windows-arm64` job using `windows-11-arm` runner
  - Added 7-Zip installation (not pre-installed on ARM runners unlike windows-latest)
  - Updated `create-release` job to include ARM64 artifacts

## Technical Details

The ARM64 implementation mirrors the existing x64 build with key differences:

1. **Runner**: Uses GitHub's `windows-11-arm` partner runner (Windows 11 Desktop by Arm Limited)
2. **MPV Dependency**: Downloads ARM64 MPV builds from [shinchiro/mpv-winbuild-cmake](https://github.com/shinchiro/mpv-winbuild-cmake)
3. **7-Zip**: Explicitly installed via Chocolatey (pre-installed on x64 runners but not ARM64)
4. **CMake**: Uses `file(DOWNLOAD)` + manual extraction instead of `FetchContent` due to libarchive LZMA2 codec limitations on ARM64 runner

## Build Artifacts

The workflow generates two ARM64 artifacts:
- `plezy-windows-arm64-installer.exe` - InnoSetup installer
- `plezy-windows-arm64-portable.7z` - Portable archive

## Testing

- ✅ CI build completes successfully
- ✅ Artifacts generated and uploaded [successful WOA build](https://github.com/fizzyfrys/plezy-woa/actions/runs/21777478532/job/62836304393)
- ✅ **Manual testing done on Windows ARM64 hardware (Snapdragon X Plus)**
  - Installer works correctly
  - Portable archive works correctly
  - Hardware video decode confirmed
  - Watch Together works correctly
  - Runs ARM64 native (verified in Task Manager)
  - Open to any other testing as requested

## Notes

- This change maintains full backward compatibility with existing x64 builds. The ARM64 build runs in parallel and does not affect other workflows.
- **ARM64 support was significantly simplified** by the recent removal of `flutter_webrtc` dependency, which had limited to no ARM64 compatibility. The current MPV-based architecture builds cleanly for ARM64 without additional patches.

---

**Closes:** #244 #332 
