### PR TITLE
fix: register bundled GoNoto font in pubspec.yaml to fix NixOS rendering

### DIFF
--- a/lib/theme/mono_theme.dart
+++ b/lib/theme/mono_theme.dart
@@ -43,6 +43,7 @@ ThemeData monoTheme({required bool dark, bool oled = false}) {
 
   final base = ThemeData(
     useMaterial3: true,
+    fontFamily: 'GoNoto',
     brightness: isDark ? Brightness.dark : Brightness.light,
     colorScheme: ColorScheme(
       brightness: isDark ? Brightness.dark : Brightness.light,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -117,8 +117,11 @@ flutter:
     - assets/plezy.png
     - assets/plezy_adaptive_foreground.svg
     - assets/trakt_circlemark.svg
-    - assets/go-noto-current-regular.ttf
     - assets/shaders/nvscaler/
     - assets/shaders/anime4k/
     - assets/player_icons/
     - assets/rating_icons/
+  fonts:
+    - family: GoNoto
+      fonts:
+        - asset: assets/go-noto-current-regular.ttf


### PR DESCRIPTION
Plezy seemed to have a bug where it relied on system fonts for rendering. As a result on nixOS without many fonts installed it resulted in invisible text. This PR changes the font declaration in pubspec.yaml according to this:https://docs.flutter.dev/cookbook/design/fonts and sets it as the default fontFamily in mono_theme.dart. I can confirm that this resulted in a build where I could see the font when using the nix derivation.

Before:
<img width="1132" height="1115" alt="image" src="https://github.com/user-attachments/assets/3ec3d523-d0be-4999-9bf1-211926b3a877" />

After:
<img width="1141" height="1136" alt="image" src="https://github.com/user-attachments/assets/ad0e27f8-c448-4378-844c-47e9b7e1e11a" />

However I am unsure why but in settings the header for each setting is still invisible, there are some fonts that are declared as fontFamily: monospace which is not packaged which may be part of the reason.