### PR TITLE
Fix episode watched status

### DIFF
--- a/lib/screens/season_detail_screen.dart
+++ b/lib/screens/season_detail_screen.dart
@@ -376,6 +376,8 @@ class _EpisodeCardState extends State<_EpisodeCard> {
         widget.episode.viewOffset! > 0;
     final progress = hasProgress ? widget.episode.viewOffset! / widget.episode.duration! : 0.0;
 
+    final hasActiveProgress = hasProgress && widget.episode.viewOffset! < widget.episode.duration!;
+
     return FocusableWrapper(
       autofocus: widget.autofocus,
       enableLongPress: true,
@@ -459,7 +461,7 @@ class _EpisodeCardState extends State<_EpisodeCard> {
                       ),
 
                       // Progress bar at bottom
-                      if (hasProgress && !widget.episode.isWatched)
+                      if (hasActiveProgress)
                         Positioned(
                           bottom: 0,
                           left: 0,
@@ -477,7 +479,7 @@ class _EpisodeCardState extends State<_EpisodeCard> {
                           ),
                         ),
 
-                      if (widget.episode.isWatched)
+                      if (widget.episode.isWatched && !hasActiveProgress)
                         Positioned(
                           top: 4,
                           right: 4,

--- a/lib/widgets/media_card.dart
+++ b/lib/widgets/media_card.dart
@@ -98,11 +98,14 @@ class MediaCardState extends State<MediaCard> {
     }
 
     // Add watched status
-    if (item.isWatched) {
-      baseLabel = '$baseLabel, ${t.accessibility.mediaCardWatched}';
-    } else if (item.viewOffset != null && item.duration != null && item.viewOffset! > 0) {
+    final hasActiveProgress =
+        item.viewOffset != null && item.duration != null && item.viewOffset! > 0 && item.viewOffset! < item.duration!;
+
+    if (hasActiveProgress) {
       final percent = ((item.viewOffset! / item.duration!) * 100).round();
       baseLabel = '$baseLabel, ${t.accessibility.mediaCardPartiallyWatched(percent: percent)}';
+    } else if (item.isWatched) {
+      baseLabel = '$baseLabel, ${t.accessibility.mediaCardWatched}';
     } else {
       baseLabel = '$baseLabel, ${t.accessibility.mediaCardUnwatched}';
     }
@@ -716,10 +719,16 @@ class _MediaCardHelpers {
   static Widget buildWatchProgress(BuildContext context, PlexMetadata metadata) {
     final showUnwatchedCount = context.watch<SettingsProvider>().showUnwatchedCount;
 
+    final hasActiveProgress =
+        metadata.viewOffset != null &&
+        metadata.duration != null &&
+        metadata.viewOffset! > 0 &&
+        metadata.viewOffset! < metadata.duration!;
+
     return Stack(
       children: [
         // Watched indicator (checkmark)
-        if (metadata.isWatched)
+        if (metadata.isWatched && !hasActiveProgress)
           Positioned(
             top: 4,
             right: 4,
@@ -756,7 +765,7 @@ class _MediaCardHelpers {
             ),
           ),
         // Progress bar for partially watched content (episodes/movies)
-        if (metadata.viewOffset != null && metadata.duration != null && metadata.viewOffset! > 0 && !metadata.isWatched)
+        if (hasActiveProgress)
           Positioned(
             bottom: 0,
             left: 0,


### PR DESCRIPTION
This PR fixes a bug that I discovered. Here is the bug.

1. Completely watch an episode of a TV show. See that it is marked as watched in the season view.
2. Start watching the episode again. Watch partway through and then stop playback and go back to the season view.

**Expected Behavior**
The indicator no longer shows that the episode is watched. Instead, it shows my new playback progress. (This is the behavior of the Plex app).

**Actual Behavior**
The watched status takes precedence over playback progress and says that the episode is watched (even though, if I press play again now, it will resume where I left off).

### Demo - Plex

https://github.com/user-attachments/assets/ac49d8a1-b484-4bb0-ae13-14b9e2fa6894

### Demo - Plezy (Before)

https://github.com/user-attachments/assets/a17b7058-9227-4a82-9aa9-c4860b921a43

### Demo - Plezy (After)

https://github.com/user-attachments/assets/9b977044-b378-471a-8d27-0fe1131d44bf

### Notes

This fix applies to both the generic media card and the season detail screen. The former was especially strange before the fix because it would show a fully watched episode in the "Continue Watching" section!