### PR TITLE
Fix playback on macOS

### DIFF
--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -28,5 +28,7 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>FLTEnableMergedPlatformUIThread</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Updated Info.plist
This disables the merged UI/platform thread that Flutter 3.41 enables by default on macOS, since it currently breaks playback.

Release 1.17.0 is fine.
Downloading the repo, setting it up and building breaks playback.
Flutter 3.41 was released 5 days ago.


