### PR TITLE
Fix missing season tabs

### DIFF
--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -1204,7 +1204,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       final isAlways = flattenSeasons == flattenSeasonsAlways;
       final isSingleSeason = flattenSeasons == flattenSeasonsSingleSeason;
       final shouldShowEpisodesDirectly =
-          isAlways || seasonsWithServerId.length <= 1 || (isSingleSeason && seasonsWithServerId.length == 1);
+          isAlways || seasonsWithServerId.isEmpty || (isSingleSeason && seasonsWithServerId.length == 1);
 
       // Create focus nodes for season tabs
       _updateSeasonTabFocusNodes(seasonsWithServerId.length);


### PR DESCRIPTION
This is a small PR which fixes an issue where a single-season TV show would not display the season navigation tabs at the top. Note that this is for a library where Plex is configured to show seasons. (For libraries where Plex is not configured to show seasons, we correctly do not see the season tabs.)

### Library Settings

<img width="730" height="532" alt="image" src="https://github.com/user-attachments/assets/305f13da-c5b9-4964-bfad-59fecc6123f3" />

### Before

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/3e47daca-dee2-485b-8d67-ce12a03767a8" />

### After

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/ddd6d8e0-93a2-4e62-b185-bcd2291d88ef" />
