### PR TITLE
refactor: remove dead methods from services

### DIFF
--- a/lib/services/in_app_review_service.dart
+++ b/lib/services/in_app_review_service.dart
@@ -139,31 +139,4 @@ class InAppReviewService {
     // Reset session count so user needs to use app more before next prompt
     await prefs.setInt(_keyQualifyingSessionsCount, 0);
   }
-
-  /// Get debug info about the current state (for development/testing)
-  Future<Map<String, dynamic>> getDebugInfo() async {
-    final prefs = await _getPrefs();
-    final sessionCount = prefs.getInt(_keyQualifyingSessionsCount) ?? 0;
-    final lastPromptString = prefs.getString(_keyLastPromptTime);
-    final isAvailable = await _inAppReview.isAvailable();
-
-    return {
-      'isEnabled': isEnabled,
-      'isAvailable': isAvailable,
-      'qualifyingSessions': sessionCount,
-      'requiredSessions': _requiredSessions,
-      'lastPromptTime': lastPromptString,
-      'cooldownDays': _promptCooldown.inDays,
-      'currentSessionStartTime': _sessionStartTime?.toIso8601String(),
-    };
-  }
-
-  /// Reset all stored data (for testing purposes)
-  Future<void> reset() async {
-    final prefs = await _getPrefs();
-    await prefs.remove(_keyQualifyingSessionsCount);
-    await prefs.remove(_keyLastPromptTime);
-    _sessionStartTime = null;
-    appLogger.d('In-app review: State reset');
-  }
 }

--- a/lib/services/keyboard_shortcuts_service.dart
+++ b/lib/services/keyboard_shortcuts_service.dart
@@ -368,23 +368,6 @@ class KeyboardShortcutsService {
     }
   }
 
-  // Validate if a key combination is valid (legacy method for backward compatibility)
-  bool isValidKeyShortcut(String keyString) {
-    // For backward compatibility, assume all non-empty strings are valid
-    // The new system will use HotKey objects for validation
-    return keyString.isNotEmpty;
-  }
-
-  // Check if a shortcut is already assigned to another action
-  String? getActionForShortcut(String keyString) {
-    for (final entry in _shortcuts.entries) {
-      if (entry.value == keyString) {
-        return entry.key;
-      }
-    }
-    return null;
-  }
-
   // Check if a hotkey is already assigned to another action
   String? getActionForHotkey(HotKey hotkey) {
     for (final entry in _hotkeys.entries) {

--- a/lib/services/server_registry.dart
+++ b/lib/services/server_registry.dart
@@ -53,21 +53,6 @@ class ServerRegistry {
     }
   }
 
-  /// Update server status (called when server connection status changes)
-  Future<void> updateServerStatus(String serverId) async {
-    final servers = await getServers();
-    final serverIndex = servers.indexWhere((s) => s.clientIdentifier == serverId);
-
-    if (serverIndex == -1) {
-      appLogger.w('Server not found for status update: $serverId');
-      return;
-    }
-
-    // Note: PlexServer from auth service doesn't have mutable status fields
-    // Status tracking is handled by MultiServerManager
-    // This method is kept for future extension if we add status to PlexServer model
-  }
-
   /// Add or update a single server
   Future<void> upsertServer(PlexServer server) async {
     final servers = await getServers();

--- a/lib/services/shader_service.dart
+++ b/lib/services/shader_service.dart
@@ -147,22 +147,4 @@ class ShaderService {
   Future<void> disable() async {
     await applyPreset(ShaderPreset.none);
   }
-
-  /// Cycle to the next preset in the available list.
-  Future<ShaderPreset> cyclePreset({List<ShaderPreset>? presets}) async {
-    presets ??= ShaderPreset.allPresets;
-    final currentIndex = presets.indexWhere((p) => p.id == _currentPreset.id);
-    final nextIndex = (currentIndex + 1) % presets.length;
-    final nextPreset = presets[nextIndex];
-
-    await applyPreset(nextPreset);
-    return nextPreset;
-  }
-
-  /// Reapply current preset (useful after video source changes).
-  Future<void> reapply() async {
-    if (_currentPreset.type != ShaderPresetType.none) {
-      await applyPreset(_currentPreset);
-    }
-  }
 }


### PR DESCRIPTION
Remove 7 unused methods from service files:
- `isValidKeyShortcut()` and `getActionForShortcut()` from KeyboardShortcutsService (replaced by hotkey system)
- `cyclePreset()` and `reapply()` from ShaderService
- `getDebugInfo()` and `reset()` from InAppReviewService
- `updateServerStatus()` from ServerRegistry (empty body, handled by MultiServerManager)