### PR TITLE
Remove dead getters from model classes

### DIFF
--- a/lib/models/plex_user_profile.dart
+++ b/lib/models/plex_user_profile.dart
@@ -72,10 +72,4 @@ class PlexUserProfile {
       },
     };
   }
-
-  /// Returns true if subtitles should be automatically selected
-  bool get shouldAutoSelectSubtitle => autoSelectSubtitle > 0;
-
-  /// Returns true if forced subtitles should be preferred
-  bool get preferForcedSubtitles => defaultSubtitleForced == 1;
 }

--- a/lib/models/user_switch_response.dart
+++ b/lib/models/user_switch_response.dart
@@ -133,5 +133,4 @@ class UserSwitchResponse {
   bool get isRestrictedUser => restricted;
   bool get isGuestUser => guest;
   bool get requiresPassword => hasPassword;
-  bool get isSecureUser => twoFactorEnabled || backupCodesCreated;
 }


### PR DESCRIPTION
## Summary
- Remove `shouldAutoSelectSubtitle` and `preferForcedSubtitles` getters from `PlexUserProfile` — zero references in codebase
- Remove `isSecureUser` getter from `UserSwitchResponse` — zero references in codebase

## Test plan
- [x] `dart analyze lib/` passes with no new errors (pre-existing errors unrelated to these changes)
- [x] Grep confirms zero references to removed getters