### PR TITLE
Add support for video thumbnail previews

### DIFF
--- a/lib/widgets/video_controls/desktop_video_controls.dart
+++ b/lib/widgets/video_controls/desktop_video_controls.dart
@@ -80,6 +80,9 @@ class DesktopVideoControls extends StatefulWidget {
   final ShaderService? shaderService;
   final VoidCallback? onShaderChanged;
 
+  /// Optional callback that returns a thumbnail URL for a given timestamp.
+  final String Function(Duration time)? thumbnailUrlBuilder;
+
   const DesktopVideoControls({
     super.key,
     required this.player,
@@ -123,6 +126,7 @@ class DesktopVideoControls extends StatefulWidget {
     this.hasFirstFrame,
     this.shaderService,
     this.onShaderChanged,
+    this.thumbnailUrlBuilder,
   });
 
   @override
@@ -435,6 +439,7 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
             onKeyEvent: _handleTimelineKeyEvent,
             onFocusChange: _onFocusChange,
             enabled: canInteract,
+            thumbnailUrlBuilder: widget.thumbnailUrlBuilder,
           ),
           const SizedBox(height: 4),
           // Row 2: Playback controls and options

--- a/lib/widgets/video_controls/mobile_video_controls.dart
+++ b/lib/widgets/video_controls/mobile_video_controls.dart
@@ -41,6 +41,9 @@ class MobileVideoControls extends StatelessWidget {
   /// Notifier for whether first video frame has rendered (shows loading state when false).
   final ValueNotifier<bool>? hasFirstFrame;
 
+  /// Optional callback that returns a thumbnail URL for a given timestamp.
+  final String Function(Duration time)? thumbnailUrlBuilder;
+
   const MobileVideoControls({
     super.key,
     required this.player,
@@ -60,6 +63,7 @@ class MobileVideoControls extends StatelessWidget {
     this.onPrevious,
     this.canControl = true,
     this.hasFirstFrame,
+    this.thumbnailUrlBuilder,
   });
 
   @override
@@ -167,6 +171,7 @@ class MobileVideoControls extends StatelessWidget {
           horizontalLayout: false,
           enabled: canControl,
           showFinishTime: true,
+          thumbnailUrlBuilder: thumbnailUrlBuilder,
         ),
       ),
     );

--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -72,6 +72,7 @@ Widget plexVideoControlsBuilder(
   ValueNotifier<bool>? controlsVisible,
   ShaderService? shaderService,
   VoidCallback? onShaderChanged,
+  String Function(Duration time)? thumbnailUrlBuilder,
 }) {
   return PlexVideoControls(
     player: player,
@@ -93,6 +94,7 @@ Widget plexVideoControlsBuilder(
     controlsVisible: controlsVisible,
     shaderService: shaderService,
     onShaderChanged: onShaderChanged,
+    thumbnailUrlBuilder: thumbnailUrlBuilder,
   );
 }
 
@@ -133,6 +135,9 @@ class PlexVideoControls extends StatefulWidget {
   /// Called when shader preset changes
   final VoidCallback? onShaderChanged;
 
+  /// Optional callback that returns a thumbnail URL for a given timestamp.
+  final String Function(Duration time)? thumbnailUrlBuilder;
+
   const PlexVideoControls({
     super.key,
     required this.player,
@@ -154,6 +159,7 @@ class PlexVideoControls extends StatefulWidget {
     this.controlsVisible,
     this.shaderService,
     this.onShaderChanged,
+    this.thumbnailUrlBuilder,
   });
 
   @override
@@ -1688,6 +1694,7 @@ class _PlexVideoControlsState extends State<PlexVideoControls> with WindowListen
                                             onPrevious: widget.onPrevious,
                                             canControl: widget.canControl,
                                             hasFirstFrame: widget.hasFirstFrame,
+                                            thumbnailUrlBuilder: widget.thumbnailUrlBuilder,
                                           ),
                                         )
                                       : Listener(
@@ -1744,6 +1751,7 @@ class _PlexVideoControlsState extends State<PlexVideoControls> with WindowListen
                                             hasFirstFrame: widget.hasFirstFrame,
                                             shaderService: widget.shaderService,
                                             onShaderChanged: widget.onShaderChanged,
+                                            thumbnailUrlBuilder: widget.thumbnailUrlBuilder,
                                           ),
                                         ),
                                 ),

--- a/lib/widgets/video_controls/widgets/video_timeline_bar.dart
+++ b/lib/widgets/video_controls/widgets/video_timeline_bar.dart
@@ -36,6 +36,9 @@ class VideoTimelineBar extends StatelessWidget {
   /// Whether to show the estimated finish time next to the remaining timestamp (mobile).
   final bool showFinishTime;
 
+  /// Optional callback that returns a thumbnail URL for a given timestamp.
+  final String Function(Duration time)? thumbnailUrlBuilder;
+
   const VideoTimelineBar({
     super.key,
     required this.player,
@@ -49,6 +52,7 @@ class VideoTimelineBar extends StatelessWidget {
     this.onFocusChange,
     this.enabled = true,
     this.showFinishTime = false,
+    this.thumbnailUrlBuilder,
   });
 
   @override
@@ -134,6 +138,7 @@ class VideoTimelineBar extends StatelessWidget {
       onKeyEvent: onKeyEvent,
       onFocusChange: onFocusChange,
       enabled: enabled,
+      thumbnailUrlBuilder: thumbnailUrlBuilder,
     );
   }
 }


### PR DESCRIPTION
This PR adds support for [video preview thumbnails](https://support.plex.tv/articles/202197528-video-preview-thumbnails/). Note that it works when hovering the mouse (desktop) and when dragging the slider (desktop + mobile).

### Notes
- The thumbnails have a slight shadow, mimicking the Plex app.
- If a piece of media has no thumbnails, we won't keep making requests every time the user hovers/drags.
- The main changes are in `lib\screens\video_player_screen.dart` (where the thumbnail URLs are generated) and `lib\widgets\video_controls\widgets\timeline_slider.dart` where the thumbnails are retrieved and shown to the user. Other changes are just for passing in the function.
- Review with whitespace off.

### Demo - Desktop

https://github.com/user-attachments/assets/7c6dce74-a6c9-4f19-93c1-9363308b4cd5

### Demo - Mobile

https://github.com/user-attachments/assets/aea92a63-ca3d-4d0d-ab54-436b4e4c0b52