### PR TITLE
Fix delete propagation when episodes are displayed in flat list

### DIFF
--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -217,7 +217,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
         setState(() {
           _episodes.removeAt(epIndex);
         });
-        if (_episodes.isEmpty && widget.metadata.isSeason && mounted) {
+        if (_episodes.isEmpty && (widget.metadata.isSeason || widget.metadata.isShow) && mounted) {
           Navigator.of(context).pop();
         }
         return;


### PR DESCRIPTION
This is a small PR which just fixes the delete propagation logic (introduced in #386) to handle the fact that episodes can now be displayed directly on the show page (as of #681).