### PR TITLE
fix: show 'mark as unwatched' for in progress items

### DIFF
--- a/lib/models/plex_metadata.dart
+++ b/lib/models/plex_metadata.dart
@@ -382,6 +382,13 @@ class PlexMetadata with MultiServerFields {
     return false;
   }
 
+  /// Returns true if this item has started but not finished playback
+  /// Only applicable for individual items (movies, episodes)
+  bool get hasActiveProgress {
+    if (duration == null || viewOffset == null) return false;
+    return viewOffset! > 0 && viewOffset! < duration!;
+  }
+
   // Helper to determine if content is watched
   bool get isWatched {
     // For series/seasons, check if all episodes are watched

--- a/lib/widgets/media_context_menu.dart
+++ b/lib/widgets/media_context_menu.dart
@@ -130,7 +130,12 @@ class MediaContextMenuState extends State<MediaContextMenu> {
         metadata!.viewedLeafCount != null &&
         metadata.leafCount != null &&
         metadata.viewedLeafCount! > 0 &&
-        metadata.viewedLeafCount! < widget.item.leafCount!;
+        metadata.viewedLeafCount! < metadata.leafCount!;
+
+    final hasActiveProgress =
+        mediaType != null &&
+        (mediaType == PlexMediaType.movie || mediaType == PlexMediaType.episode) &&
+        metadata?.hasActiveProgress == true;
 
     // Check if we should use bottom sheet (on iOS and Android)
     final useBottomSheet = Platform.isIOS || Platform.isAndroid;
@@ -154,14 +159,14 @@ class MediaContextMenuState extends State<MediaContextMenu> {
       // Regular menu items for other types
 
       // Mark as Watched
-      if (!metadata!.isWatched || isPartiallyWatched) {
+      if (!metadata!.isWatched || isPartiallyWatched || hasActiveProgress) {
         menuActions.add(
           _MenuAction(value: 'watch', icon: Symbols.check_circle_outline_rounded, label: t.mediaMenu.markAsWatched),
         );
       }
 
       // Mark as Unwatched
-      if (metadata.isWatched || isPartiallyWatched) {
+      if (metadata.isWatched || isPartiallyWatched || hasActiveProgress) {
         menuActions.add(
           _MenuAction(
             value: 'unwatch',


### PR DESCRIPTION
Films or TV episodes that had begun playback progress but had not yet finished it were only showing the "Mark as Watched" button, but they should also show the "Mark as Unwatched" button as the official Plex UI does. For consistency we also apply this logic to the "Mark as Watched" button too, but in practice this bit is probably not required.

There is also a small safety fix to use `metadata.leafCount!;` instead of `widget.item.leafCount!;` when setting `isPartiallyWatched`.

As a disclaimer these changes were partially generated by Copilot, but I cleaned it up and make sure I fully understand the change being made and tested it the best I can.

Thank you for making this client, it's a much better experience than the official app already and I'm happy to be able to contribute even a little bit to it.

Screenshots of changes:

<details>
<summary>Open me</summary>

Example of both buttons from official Plex client:
<img width="360" height="666" alt="image" src="https://github.com/user-attachments/assets/79f939c8-c583-417c-8a82-f469606617d6" />

Film in progress in recently added section showing both buttons:
<img width="957" height="577" alt="WUfUBbwOoJ" src="https://github.com/user-attachments/assets/8075b0cc-e3da-4654-82fc-c255d9ea1535" />

Film in progress in continue watching section showing both buttons:
<img width="498" height="477" alt="plezy_ayY6WZsSMf" src="https://github.com/user-attachments/assets/60c8d3ff-a4f1-4a63-a4af-dfc6644b65f4" />

Next season episode with no progress only showing mark watched:
<img width="506" height="380" alt="plezy_3y0OHrGKZZ" src="https://github.com/user-attachments/assets/4f7e6347-5784-4707-9ab8-940fcefa0407" />

Next season episode in progress showing both buttons:
<img width="615" height="395" alt="plezy_fFQN35LBna" src="https://github.com/user-attachments/assets/8accb563-bd21-432e-b2c7-26c5b7d07303" />

Unwatched film only showing mark as watched:
<img width="491" height="570" alt="plezy_G2IXX6GBoI" src="https://github.com/user-attachments/assets/68bfa26e-8cdb-4abd-bd08-82b149da5d78" />

Watched film only showing mark as unwatched:
<img width="417" height="548" alt="plezy_uZyXJH9u86" src="https://github.com/user-attachments/assets/ab20e53a-cd53-421a-bf32-288c645d9e4a" />

Episode in season view in progress showing both buttons:
<img width="1112" height="481" alt="plezy_LGeCuxtTjW" src="https://github.com/user-attachments/assets/dbf50ab4-d6e9-474d-a42a-5c205c204529" />

Episode in season view watched only showing mark as unwatched:
<img width="1119" height="548" alt="plezy_mvbAVs9gfh" src="https://github.com/user-attachments/assets/a7b37117-26d5-4e0b-af0d-020986a38b4e" />

Episode in season view unwatched only showing mark as watched:
<img width="914" height="462" alt="plezy_WTiJDnHjqV" src="https://github.com/user-attachments/assets/33d90b25-db7a-46c8-87c3-49c846fb6322" />
</details>