### PR TITLE
Fix issue with always on top getting stuck

### DIFF
--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -671,9 +671,12 @@ class _PlexVideoControlsState extends State<PlexVideoControls> with WindowListen
     }
     // Remove lifecycle observer
     WidgetsBinding.instance.removeObserver(this);
-    // Remove window listener
+    // Remove window listener and reset always-on-top if it was enabled
     if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
       windowManager.removeListener(this);
+      if (_isAlwaysOnTop) {
+        windowManager.setAlwaysOnTop(false);
+      }
     }
     if (Platform.isMacOS) {
       _pipService.isPipActive.removeListener(_onMacPipChanged);


### PR DESCRIPTION
This PR fixes an issue where Plezy could get stuck on top forever if you enable always on top mode in the player and then exit the player without disabling the mode.

### Before

https://github.com/user-attachments/assets/275bd768-b1eb-4ff4-bd48-5c1357e8196b

### After

https://github.com/user-attachments/assets/35f301d3-7f07-464a-ae4b-536652b6dd8c

