### PR TITLE
chore: remove unused workmanager and android_intent_plus deps

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,14 +25,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.6"
-  android_intent_plus:
-    dependency: "direct main"
-    description:
-      name: android_intent_plus
-      sha256: "2329378af63f49b985cb2e110ac784d08374f1e2b1984be77ba9325b1c8cce11"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.3.1"
   ansicolor:
     dependency: transitive
     description:
@@ -1480,38 +1472,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
-  workmanager:
-    dependency: "direct main"
-    description:
-      name: workmanager
-      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.0+3"
-  workmanager_android:
-    dependency: transitive
-    description:
-      name: workmanager_android
-      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.0+2"
-  workmanager_apple:
-    dependency: transitive
-    description:
-      name: workmanager_apple
-      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1+2"
-  workmanager_platform_interface:
-    dependency: transitive
-    description:
-      name: workmanager_platform_interface
-      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   universal_gamepad: ^1.5.0
   drift: ^2.28.2
   sqlite3_flutter_libs: ^0.5.41
-  workmanager: ^0.9.0+3
   crypto: ^3.0.7
   file_picker: ^10.3.10
   saf_util: ^0.11.0
@@ -54,7 +53,6 @@ dependencies:
   dart_discord_presence: ^1.1.0
   flutter_svg: ^2.2.3
   mobile_scanner: ^6.0.2
-  android_intent_plus: ^5.0.2
   background_downloader: ^9.5.2
   sentry_flutter: ^8.12.0
   auto_updater:


### PR DESCRIPTION
## Summary
- Remove `workmanager` dependency (not imported in any Dart file in `lib/`)
- Remove `android_intent_plus` dependency (not imported in any Dart file in `lib/`)
- Run `flutter pub get` to update lock file

## Test plan
- [x] `flutter pub get` resolves successfully
- [x] `dart analyze lib/` passes (no new issues)