### PR TITLE
Remove dead utility methods

### DIFF
--- a/lib/utils/content_utils.dart
+++ b/lib/utils/content_utils.dart
@@ -44,11 +44,6 @@ class ContentTypeHelper {
     }
   }
 
-  /// Filters out music content from a list of items
-  static List<T> filterOutMusic<T>(List<T> items, String Function(T) getType) {
-    return items.where((item) => !isMusicContent(getType(item))).toList();
-  }
-
   /// Returns the appropriate icon for a given library type
   static IconData getLibraryIcon(String type) {
     switch (type.toLowerCase()) {

--- a/lib/utils/provider_extensions.dart
+++ b/lib/utils/provider_extensions.dart
@@ -13,11 +13,7 @@ import 'app_logger.dart';
 extension ProviderExtensions on BuildContext {
   UserProfileProvider get userProfile => Provider.of<UserProfileProvider>(this, listen: false);
 
-  UserProfileProvider watchUserProfile() => Provider.of<UserProfileProvider>(this, listen: true);
-
   HiddenLibrariesProvider get hiddenLibraries => Provider.of<HiddenLibrariesProvider>(this, listen: false);
-
-  HiddenLibrariesProvider watchHiddenLibraries() => Provider.of<HiddenLibrariesProvider>(this, listen: true);
 
   // Direct profile settings access (nullable)
   PlexUserProfile? get profileSettings => userProfile.profileSettings;


### PR DESCRIPTION
## Summary
- Remove `ContentTypeHelper.filterOutMusic()` from `lib/utils/content_utils.dart` — zero call sites
- Remove `watchUserProfile()` from `lib/utils/provider_extensions.dart` — zero call sites; the non-listening getter `userProfile` is used instead
- Remove `watchHiddenLibraries()` from `lib/utils/provider_extensions.dart` — zero call sites; the non-listening getter `hiddenLibraries` is used instead

## Test plan
- [x] `dart analyze lib/` passes (no new errors introduced; pre-existing errors from other work are unchanged)