### PR TITLE
fix: Live TV uses wrong begins at time

### DIFF
--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -1127,7 +1127,9 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
               final watchFromStart = await _showWatchFromStartDialog(effectiveStart, nowEpoch);
               if (!mounted) return;
               if (watchFromStart == true) {
-                offsetSeconds = max(_programBeginsAt! - _captureBuffer!.startedAt.round(), 0);
+                final _programBeginsAtOffset = _programBeginsAt! - _captureBuffer!.startedAt.round();
+                appLogger.d('Watch from start: _programBeginsAtOffset=${_programBeginsAtOffset}, _captureBuffer!.seekStartSeconds.round()=${_captureBuffer!.seekStartSeconds.round()}');
+                offsetSeconds = max(_programBeginsAtOffset, _captureBuffer!.seekStartSeconds.round());
               }
             }
           }

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -2575,14 +2575,34 @@ class PlexClient {
       final subList = subscriptions is List ? subscriptions : subscriptions is Map ? [subscriptions] : null;
       if (subList != null && subList.isNotEmpty) {
         final sub = subList.first as Map<String, dynamic>;
+
+        final timeline = sub['Timeline'];
+
+        // Safely extract the first element if it's a list, or the map itself
+        final op = timeline is List
+            ? (timeline.isNotEmpty ? timeline.first : null)
+            : (timeline is Map ? timeline : null);
+
+        if (op is Map) {
+          if (op['Metadata'] case [Map firstMetadata, ...]) {
+            if (firstMetadata['Media'] case [Map firstMedia, ...]) {
+              final rawBeginsAt = firstMedia['beginsAt'];
+
+              beginsAt = switch (rawBeginsAt) {
+                num n => n.toInt(),
+                String s => int.tryParse(s),
+                _ => null,
+              };
+
+              appLogger.d('beginsAt=$beginsAt');
+            }
+          }
+        }
+
         final ops = sub['MediaGrabOperation'];
         final opList = ops is List ? ops : ops is Map ? [ops] : null;
         if (opList != null && opList.isNotEmpty) {
           final op = opList.first as Map<String, dynamic>;
-          final rawBeginsAt = op['beginsAt'];
-          beginsAt = rawBeginsAt is num
-              ? rawBeginsAt.toInt()
-              : rawBeginsAt is String ? int.tryParse(rawBeginsAt) : null;
           final nested = op['Metadata'];
           if (nested is Map<String, dynamic>) {
             metadataJson = nested;
@@ -2629,13 +2649,18 @@ class PlexClient {
       }
 
       // beginsAt may also be on the Media items (not just the GrabOperation)
+      // This value is the start of the requested stream, not the current program. So it will effectively be the current time
       if (beginsAt == null) {
         final media = metadataJson['Media'];
         if (media is List && media.isNotEmpty) {
           final firstMedia = media.first;
           if (firstMedia is Map<String, dynamic>) {
-            final raw = firstMedia['beginsAt'];
-            beginsAt = raw is num ? raw.toInt() : raw is String ? int.tryParse(raw) : null;
+            final rawBeginsAt = firstMedia['beginsAt'];
+              beginsAt = switch (rawBeginsAt) {
+                num n => n.toInt(),
+                String s => int.tryParse(s),
+                _ => null,
+              };
           }
         }
       }


### PR DESCRIPTION
```xml
<? xml version = "1.0" encoding = "UTF-8" ?>
    <MediaContainer size="1">
        <MediaSubscription key="23427" type="4" createdAt="1775403303" title="This Episode" airingsType="New Airings Only" channelIdentifier="12">
            <MediaGrabOperation rolling="1" mediaSubscriptionID="1234" mediaIndex="0" id="...." key="/media/grabbers/operations/...." grabberIdentifier="tv.plex.grabbers.hdhomerun" grabberProtocol="livetv" percent="-1" currentSize="0" deviceID="76" status="inprogress" provider="tv.plex.providers.epg.xmltv:79">
                <Video addedAt="1775360780" duration="1800000" grandparentGuid="..." grandparentKey="...." grandparentRatingKey="me" grandparentTitle="..." guid="..." index="2" key="/livetv/sessions/..." onAir="1" parentGuid="...." parentIndex="17" parentTitle="Season 17" ratingKey="115109" skipParent="1" summary="...." title="Episode 2" type="episode">
                    <Media aspectRatio="1.78" audioChannels="2" audioCodec="mp3" beginsAt="1775403303" channelIdentifier="12" container="mpegts" endsAt="1775403603" hasVoiceActivity="0" height="1080" id="239307" origin="livetv" protocol="hls" uuid="860db61b-0619-4c12-83c5-c4639cb9450a" videoCodec="h264" videoResolution="1080" width="1920">
                        <Part container="mpegts" id="251845" key="/livetv/sessions/..../..../index.m3u8?offset=-1.000000" protocol="hls">
                            <Stream closedCaptions="1" codec="h264" displayTitle="1080p (H.264)" extendedDisplayTitle="1080p (H.264)" frameRate="59.940" height="1080" id="704171" index="0" level="42" pixelAspectRatio="1:1" profile="high" streamType="1" width="1920" />
                            <Stream audioChannelLayout="stereo" bitrate="128" channels="2" codec="mp3" displayTitle="English (MP3 Stereo)" extendedDisplayTitle="English (MP3 Stereo)" id="704172" index="1" language="English" languageCode="eng" languageTag="en" samplingRate="48000" selected="1" streamType="2" />
                            <Stream canAutoSync="0" codec="eia_608" displayTitle="Unknown (Closed Captions)" embeddedInVideo="1" extendedDisplayTitle="Unknown (Closed Captions)" id="704173" index="2" streamType="3" />
                        </Part>
                    </Media>
                    <TranscodeSession key="/transcode/sessions/..." throttled="0" complete="0" progress="-1" size="-22" speed="0.89999997615814209" error="0" duration="7200000" context="static" sourceVideoCodec="" sourceAudioCodec="" videoDecision="copy" audioDecision="copy" protocol="hls" container="mpegts" videoCodec="*" audioCodec="*" audioChannels="2" width="1920" height="1080" transcodeHwRequested="1" transcodeHwFullPipeline="0" timeStamp="1775402249.0162058" maxOffsetAvailable="1066.7620219999999" minOffsetAvailable="0.13002200424671173" />
                </Video>
            </MediaGrabOperation>
            <Timeline>
                <Video ratingKey="..." key="..." ... index="2" parentIndex="17" duration="1800000" addedAt="1775360780" onAir="1">
                    <Media id="1234" duration="1800000" audioChannels="2" videoResolution="480" channelCallSign="...." channelIdentifier="12" channelThumb="..." channelTitle="..." channelVcn="12" premiere="1" protocol="livetv" beginsAt="1775403000" endsAt="1775404800" onAir="1" channelID="12" hasVoiceActivity="0">
                    </Media>
                </Video>
                <Video>...
                </Video>
            </Timeline>
```

`beginsAt` within `MediaGrabOperation` is effectively be the current time (the time the stream is requested). The actual program beginsAt time is in the first element of `Timeline`