### PR TITLE
Remove dead code from provider files

### DIFF
--- a/lib/providers/multi_server_provider.dart
+++ b/lib/providers/multi_server_provider.dart
@@ -86,18 +86,6 @@ class MultiServerProvider extends ChangeNotifier {
   /// Check if any servers are connected
   bool get hasConnectedServers => onlineServerCount > 0;
 
-  /// Update token for a specific server
-  void updateTokenForServer(String serverId, String newToken) {
-    final client = _serverManager.getClient(serverId);
-    if (client != null) {
-      client.updateToken(newToken);
-      appLogger.d('MultiServerProvider: Token updated for server $serverId');
-      notifyListeners();
-    } else {
-      appLogger.w('MultiServerProvider: Cannot update token - server $serverId not found');
-    }
-  }
-
   /// Clear all server connections
   void clearAllConnections() {
     _serverManager.disconnectAll();

--- a/lib/providers/offline_watch_provider.dart
+++ b/lib/providers/offline_watch_provider.dart
@@ -59,17 +59,6 @@ class OfflineWatchProvider extends ChangeNotifier {
     return false;
   }
 
-  /// Check watch status synchronously using cached metadata.
-  ///
-  /// This is useful for UI that can't await, but may not reflect
-  /// the most recent local actions.
-  bool isWatchedSync(PlexMetadata metadata) {
-    // Note: This doesn't check local actions synchronously
-    // because that would require async database access.
-    // For real-time accuracy, use isWatched() instead.
-    return metadata.isWatched;
-  }
-
   /// Get the effective view offset (resume position) for a media item.
   ///
   /// Priority:
@@ -148,25 +137,6 @@ class OfflineWatchProvider extends ChangeNotifier {
     return episodes.firstOrNull;
   }
 
-  /// Find the next unwatched downloaded episode synchronously.
-  ///
-  /// This uses cached metadata without checking local offline actions.
-  /// For real-time accuracy, use getNextUnwatchedEpisode() instead.
-  PlexMetadata? getNextUnwatchedEpisodeSync(String showRatingKey) {
-    final episodes = _getSortedEpisodes(showRatingKey);
-    if (episodes.isEmpty) return null;
-
-    // Find first unwatched episode (using metadata's isWatched)
-    for (final episode in episodes) {
-      if (!episode.isWatched) {
-        return episode;
-      }
-    }
-
-    // All episodes watched - return first episode for replay
-    return episodes.firstOrNull;
-  }
-
   /// Emit a watch state change event for immediate UI update.
   void _emitWatchStateChange({
     required String serverId,
@@ -232,11 +202,6 @@ class OfflineWatchProvider extends ChangeNotifier {
     final watchStatuses = await _resolveEpisodeWatchStatuses(episodes);
 
     return [for (final episode in episodes) (episode, watchStatuses[episode.globalKey]!)];
-  }
-
-  /// Trigger a manual sync of pending items.
-  Future<void> syncNow() async {
-    await _syncService.syncPendingItems();
   }
 
   @override

--- a/lib/providers/playback_state_provider.dart
+++ b/lib/providers/playback_state_provider.dart
@@ -66,13 +66,6 @@ class PlaybackStateProvider with ChangeNotifier {
   /// Total number of items in the play queue
   int get queueLength => _playQueueTotalCount;
 
-  /// Gets the current position in the queue (1-indexed)
-  int get currentPosition {
-    if (_currentPlayQueueItemID == null || _loadedItems.isEmpty) return 0;
-    final index = _loadedItems.indexWhere((item) => item.playQueueItemID == _currentPlayQueueItemID);
-    return index != -1 ? index + 1 : 0;
-  }
-
   /// Set the client reference for loading more items
   void setClient(PlexClient client) {
     _client = client;

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -114,20 +114,4 @@ class ThemeProvider extends ChangeNotifier {
     }
   }
 
-  void toggleTheme() {
-    switch (_themeMode) {
-      case settings.ThemeMode.system:
-        setThemeMode(settings.ThemeMode.light);
-        break;
-      case settings.ThemeMode.light:
-        setThemeMode(settings.ThemeMode.dark);
-        break;
-      case settings.ThemeMode.dark:
-        setThemeMode(settings.ThemeMode.oled);
-        break;
-      case settings.ThemeMode.oled:
-        setThemeMode(settings.ThemeMode.system);
-        break;
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- Remove `updateTokenForServer()` from `MultiServerProvider` (never called)
- Remove `toggleTheme()` from `ThemeProvider` (never called; `setThemeMode()` used directly)
- Remove `isWatchedSync()`, `getNextUnwatchedEpisodeSync()`, and `syncNow()` from `OfflineWatchProvider` (async versions used instead)
- Remove `currentPosition` getter from `PlaybackStateProvider` (never accessed)

## Test plan
- [x] `dart analyze lib/` passes with no new errors
- No behavioral changes — all removed methods had zero external call sites