### PR TITLE
Fix an issue setting episode artwork

### DIFF
--- a/lib/screens/metadata_edit_screen.dart
+++ b/lib/screens/metadata_edit_screen.dart
@@ -219,8 +219,22 @@ class _MetadataEditScreenState extends State<MetadataEditScreen> {
     );
 
     if (result == true && mounted) {
-      // Reload metadata to get updated artwork paths
-      _loadMetadata();
+      // Re-fetch metadata to get updated artwork paths without resetting
+      // any text field edits the user may have made.
+      await _reloadArtwork();
+    }
+  }
+
+  Future<void> _reloadArtwork() async {
+    try {
+      final meta = await _client.getMetadataWithImages(widget.metadata.ratingKey);
+      if (!mounted) return;
+      if (meta != null) {
+        setState(() => _fullMetadata = meta);
+      }
+    } catch (_) {
+      // Artwork was already saved by the picker; display will refresh next
+      // time the editor is opened.
     }
   }
 

--- a/lib/widgets/artwork_picker_dialog.dart
+++ b/lib/widgets/artwork_picker_dialog.dart
@@ -49,12 +49,16 @@ class _ArtworkPickerDialogState extends State<ArtworkPickerDialog> {
   }
 
   Future<void> _selectArtwork(Map<String, dynamic> artwork) async {
-    final key = artwork['key'] as String?;
-    if (key == null || _isApplying) return;
+    // Use ratingKey (the artwork provider identifier) rather than key (a
+    // file-serving path that is already percent-encoded).  Passing key through
+    // Dio's query-parameter encoding double-encodes it, causing Plex to
+    // silently ignore the selection despite returning 200.
+    final url = artwork['ratingKey'] as String? ?? artwork['key'] as String?;
+    if (url == null || _isApplying) return;
 
     setState(() => _isApplying = true);
 
-    final success = await widget.client.setArtworkFromUrl(widget.ratingKey, widget.element, key);
+    final success = await widget.client.setArtworkFromUrl(widget.ratingKey, widget.element, url);
 
     if (!mounted) return;
     setState(() => _isApplying = false);


### PR DESCRIPTION
This PR fixes a couple bugs that I discovered while trying to change the Poster artwork for a TV show episode.

1. The save was not working at all because we were sending the wrong field from the artwork response to the Plex API. `_selectArtwork` was using `artwork['key']` which is a file-serving path that is already url-encoded, as the `url` query parameter. Dio then double-encoded it (e.g., `%3A` -> `%253A`), producing an invalid url. I found that Plex actually returns 200 which is why you see the successful snackbar, but it didn't do anything. The fix uses `artwork['ratingKey']` instead, which is the raw artwork provider identifier that Plex actually expects.

2. The metadata editor was not immediately reflecting the change after picking the new artwork because `_openArtworkPicker` called `_loadMetadata()` to refresh, but `_loadMetadata()` has an early-return optimization that skips re-fetching when `widget.metadata` already has full fields populated so it just reused the stale data. The fix adds a dedicated `_reloadArtwork()` method that always fetches fresh metadata from the server and updates the artwork display without resetting any in-progress text field edits.

### Demo

#### Before

https://github.com/user-attachments/assets/bf7c4dd6-a0e0-4d01-81d3-4944810033ba

#### After

https://github.com/user-attachments/assets/1f340b3c-bdf0-4f1b-9990-1b30e8ddc5de

