### PR TITLE
Fix the colors of the delete buttons

### DIFF
--- a/lib/utils/dialogs.dart
+++ b/lib/utils/dialogs.dart
@@ -32,7 +32,9 @@ Future<bool> showConfirmDialog(
           ),
           FilledButton(
             onPressed: () => Navigator.pop(dialogContext, true),
-            style: isDestructive ? FilledButton.styleFrom(backgroundColor: colorScheme.error) : null,
+            style: isDestructive
+                ? FilledButton.styleFrom(backgroundColor: colorScheme.error, foregroundColor: colorScheme.onError)
+                : null,
             child: Text(confirmText),
           ),
         ],

--- a/lib/widgets/media_context_menu.dart
+++ b/lib/widgets/media_context_menu.dart
@@ -269,7 +269,7 @@ class MediaContextMenuState extends State<MediaContextMenu> {
             value: 'delete_media',
             icon: Symbols.delete_rounded,
             label: t.common.delete,
-            hoverColor: Colors.red,
+            hoverColor: Theme.of(context).colorScheme.error,
           ),
         );
       }
@@ -1002,11 +1002,7 @@ class MediaContextMenuState extends State<MediaContextMenu> {
     final metadata = widget.item as PlexMetadata;
     final client = _getClientForItem();
 
-    await ExternalPlayerService.launch(
-      context: context,
-      metadata: metadata,
-      client: client,
-    );
+    await ExternalPlayerService.launch(context: context, metadata: metadata, client: client);
   }
 
   /// Handle download action


### PR DESCRIPTION
This PR makes a couple of color tweaks for consistency.

In the media context menu, I changed the delete menu item hover from `Colors.red` to `Theme.of(context).colorScheme.error` so that it matches the delete confirmation button, and so that it is based on the theme instead of being hard-coded.

And I changed the delete confirmation button foreground color to `colorScheme.onError` to provide better contrast and fit the theme.

### Before

<img width="220" height="352" alt="image" src="https://github.com/user-attachments/assets/09974980-1e12-4e01-b849-04da4c5d6b48" />

<img width="456" height="173" alt="image" src="https://github.com/user-attachments/assets/cdf8ab29-e4e5-4f86-8346-040c67c68ec5" />

### After

<img width="220" height="352" alt="image" src="https://github.com/user-attachments/assets/ad982a58-78db-4efa-a478-5087f2d529c3" />

<img width="456" height="172" alt="image" src="https://github.com/user-attachments/assets/1631aa36-9da2-42b7-a5ff-8b56a2599d58" />
