### PR TITLE
Fix for #668

### DIFF
--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:io' show Platform;
 
+import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 
 import '../models.dart';
@@ -98,6 +100,14 @@ class PlayerNative extends PlayerBase {
 
     // Show the video layer
     await setVisible(true);
+
+    // Linux: wait one frame so texture populate() runs and creates MPV render context before loadfile.
+    if (Platform.isLinux) {
+      WidgetsBinding.instance.scheduleFrame();
+      final c = Completer<void>();
+      WidgetsBinding.instance.addPostFrameCallback((_) => c.complete());
+      await c.future;
+    }
 
     // Set HTTP headers for Plex authentication and profile
     if (media.headers != null && media.headers!.isNotEmpty) {


### PR DESCRIPTION
This fixes the issue for me but might not be the right solution, after setVisible i 'think' mpv gets called too early and before drawing we get that 'no render context set' if we wrap a promise around scheduling just one frame it holds it and seems to work for me, since the context is ready by the time it continues.

Maybe that wait could be integrated into the setVisible? https://github.com/edde746/plezy/blob/4cc83006ecb512b64d5a2e57f5c7602c79de8c0f/lib/mpv/player/player_native.dart#L122