### PR TITLE
Show season posters on tab in show view

### DIFF
--- a/lib/i18n/da.i18n.json
+++ b/lib/i18n/da.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Vis antal usete episoder på serier og sæsoner",
     "showEpisodeNumberOnCards": "Vis episodenummer på kort",
     "showEpisodeNumberOnCardsDescription": "Vis episodenummer ved siden af sæsonen (f.eks. S2 E3) på episodekort",
+    "showSeasonPostersOnTabs": "Vis sæsonplakater på faner",
+    "showSeasonPostersOnTabsDescription": "Vis sæsonens plakat over hver sæsonfane på en series detaljeside",
     "hideSpoilers": "Skjul spoilere for usete episoder",
     "hideSpoilersDescription": "Slør miniaturebilleder og skjul beskrivelser for episoder, du ikke har set endnu",
     "playerBackend": "Afspillerbackend",

--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Zeigt die Anzahl nicht gesehener Episoden bei Serien und Staffeln an",
     "showEpisodeNumberOnCards": "Episodennummer auf Karten anzeigen",
     "showEpisodeNumberOnCardsDescription": "Episodennummer neben der Staffel (z. B. S2 E3) auf Episodenkarten anzeigen",
+    "showSeasonPostersOnTabs": "Staffelposter auf Tabs anzeigen",
+    "showSeasonPostersOnTabsDescription": "Zeigt das Poster der Staffel über jedem Staffel-Tab auf der Detailseite einer Serie an",
     "hideSpoilers": "Spoiler für nicht gesehene Episoden verbergen",
     "hideSpoilersDescription": "Vorschaubilder unscharf machen und Beschreibungen für noch nicht gesehene Episoden ausblenden",
     "playerBackend": "Player-Backend",

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Display unwatched episode count on shows and seasons",
     "showEpisodeNumberOnCards": "Show Episode Number on Cards",
     "showEpisodeNumberOnCardsDescription": "Show episode number alongside the season (e.g. S2 E3) on episode cards",
+    "showSeasonPostersOnTabs": "Show Season Posters on Tabs",
+    "showSeasonPostersOnTabsDescription": "Display the season's poster above each season tab on a show's detail page",
     "hideSpoilers": "Hide Spoilers for Unwatched Episodes",
     "hideSpoilersDescription": "Blur thumbnails and hide descriptions for episodes you haven't watched yet",
     "playerBackend": "Player Backend",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Mostrar el conteo de episodios no vistos en series y temporadas",
     "showEpisodeNumberOnCards": "Mostrar número de episodio en las tarjetas",
     "showEpisodeNumberOnCardsDescription": "Muestra el número de episodio junto a la temporada (p. ej. S2 E3) en las tarjetas de episodios",
+    "showSeasonPostersOnTabs": "Mostrar pósters de temporada en las pestañas",
+    "showSeasonPostersOnTabsDescription": "Muestra el póster de la temporada sobre cada pestaña de temporada en la página de detalles de una serie",
     "hideSpoilers": "Ocultar spoilers de episodios no vistos",
     "hideSpoilersDescription": "Difuminar miniaturas y ocultar descripciones de episodios que aún no has visto",
     "playerBackend": "Reproductor",

--- a/lib/i18n/fr.i18n.json
+++ b/lib/i18n/fr.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Afficher le nombre d'épisodes non visionnés pour les séries et saisons",
     "showEpisodeNumberOnCards": "Afficher le numéro d'épisode sur les cartes",
     "showEpisodeNumberOnCardsDescription": "Afficher le numéro d'épisode à côté de la saison (ex. S2 E3) sur les cartes d'épisodes",
+    "showSeasonPostersOnTabs": "Afficher les posters de saison sur les onglets",
+    "showSeasonPostersOnTabsDescription": "Afficher le poster de la saison au-dessus de chaque onglet de saison sur la page de détail d'une série",
     "hideSpoilers": "Masquer les spoilers des épisodes non vus",
     "hideSpoilersDescription": "Flouter les miniatures et masquer les descriptions des épisodes que vous n'avez pas encore regardés",
     "playerBackend": "Moteur de lecture",

--- a/lib/i18n/it.i18n.json
+++ b/lib/i18n/it.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Mostra il numero di episodi non visti per serie e stagioni",
     "showEpisodeNumberOnCards": "Mostra numero episodio sulle schede",
     "showEpisodeNumberOnCardsDescription": "Mostra il numero dell'episodio accanto alla stagione (es. S2 E3) sulle schede degli episodi",
+    "showSeasonPostersOnTabs": "Mostra poster delle stagioni sulle schede",
+    "showSeasonPostersOnTabsDescription": "Mostra il poster della stagione sopra ogni scheda di stagione nella pagina di dettaglio di una serie",
     "hideSpoilers": "Nascondi spoiler per episodi non visti",
     "hideSpoilersDescription": "Sfoca le miniature e nascondi le descrizioni degli episodi che non hai ancora guardato",
     "playerBackend": "Motore di riproduzione",

--- a/lib/i18n/ja.i18n.json
+++ b/lib/i18n/ja.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "番組とシーズンに未視聴エピソード数を表示",
     "showEpisodeNumberOnCards": "カードにエピソード番号を表示",
     "showEpisodeNumberOnCardsDescription": "エピソードカードにシーズンと並べてエピソード番号（例: S2 E3）を表示",
+    "showSeasonPostersOnTabs": "タブにシーズンポスターを表示",
+    "showSeasonPostersOnTabsDescription": "番組の詳細ページで、各シーズンタブの上にそのシーズンのポスターを表示します",
     "hideSpoilers": "未視聴エピソードのネタバレを非表示",
     "hideSpoilersDescription": "まだ視聴していないエピソードのサムネイルをぼかし、説明を非表示",
     "playerBackend": "プレーヤーバックエンド",

--- a/lib/i18n/ko.i18n.json
+++ b/lib/i18n/ko.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "시리즈 및 시즌에 미시청 에피소드 수 표시",
     "showEpisodeNumberOnCards": "카드에 에피소드 번호 표시",
     "showEpisodeNumberOnCardsDescription": "에피소드 카드에 시즌과 함께 에피소드 번호(예: S2 E3)를 표시합니다",
+    "showSeasonPostersOnTabs": "탭에 시즌 포스터 표시",
+    "showSeasonPostersOnTabsDescription": "프로그램 상세 페이지의 각 시즌 탭 위에 해당 시즌의 포스터를 표시합니다",
     "hideSpoilers": "미시청 에피소드 스포일러 숨기기",
     "hideSpoilersDescription": "아직 시청하지 않은 에피소드의 썸네일을 흐리게 하고 설명을 숨깁니다",
     "playerBackend": "플레이어 백엔드",

--- a/lib/i18n/nb.i18n.json
+++ b/lib/i18n/nb.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Vis antall usette episoder på serier og sesonger",
     "showEpisodeNumberOnCards": "Vis episodenummer på kort",
     "showEpisodeNumberOnCardsDescription": "Vis episodenummer ved siden av sesongen (f.eks. S2 E3) på episodekort",
+    "showSeasonPostersOnTabs": "Vis sesongplakater på faner",
+    "showSeasonPostersOnTabsDescription": "Vis sesongens plakat over hver sesongfane på en series detaljside",
     "hideSpoilers": "Skjul spoilere for usette episoder",
     "hideSpoilersDescription": "Slør miniatyrbilder og skjul beskrivelser for episoder du ikke har sett ennå",
     "playerBackend": "Spillermotor",

--- a/lib/i18n/nl.i18n.json
+++ b/lib/i18n/nl.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Toon aantal ongekeken afleveringen bij series en seizoenen",
     "showEpisodeNumberOnCards": "Afleveringsnummer op kaarten tonen",
     "showEpisodeNumberOnCardsDescription": "Toon het afleveringsnummer naast het seizoen (bijv. S2 E3) op afleveringskaarten",
+    "showSeasonPostersOnTabs": "Toon seizoensposters op tabbladen",
+    "showSeasonPostersOnTabsDescription": "Toon de poster van het seizoen boven elk seizoenstabblad op de detailpagina van een serie",
     "hideSpoilers": "Spoilers voor ongekeken afleveringen verbergen",
     "hideSpoilersDescription": "Miniaturen vervagen en beschrijvingen verbergen voor afleveringen die je nog niet hebt gezien",
     "playerBackend": "Speler backend",

--- a/lib/i18n/pl.i18n.json
+++ b/lib/i18n/pl.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Wyświetl liczbę nieobejrzanych odcinków w serialach i sezonach",
     "showEpisodeNumberOnCards": "Pokaż numer odcinka na kartach",
     "showEpisodeNumberOnCardsDescription": "Wyświetla numer odcinka obok sezonu (np. S2 E3) na kartach odcinków",
+    "showSeasonPostersOnTabs": "Pokaż plakaty sezonów na zakładkach",
+    "showSeasonPostersOnTabsDescription": "Wyświetla plakat sezonu nad każdą zakładką sezonu na stronie szczegółów serialu",
     "hideSpoilers": "Ukryj spoilery nieobejrzanych odcinków",
     "hideSpoilersDescription": "Rozmyj miniatury i ukryj opisy odcinków, których jeszcze nie obejrzałeś",
     "playerBackend": "Backend odtwarzacza",

--- a/lib/i18n/pt.i18n.json
+++ b/lib/i18n/pt.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Exibir contagem de episódios não assistidos em séries e temporadas",
     "showEpisodeNumberOnCards": "Mostrar Número do Episódio nos Cards",
     "showEpisodeNumberOnCardsDescription": "Mostrar o número do episódio ao lado da temporada (ex. S2 E3) nos cards de episódios",
+    "showSeasonPostersOnTabs": "Mostrar Pôsteres de Temporada nas Abas",
+    "showSeasonPostersOnTabsDescription": "Exibe o pôster da temporada acima de cada aba de temporada na página de detalhes de uma série",
     "hideSpoilers": "Ocultar Spoilers de Episódios Não Assistidos",
     "hideSpoilersDescription": "Desfocar miniaturas e ocultar descrições de episódios que você ainda não assistiu",
     "playerBackend": "Backend do Player",

--- a/lib/i18n/ru.i18n.json
+++ b/lib/i18n/ru.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Отображать количество непросмотренных эпизодов для сериалов и сезонов",
     "showEpisodeNumberOnCards": "Показывать номер эпизода на карточках",
     "showEpisodeNumberOnCardsDescription": "Отображать номер эпизода рядом с сезоном (напр. S2 E3) на карточках эпизодов",
+    "showSeasonPostersOnTabs": "Показывать постеры сезонов на вкладках",
+    "showSeasonPostersOnTabsDescription": "Отображать постер сезона над каждой вкладкой сезона на странице сведений сериала",
     "hideSpoilers": "Скрыть спойлеры непросмотренных эпизодов",
     "hideSpoilersDescription": "Размывать миниатюры и скрывать описания эпизодов, которые вы ещё не смотрели",
     "playerBackend": "Бэкенд плеера",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 15
-/// Strings: 14595 (973 per locale)
+/// Strings: 14625 (975 per locale)
 ///
-/// Built on 2026-04-26 at 18:24 UTC
+/// Built on 2026-04-27 at 13:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_da.g.dart
+++ b/lib/i18n/strings_da.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsDa implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Vis antal usete episoder på serier og sæsoner';
 	@override String get showEpisodeNumberOnCards => 'Vis episodenummer på kort';
 	@override String get showEpisodeNumberOnCardsDescription => 'Vis episodenummer ved siden af sæsonen (f.eks. S2 E3) på episodekort';
+	@override String get showSeasonPostersOnTabs => 'Vis sæsonplakater på faner';
+	@override String get showSeasonPostersOnTabsDescription => 'Vis sæsonens plakat over hver sæsonfane på en series detaljeside';
 	@override String get hideSpoilers => 'Skjul spoilere for usete episoder';
 	@override String get hideSpoilersDescription => 'Slør miniaturebilleder og skjul beskrivelser for episoder, du ikke har set endnu';
 	@override String get playerBackend => 'Afspillerbackend';
@@ -1646,6 +1648,8 @@ extension on TranslationsDa {
 			'settings.showUnwatchedCountDescription' => 'Vis antal usete episoder på serier og sæsoner',
 			'settings.showEpisodeNumberOnCards' => 'Vis episodenummer på kort',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Vis episodenummer ved siden af sæsonen (f.eks. S2 E3) på episodekort',
+			'settings.showSeasonPostersOnTabs' => 'Vis sæsonplakater på faner',
+			'settings.showSeasonPostersOnTabsDescription' => 'Vis sæsonens plakat over hver sæsonfane på en series detaljeside',
 			'settings.hideSpoilers' => 'Skjul spoilere for usete episoder',
 			'settings.hideSpoilersDescription' => 'Slør miniaturebilleder og skjul beskrivelser for episoder, du ikke har set endnu',
 			'settings.playerBackend' => 'Afspillerbackend',
@@ -2050,10 +2054,10 @@ extension on TranslationsDa {
 			'libraries.analyzing' => ({required Object title}) => 'Analyserer "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analyse startet for "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Kunne ikke analysere bibliotek: ${error}',
-			'libraries.noLibrariesFound' => 'Ingen biblioteker fundet',
-			'libraries.allLibrariesHidden' => 'Alle biblioteker er skjult',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Ingen biblioteker fundet',
+			'libraries.allLibrariesHidden' => 'Alle biblioteker er skjult',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Skjulte biblioteker (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Dette bibliotek er tomt',
 			'libraries.all' => 'Alle',

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsDe implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Zeigt die Anzahl nicht gesehener Episoden bei Serien und Staffeln an';
 	@override String get showEpisodeNumberOnCards => 'Episodennummer auf Karten anzeigen';
 	@override String get showEpisodeNumberOnCardsDescription => 'Episodennummer neben der Staffel (z. B. S2 E3) auf Episodenkarten anzeigen';
+	@override String get showSeasonPostersOnTabs => 'Staffelposter auf Tabs anzeigen';
+	@override String get showSeasonPostersOnTabsDescription => 'Zeigt das Poster der Staffel über jedem Staffel-Tab auf der Detailseite einer Serie an';
 	@override String get hideSpoilers => 'Spoiler für nicht gesehene Episoden verbergen';
 	@override String get hideSpoilersDescription => 'Vorschaubilder unscharf machen und Beschreibungen für noch nicht gesehene Episoden ausblenden';
 	@override String get playerBackend => 'Player-Backend';
@@ -1646,6 +1648,8 @@ extension on TranslationsDe {
 			'settings.showUnwatchedCountDescription' => 'Zeigt die Anzahl nicht gesehener Episoden bei Serien und Staffeln an',
 			'settings.showEpisodeNumberOnCards' => 'Episodennummer auf Karten anzeigen',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Episodennummer neben der Staffel (z. B. S2 E3) auf Episodenkarten anzeigen',
+			'settings.showSeasonPostersOnTabs' => 'Staffelposter auf Tabs anzeigen',
+			'settings.showSeasonPostersOnTabsDescription' => 'Zeigt das Poster der Staffel über jedem Staffel-Tab auf der Detailseite einer Serie an',
 			'settings.hideSpoilers' => 'Spoiler für nicht gesehene Episoden verbergen',
 			'settings.hideSpoilersDescription' => 'Vorschaubilder unscharf machen und Beschreibungen für noch nicht gesehene Episoden ausblenden',
 			'settings.playerBackend' => 'Player-Backend',
@@ -2050,10 +2054,10 @@ extension on TranslationsDe {
 			'libraries.analyzing' => ({required Object title}) => 'Analysiere „${title}“...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analyse gestartet für „${title}“',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Analyse der Mediathek fehlgeschlagen: ${error}',
-			'libraries.noLibrariesFound' => 'Keine Mediatheken gefunden',
-			'libraries.allLibrariesHidden' => 'Alle Mediatheken sind ausgeblendet',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Keine Mediatheken gefunden',
+			'libraries.allLibrariesHidden' => 'Alle Mediatheken sind ausgeblendet',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Ausgeblendete Mediatheken (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Diese Mediathek ist leer',
 			'libraries.all' => 'Alle',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -454,6 +454,12 @@ class TranslationsSettingsEn {
 	/// en: 'Show episode number alongside the season (e.g. S2 E3) on episode cards'
 	String get showEpisodeNumberOnCardsDescription => 'Show episode number alongside the season (e.g. S2 E3) on episode cards';
 
+	/// en: 'Show Season Posters on Tabs'
+	String get showSeasonPostersOnTabs => 'Show Season Posters on Tabs';
+
+	/// en: 'Display the season's poster above each season tab on a show's detail page'
+	String get showSeasonPostersOnTabsDescription => 'Display the season\'s poster above each season tab on a show\'s detail page';
+
 	/// en: 'Hide Spoilers for Unwatched Episodes'
 	String get hideSpoilers => 'Hide Spoilers for Unwatched Episodes';
 
@@ -3600,6 +3606,8 @@ extension on Translations {
 			'settings.showUnwatchedCountDescription' => 'Display unwatched episode count on shows and seasons',
 			'settings.showEpisodeNumberOnCards' => 'Show Episode Number on Cards',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Show episode number alongside the season (e.g. S2 E3) on episode cards',
+			'settings.showSeasonPostersOnTabs' => 'Show Season Posters on Tabs',
+			'settings.showSeasonPostersOnTabsDescription' => 'Display the season\'s poster above each season tab on a show\'s detail page',
 			'settings.hideSpoilers' => 'Hide Spoilers for Unwatched Episodes',
 			'settings.hideSpoilersDescription' => 'Blur thumbnails and hide descriptions for episodes you haven\'t watched yet',
 			'settings.playerBackend' => 'Player Backend',
@@ -4004,10 +4012,10 @@ extension on Translations {
 			'libraries.analyzing' => ({required Object title}) => 'Analyzing "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analysis started for "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Failed to analyze library: ${error}',
-			'libraries.noLibrariesFound' => 'No libraries found',
-			'libraries.allLibrariesHidden' => 'All libraries are hidden',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'No libraries found',
+			'libraries.allLibrariesHidden' => 'All libraries are hidden',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Hidden libraries (${count})',
 			'libraries.thisLibraryIsEmpty' => 'This library is empty',
 			'libraries.all' => 'All',

--- a/lib/i18n/strings_es.g.dart
+++ b/lib/i18n/strings_es.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsEs implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Mostrar el conteo de episodios no vistos en series y temporadas';
 	@override String get showEpisodeNumberOnCards => 'Mostrar número de episodio en las tarjetas';
 	@override String get showEpisodeNumberOnCardsDescription => 'Muestra el número de episodio junto a la temporada (p. ej. S2 E3) en las tarjetas de episodios';
+	@override String get showSeasonPostersOnTabs => 'Mostrar pósters de temporada en las pestañas';
+	@override String get showSeasonPostersOnTabsDescription => 'Muestra el póster de la temporada sobre cada pestaña de temporada en la página de detalles de una serie';
 	@override String get hideSpoilers => 'Ocultar spoilers de episodios no vistos';
 	@override String get hideSpoilersDescription => 'Difuminar miniaturas y ocultar descripciones de episodios que aún no has visto';
 	@override String get playerBackend => 'Reproductor';
@@ -1646,6 +1648,8 @@ extension on TranslationsEs {
 			'settings.showUnwatchedCountDescription' => 'Mostrar el conteo de episodios no vistos en series y temporadas',
 			'settings.showEpisodeNumberOnCards' => 'Mostrar número de episodio en las tarjetas',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Muestra el número de episodio junto a la temporada (p. ej. S2 E3) en las tarjetas de episodios',
+			'settings.showSeasonPostersOnTabs' => 'Mostrar pósters de temporada en las pestañas',
+			'settings.showSeasonPostersOnTabsDescription' => 'Muestra el póster de la temporada sobre cada pestaña de temporada en la página de detalles de una serie',
 			'settings.hideSpoilers' => 'Ocultar spoilers de episodios no vistos',
 			'settings.hideSpoilersDescription' => 'Difuminar miniaturas y ocultar descripciones de episodios que aún no has visto',
 			'settings.playerBackend' => 'Reproductor',
@@ -2050,10 +2054,10 @@ extension on TranslationsEs {
 			'libraries.analyzing' => ({required Object title}) => 'Analizando "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Análisis iniciado para "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Error al analizar la biblioteca: ${error}',
-			'libraries.noLibrariesFound' => 'No se encontraron bibliotecas',
-			'libraries.allLibrariesHidden' => 'Todas las bibliotecas están ocultas',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'No se encontraron bibliotecas',
+			'libraries.allLibrariesHidden' => 'Todas las bibliotecas están ocultas',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Bibliotecas ocultas (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Esta biblioteca está vacía',
 			'libraries.all' => 'Todos',

--- a/lib/i18n/strings_fr.g.dart
+++ b/lib/i18n/strings_fr.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsFr implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Afficher le nombre d\'épisodes non visionnés pour les séries et saisons';
 	@override String get showEpisodeNumberOnCards => 'Afficher le numéro d\'épisode sur les cartes';
 	@override String get showEpisodeNumberOnCardsDescription => 'Afficher le numéro d\'épisode à côté de la saison (ex. S2 E3) sur les cartes d\'épisodes';
+	@override String get showSeasonPostersOnTabs => 'Afficher les posters de saison sur les onglets';
+	@override String get showSeasonPostersOnTabsDescription => 'Afficher le poster de la saison au-dessus de chaque onglet de saison sur la page de détail d\'une série';
 	@override String get hideSpoilers => 'Masquer les spoilers des épisodes non vus';
 	@override String get hideSpoilersDescription => 'Flouter les miniatures et masquer les descriptions des épisodes que vous n\'avez pas encore regardés';
 	@override String get playerBackend => 'Moteur de lecture';
@@ -1646,6 +1648,8 @@ extension on TranslationsFr {
 			'settings.showUnwatchedCountDescription' => 'Afficher le nombre d\'épisodes non visionnés pour les séries et saisons',
 			'settings.showEpisodeNumberOnCards' => 'Afficher le numéro d\'épisode sur les cartes',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Afficher le numéro d\'épisode à côté de la saison (ex. S2 E3) sur les cartes d\'épisodes',
+			'settings.showSeasonPostersOnTabs' => 'Afficher les posters de saison sur les onglets',
+			'settings.showSeasonPostersOnTabsDescription' => 'Afficher le poster de la saison au-dessus de chaque onglet de saison sur la page de détail d\'une série',
 			'settings.hideSpoilers' => 'Masquer les spoilers des épisodes non vus',
 			'settings.hideSpoilersDescription' => 'Flouter les miniatures et masquer les descriptions des épisodes que vous n\'avez pas encore regardés',
 			'settings.playerBackend' => 'Moteur de lecture',
@@ -2050,10 +2054,10 @@ extension on TranslationsFr {
 			'libraries.analyzing' => ({required Object title}) => 'Analyse de "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'L\'analyse a commencé pour "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Échec de l\'analyse de la bibliothèque: ${error}',
-			'libraries.noLibrariesFound' => 'Aucune bibliothèque trouvée',
-			'libraries.allLibrariesHidden' => 'Toutes les bibliothèques sont masquées',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Aucune bibliothèque trouvée',
+			'libraries.allLibrariesHidden' => 'Toutes les bibliothèques sont masquées',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Bibliothèques masquées (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Cette bibliothèque est vide',
 			'libraries.all' => 'Tout',

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsIt implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Mostra il numero di episodi non visti per serie e stagioni';
 	@override String get showEpisodeNumberOnCards => 'Mostra numero episodio sulle schede';
 	@override String get showEpisodeNumberOnCardsDescription => 'Mostra il numero dell\'episodio accanto alla stagione (es. S2 E3) sulle schede degli episodi';
+	@override String get showSeasonPostersOnTabs => 'Mostra poster delle stagioni sulle schede';
+	@override String get showSeasonPostersOnTabsDescription => 'Mostra il poster della stagione sopra ogni scheda di stagione nella pagina di dettaglio di una serie';
 	@override String get hideSpoilers => 'Nascondi spoiler per episodi non visti';
 	@override String get hideSpoilersDescription => 'Sfoca le miniature e nascondi le descrizioni degli episodi che non hai ancora guardato';
 	@override String get playerBackend => 'Motore di riproduzione';
@@ -1646,6 +1648,8 @@ extension on TranslationsIt {
 			'settings.showUnwatchedCountDescription' => 'Mostra il numero di episodi non visti per serie e stagioni',
 			'settings.showEpisodeNumberOnCards' => 'Mostra numero episodio sulle schede',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Mostra il numero dell\'episodio accanto alla stagione (es. S2 E3) sulle schede degli episodi',
+			'settings.showSeasonPostersOnTabs' => 'Mostra poster delle stagioni sulle schede',
+			'settings.showSeasonPostersOnTabsDescription' => 'Mostra il poster della stagione sopra ogni scheda di stagione nella pagina di dettaglio di una serie',
 			'settings.hideSpoilers' => 'Nascondi spoiler per episodi non visti',
 			'settings.hideSpoilersDescription' => 'Sfoca le miniature e nascondi le descrizioni degli episodi che non hai ancora guardato',
 			'settings.playerBackend' => 'Motore di riproduzione',
@@ -2050,10 +2054,10 @@ extension on TranslationsIt {
 			'libraries.analyzing' => ({required Object title}) => 'Analisi "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analisi iniziata per "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Impossibile analizzare libreria: ${error}',
-			'libraries.noLibrariesFound' => 'Nessuna libreria trovata',
-			'libraries.allLibrariesHidden' => 'Tutte le librerie sono nascoste',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Nessuna libreria trovata',
+			'libraries.allLibrariesHidden' => 'Tutte le librerie sono nascoste',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Librerie nascoste (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Questa libreria è vuota',
 			'libraries.all' => 'Tutto',

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsJa implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => '番組とシーズンに未視聴エピソード数を表示';
 	@override String get showEpisodeNumberOnCards => 'カードにエピソード番号を表示';
 	@override String get showEpisodeNumberOnCardsDescription => 'エピソードカードにシーズンと並べてエピソード番号（例: S2 E3）を表示';
+	@override String get showSeasonPostersOnTabs => 'タブにシーズンポスターを表示';
+	@override String get showSeasonPostersOnTabsDescription => '番組の詳細ページで、各シーズンタブの上にそのシーズンのポスターを表示します';
 	@override String get hideSpoilers => '未視聴エピソードのネタバレを非表示';
 	@override String get hideSpoilersDescription => 'まだ視聴していないエピソードのサムネイルをぼかし、説明を非表示';
 	@override String get playerBackend => 'プレーヤーバックエンド';
@@ -1646,6 +1648,8 @@ extension on TranslationsJa {
 			'settings.showUnwatchedCountDescription' => '番組とシーズンに未視聴エピソード数を表示',
 			'settings.showEpisodeNumberOnCards' => 'カードにエピソード番号を表示',
 			'settings.showEpisodeNumberOnCardsDescription' => 'エピソードカードにシーズンと並べてエピソード番号（例: S2 E3）を表示',
+			'settings.showSeasonPostersOnTabs' => 'タブにシーズンポスターを表示',
+			'settings.showSeasonPostersOnTabsDescription' => '番組の詳細ページで、各シーズンタブの上にそのシーズンのポスターを表示します',
 			'settings.hideSpoilers' => '未視聴エピソードのネタバレを非表示',
 			'settings.hideSpoilersDescription' => 'まだ視聴していないエピソードのサムネイルをぼかし、説明を非表示',
 			'settings.playerBackend' => 'プレーヤーバックエンド',
@@ -2050,10 +2054,10 @@ extension on TranslationsJa {
 			'libraries.analyzing' => ({required Object title}) => '"${title}"を解析中...',
 			'libraries.analysisStarted' => ({required Object title}) => '"${title}"の解析を開始しました',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'ライブラリの解析に失敗しました: ${error}',
-			'libraries.noLibrariesFound' => 'ライブラリが見つかりません',
-			'libraries.allLibrariesHidden' => 'すべてのライブラリが非表示です',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'ライブラリが見つかりません',
+			'libraries.allLibrariesHidden' => 'すべてのライブラリが非表示です',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => '非表示のライブラリ (${count})',
 			'libraries.thisLibraryIsEmpty' => 'このライブラリは空です',
 			'libraries.all' => 'すべて',

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsKo implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => '시리즈 및 시즌에 미시청 에피소드 수 표시';
 	@override String get showEpisodeNumberOnCards => '카드에 에피소드 번호 표시';
 	@override String get showEpisodeNumberOnCardsDescription => '에피소드 카드에 시즌과 함께 에피소드 번호(예: S2 E3)를 표시합니다';
+	@override String get showSeasonPostersOnTabs => '탭에 시즌 포스터 표시';
+	@override String get showSeasonPostersOnTabsDescription => '프로그램 상세 페이지의 각 시즌 탭 위에 해당 시즌의 포스터를 표시합니다';
 	@override String get hideSpoilers => '미시청 에피소드 스포일러 숨기기';
 	@override String get hideSpoilersDescription => '아직 시청하지 않은 에피소드의 썸네일을 흐리게 하고 설명을 숨깁니다';
 	@override String get playerBackend => '플레이어 백엔드';
@@ -1646,6 +1648,8 @@ extension on TranslationsKo {
 			'settings.showUnwatchedCountDescription' => '시리즈 및 시즌에 미시청 에피소드 수 표시',
 			'settings.showEpisodeNumberOnCards' => '카드에 에피소드 번호 표시',
 			'settings.showEpisodeNumberOnCardsDescription' => '에피소드 카드에 시즌과 함께 에피소드 번호(예: S2 E3)를 표시합니다',
+			'settings.showSeasonPostersOnTabs' => '탭에 시즌 포스터 표시',
+			'settings.showSeasonPostersOnTabsDescription' => '프로그램 상세 페이지의 각 시즌 탭 위에 해당 시즌의 포스터를 표시합니다',
 			'settings.hideSpoilers' => '미시청 에피소드 스포일러 숨기기',
 			'settings.hideSpoilersDescription' => '아직 시청하지 않은 에피소드의 썸네일을 흐리게 하고 설명을 숨깁니다',
 			'settings.playerBackend' => '플레이어 백엔드',
@@ -2050,10 +2054,10 @@ extension on TranslationsKo {
 			'libraries.analyzing' => ({required Object title}) => '"${title}" 분석 중...',
 			'libraries.analysisStarted' => ({required Object title}) => '"${title}" 분석 시작됨',
 			'libraries.failedToAnalyze' => ({required Object error}) => '미디어 라이브러리 분석 실패: ${error}',
-			'libraries.noLibrariesFound' => '미디어 라이브러리 없음',
-			'libraries.allLibrariesHidden' => '모든 라이브러리가 숨겨졌습니다',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => '미디어 라이브러리 없음',
+			'libraries.allLibrariesHidden' => '모든 라이브러리가 숨겨졌습니다',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => '숨겨진 라이브러리 (${count})',
 			'libraries.thisLibraryIsEmpty' => '이 미디어 라이브러리는 비어 있습니다',
 			'libraries.all' => '전체',

--- a/lib/i18n/strings_nb.g.dart
+++ b/lib/i18n/strings_nb.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsNb implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Vis antall usette episoder på serier og sesonger';
 	@override String get showEpisodeNumberOnCards => 'Vis episodenummer på kort';
 	@override String get showEpisodeNumberOnCardsDescription => 'Vis episodenummer ved siden av sesongen (f.eks. S2 E3) på episodekort';
+	@override String get showSeasonPostersOnTabs => 'Vis sesongplakater på faner';
+	@override String get showSeasonPostersOnTabsDescription => 'Vis sesongens plakat over hver sesongfane på en series detaljside';
 	@override String get hideSpoilers => 'Skjul spoilere for usette episoder';
 	@override String get hideSpoilersDescription => 'Slør miniatyrbilder og skjul beskrivelser for episoder du ikke har sett ennå';
 	@override String get playerBackend => 'Spillermotor';
@@ -1646,6 +1648,8 @@ extension on TranslationsNb {
 			'settings.showUnwatchedCountDescription' => 'Vis antall usette episoder på serier og sesonger',
 			'settings.showEpisodeNumberOnCards' => 'Vis episodenummer på kort',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Vis episodenummer ved siden av sesongen (f.eks. S2 E3) på episodekort',
+			'settings.showSeasonPostersOnTabs' => 'Vis sesongplakater på faner',
+			'settings.showSeasonPostersOnTabsDescription' => 'Vis sesongens plakat over hver sesongfane på en series detaljside',
 			'settings.hideSpoilers' => 'Skjul spoilere for usette episoder',
 			'settings.hideSpoilersDescription' => 'Slør miniatyrbilder og skjul beskrivelser for episoder du ikke har sett ennå',
 			'settings.playerBackend' => 'Spillermotor',
@@ -2050,10 +2054,10 @@ extension on TranslationsNb {
 			'libraries.analyzing' => ({required Object title}) => 'Analyserer "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analyse startet for "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Kunne ikke analysere bibliotek: ${error}',
-			'libraries.noLibrariesFound' => 'Ingen biblioteker funnet',
-			'libraries.allLibrariesHidden' => 'Alle biblioteker er skjult',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Ingen biblioteker funnet',
+			'libraries.allLibrariesHidden' => 'Alle biblioteker er skjult',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Skjulte biblioteker (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Dette biblioteket er tomt',
 			'libraries.all' => 'Alle',

--- a/lib/i18n/strings_nl.g.dart
+++ b/lib/i18n/strings_nl.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsNl implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Toon aantal ongekeken afleveringen bij series en seizoenen';
 	@override String get showEpisodeNumberOnCards => 'Afleveringsnummer op kaarten tonen';
 	@override String get showEpisodeNumberOnCardsDescription => 'Toon het afleveringsnummer naast het seizoen (bijv. S2 E3) op afleveringskaarten';
+	@override String get showSeasonPostersOnTabs => 'Toon seizoensposters op tabbladen';
+	@override String get showSeasonPostersOnTabsDescription => 'Toon de poster van het seizoen boven elk seizoenstabblad op de detailpagina van een serie';
 	@override String get hideSpoilers => 'Spoilers voor ongekeken afleveringen verbergen';
 	@override String get hideSpoilersDescription => 'Miniaturen vervagen en beschrijvingen verbergen voor afleveringen die je nog niet hebt gezien';
 	@override String get playerBackend => 'Speler backend';
@@ -1646,6 +1648,8 @@ extension on TranslationsNl {
 			'settings.showUnwatchedCountDescription' => 'Toon aantal ongekeken afleveringen bij series en seizoenen',
 			'settings.showEpisodeNumberOnCards' => 'Afleveringsnummer op kaarten tonen',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Toon het afleveringsnummer naast het seizoen (bijv. S2 E3) op afleveringskaarten',
+			'settings.showSeasonPostersOnTabs' => 'Toon seizoensposters op tabbladen',
+			'settings.showSeasonPostersOnTabsDescription' => 'Toon de poster van het seizoen boven elk seizoenstabblad op de detailpagina van een serie',
 			'settings.hideSpoilers' => 'Spoilers voor ongekeken afleveringen verbergen',
 			'settings.hideSpoilersDescription' => 'Miniaturen vervagen en beschrijvingen verbergen voor afleveringen die je nog niet hebt gezien',
 			'settings.playerBackend' => 'Speler backend',
@@ -2050,10 +2054,10 @@ extension on TranslationsNl {
 			'libraries.analyzing' => ({required Object title}) => 'Analyseren "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analyse gestart voor "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Kon bibliotheek niet analyseren: ${error}',
-			'libraries.noLibrariesFound' => 'Geen bibliotheken gevonden',
-			'libraries.allLibrariesHidden' => 'Alle bibliotheken zijn verborgen',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Geen bibliotheken gevonden',
+			'libraries.allLibrariesHidden' => 'Alle bibliotheken zijn verborgen',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Verborgen bibliotheken (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Deze bibliotheek is leeg',
 			'libraries.all' => 'Alles',

--- a/lib/i18n/strings_pl.g.dart
+++ b/lib/i18n/strings_pl.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsPl implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Wyświetl liczbę nieobejrzanych odcinków w serialach i sezonach';
 	@override String get showEpisodeNumberOnCards => 'Pokaż numer odcinka na kartach';
 	@override String get showEpisodeNumberOnCardsDescription => 'Wyświetla numer odcinka obok sezonu (np. S2 E3) na kartach odcinków';
+	@override String get showSeasonPostersOnTabs => 'Pokaż plakaty sezonów na zakładkach';
+	@override String get showSeasonPostersOnTabsDescription => 'Wyświetla plakat sezonu nad każdą zakładką sezonu na stronie szczegółów serialu';
 	@override String get hideSpoilers => 'Ukryj spoilery nieobejrzanych odcinków';
 	@override String get hideSpoilersDescription => 'Rozmyj miniatury i ukryj opisy odcinków, których jeszcze nie obejrzałeś';
 	@override String get playerBackend => 'Backend odtwarzacza';
@@ -1646,6 +1648,8 @@ extension on TranslationsPl {
 			'settings.showUnwatchedCountDescription' => 'Wyświetl liczbę nieobejrzanych odcinków w serialach i sezonach',
 			'settings.showEpisodeNumberOnCards' => 'Pokaż numer odcinka na kartach',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Wyświetla numer odcinka obok sezonu (np. S2 E3) na kartach odcinków',
+			'settings.showSeasonPostersOnTabs' => 'Pokaż plakaty sezonów na zakładkach',
+			'settings.showSeasonPostersOnTabsDescription' => 'Wyświetla plakat sezonu nad każdą zakładką sezonu na stronie szczegółów serialu',
 			'settings.hideSpoilers' => 'Ukryj spoilery nieobejrzanych odcinków',
 			'settings.hideSpoilersDescription' => 'Rozmyj miniatury i ukryj opisy odcinków, których jeszcze nie obejrzałeś',
 			'settings.playerBackend' => 'Backend odtwarzacza',
@@ -2050,10 +2054,10 @@ extension on TranslationsPl {
 			'libraries.analyzing' => ({required Object title}) => 'Analizowanie "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analiza rozpoczęta dla "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Nie udało się przeanalizować biblioteki: ${error}',
-			'libraries.noLibrariesFound' => 'Nie znaleziono bibliotek',
-			'libraries.allLibrariesHidden' => 'Wszystkie biblioteki są ukryte',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Nie znaleziono bibliotek',
+			'libraries.allLibrariesHidden' => 'Wszystkie biblioteki są ukryte',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Ukryte biblioteki (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Ta biblioteka jest pusta',
 			'libraries.all' => 'Wszystkie',

--- a/lib/i18n/strings_pt.g.dart
+++ b/lib/i18n/strings_pt.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsPt implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Exibir contagem de episódios não assistidos em séries e temporadas';
 	@override String get showEpisodeNumberOnCards => 'Mostrar Número do Episódio nos Cards';
 	@override String get showEpisodeNumberOnCardsDescription => 'Mostrar o número do episódio ao lado da temporada (ex. S2 E3) nos cards de episódios';
+	@override String get showSeasonPostersOnTabs => 'Mostrar Pôsteres de Temporada nas Abas';
+	@override String get showSeasonPostersOnTabsDescription => 'Exibe o pôster da temporada acima de cada aba de temporada na página de detalhes de uma série';
 	@override String get hideSpoilers => 'Ocultar Spoilers de Episódios Não Assistidos';
 	@override String get hideSpoilersDescription => 'Desfocar miniaturas e ocultar descrições de episódios que você ainda não assistiu';
 	@override String get playerBackend => 'Backend do Player';
@@ -1646,6 +1648,8 @@ extension on TranslationsPt {
 			'settings.showUnwatchedCountDescription' => 'Exibir contagem de episódios não assistidos em séries e temporadas',
 			'settings.showEpisodeNumberOnCards' => 'Mostrar Número do Episódio nos Cards',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Mostrar o número do episódio ao lado da temporada (ex. S2 E3) nos cards de episódios',
+			'settings.showSeasonPostersOnTabs' => 'Mostrar Pôsteres de Temporada nas Abas',
+			'settings.showSeasonPostersOnTabsDescription' => 'Exibe o pôster da temporada acima de cada aba de temporada na página de detalhes de uma série',
 			'settings.hideSpoilers' => 'Ocultar Spoilers de Episódios Não Assistidos',
 			'settings.hideSpoilersDescription' => 'Desfocar miniaturas e ocultar descrições de episódios que você ainda não assistiu',
 			'settings.playerBackend' => 'Backend do Player',
@@ -2050,10 +2054,10 @@ extension on TranslationsPt {
 			'libraries.analyzing' => ({required Object title}) => 'Analisando "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Análise iniciada para "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Falha ao analisar biblioteca: ${error}',
-			'libraries.noLibrariesFound' => 'Nenhuma biblioteca encontrada',
-			'libraries.allLibrariesHidden' => 'Todas as bibliotecas estão ocultas',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Nenhuma biblioteca encontrada',
+			'libraries.allLibrariesHidden' => 'Todas as bibliotecas estão ocultas',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Bibliotecas ocultas (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Esta biblioteca está vazia',
 			'libraries.all' => 'Todos',

--- a/lib/i18n/strings_ru.g.dart
+++ b/lib/i18n/strings_ru.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsRu implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Отображать количество непросмотренных эпизодов для сериалов и сезонов';
 	@override String get showEpisodeNumberOnCards => 'Показывать номер эпизода на карточках';
 	@override String get showEpisodeNumberOnCardsDescription => 'Отображать номер эпизода рядом с сезоном (напр. S2 E3) на карточках эпизодов';
+	@override String get showSeasonPostersOnTabs => 'Показывать постеры сезонов на вкладках';
+	@override String get showSeasonPostersOnTabsDescription => 'Отображать постер сезона над каждой вкладкой сезона на странице сведений сериала';
 	@override String get hideSpoilers => 'Скрыть спойлеры непросмотренных эпизодов';
 	@override String get hideSpoilersDescription => 'Размывать миниатюры и скрывать описания эпизодов, которые вы ещё не смотрели';
 	@override String get playerBackend => 'Бэкенд плеера';
@@ -1646,6 +1648,8 @@ extension on TranslationsRu {
 			'settings.showUnwatchedCountDescription' => 'Отображать количество непросмотренных эпизодов для сериалов и сезонов',
 			'settings.showEpisodeNumberOnCards' => 'Показывать номер эпизода на карточках',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Отображать номер эпизода рядом с сезоном (напр. S2 E3) на карточках эпизодов',
+			'settings.showSeasonPostersOnTabs' => 'Показывать постеры сезонов на вкладках',
+			'settings.showSeasonPostersOnTabsDescription' => 'Отображать постер сезона над каждой вкладкой сезона на странице сведений сериала',
 			'settings.hideSpoilers' => 'Скрыть спойлеры непросмотренных эпизодов',
 			'settings.hideSpoilersDescription' => 'Размывать миниатюры и скрывать описания эпизодов, которые вы ещё не смотрели',
 			'settings.playerBackend' => 'Бэкенд плеера',
@@ -2050,10 +2054,10 @@ extension on TranslationsRu {
 			'libraries.analyzing' => ({required Object title}) => 'Анализ "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Анализ начат для "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Не удалось проанализировать библиотеку: ${error}',
-			'libraries.noLibrariesFound' => 'Библиотеки не найдены',
-			'libraries.allLibrariesHidden' => 'Все библиотеки скрыты',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Библиотеки не найдены',
+			'libraries.allLibrariesHidden' => 'Все библиотеки скрыты',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Скрытые библиотеки (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Эта библиотека пуста',
 			'libraries.all' => 'Все',

--- a/lib/i18n/strings_sv.g.dart
+++ b/lib/i18n/strings_sv.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsSv implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => 'Visa antal osedda avsnitt för serier och säsonger';
 	@override String get showEpisodeNumberOnCards => 'Visa avsnittsnummer på kort';
 	@override String get showEpisodeNumberOnCardsDescription => 'Visa avsnittsnummer tillsammans med säsongen (t.ex. S2 E3) på avsnittskort';
+	@override String get showSeasonPostersOnTabs => 'Visa säsongsaffischer på flikar';
+	@override String get showSeasonPostersOnTabsDescription => 'Visa säsongens affisch ovanför varje säsongsflik på en series detaljsida';
 	@override String get hideSpoilers => 'Dölj spoilers för osedda avsnitt';
 	@override String get hideSpoilersDescription => 'Gör miniatyrer suddiga och dölj beskrivningar för avsnitt du inte har sett ännu';
 	@override String get playerBackend => 'Spelarmotor';
@@ -1646,6 +1648,8 @@ extension on TranslationsSv {
 			'settings.showUnwatchedCountDescription' => 'Visa antal osedda avsnitt för serier och säsonger',
 			'settings.showEpisodeNumberOnCards' => 'Visa avsnittsnummer på kort',
 			'settings.showEpisodeNumberOnCardsDescription' => 'Visa avsnittsnummer tillsammans med säsongen (t.ex. S2 E3) på avsnittskort',
+			'settings.showSeasonPostersOnTabs' => 'Visa säsongsaffischer på flikar',
+			'settings.showSeasonPostersOnTabsDescription' => 'Visa säsongens affisch ovanför varje säsongsflik på en series detaljsida',
 			'settings.hideSpoilers' => 'Dölj spoilers för osedda avsnitt',
 			'settings.hideSpoilersDescription' => 'Gör miniatyrer suddiga och dölj beskrivningar för avsnitt du inte har sett ännu',
 			'settings.playerBackend' => 'Spelarmotor',
@@ -2050,10 +2054,10 @@ extension on TranslationsSv {
 			'libraries.analyzing' => ({required Object title}) => 'Analyserar "${title}"...',
 			'libraries.analysisStarted' => ({required Object title}) => 'Analys startad för "${title}"',
 			'libraries.failedToAnalyze' => ({required Object error}) => 'Misslyckades att analysera bibliotek: ${error}',
-			'libraries.noLibrariesFound' => 'Inga bibliotek hittades',
-			'libraries.allLibrariesHidden' => 'Alla bibliotek är dolda',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => 'Inga bibliotek hittades',
+			'libraries.allLibrariesHidden' => 'Alla bibliotek är dolda',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => 'Dolda bibliotek (${count})',
 			'libraries.thisLibraryIsEmpty' => 'Detta bibliotek är tomt',
 			'libraries.all' => 'Alla',

--- a/lib/i18n/strings_zh.g.dart
+++ b/lib/i18n/strings_zh.g.dart
@@ -238,6 +238,8 @@ class _TranslationsSettingsZh implements TranslationsSettingsEn {
 	@override String get showUnwatchedCountDescription => '在剧集和季上显示未观看的集数';
 	@override String get showEpisodeNumberOnCards => '在卡片上显示集数';
 	@override String get showEpisodeNumberOnCardsDescription => '在剧集卡片上，季号旁同时显示集数（例如 S2 E3）';
+	@override String get showSeasonPostersOnTabs => '在选项卡上显示季海报';
+	@override String get showSeasonPostersOnTabsDescription => '在剧集详情页中，每个季选项卡的上方显示该季的海报';
 	@override String get hideSpoilers => '隐藏未看剧集的剧透内容';
 	@override String get hideSpoilersDescription => '模糊未观看剧集的缩略图并隐藏其描述';
 	@override String get playerBackend => '播放器引擎';
@@ -1646,6 +1648,8 @@ extension on TranslationsZh {
 			'settings.showUnwatchedCountDescription' => '在剧集和季上显示未观看的集数',
 			'settings.showEpisodeNumberOnCards' => '在卡片上显示集数',
 			'settings.showEpisodeNumberOnCardsDescription' => '在剧集卡片上，季号旁同时显示集数（例如 S2 E3）',
+			'settings.showSeasonPostersOnTabs' => '在选项卡上显示季海报',
+			'settings.showSeasonPostersOnTabsDescription' => '在剧集详情页中，每个季选项卡的上方显示该季的海报',
 			'settings.hideSpoilers' => '隐藏未看剧集的剧透内容',
 			'settings.hideSpoilersDescription' => '模糊未观看剧集的缩略图并隐藏其描述',
 			'settings.playerBackend' => '播放器引擎',
@@ -2050,10 +2054,10 @@ extension on TranslationsZh {
 			'libraries.analyzing' => ({required Object title}) => '正在分析 “${title}”...',
 			'libraries.analysisStarted' => ({required Object title}) => '已开始分析 “${title}”',
 			'libraries.failedToAnalyze' => ({required Object error}) => '无法分析媒体库: ${error}',
-			'libraries.noLibrariesFound' => '未找到媒体库',
-			'libraries.allLibrariesHidden' => '所有媒体库已隐藏',
 			_ => null,
 		} ?? switch (path) {
+			'libraries.noLibrariesFound' => '未找到媒体库',
+			'libraries.allLibrariesHidden' => '所有媒体库已隐藏',
 			'libraries.hiddenLibrariesCount' => ({required Object count}) => '已隐藏的媒体库 (${count})',
 			'libraries.thisLibraryIsEmpty' => '此媒体库为空',
 			'libraries.all' => '全部',

--- a/lib/i18n/sv.i18n.json
+++ b/lib/i18n/sv.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "Visa antal osedda avsnitt för serier och säsonger",
     "showEpisodeNumberOnCards": "Visa avsnittsnummer på kort",
     "showEpisodeNumberOnCardsDescription": "Visa avsnittsnummer tillsammans med säsongen (t.ex. S2 E3) på avsnittskort",
+    "showSeasonPostersOnTabs": "Visa säsongsaffischer på flikar",
+    "showSeasonPostersOnTabsDescription": "Visa säsongens affisch ovanför varje säsongsflik på en series detaljsida",
     "hideSpoilers": "Dölj spoilers för osedda avsnitt",
     "hideSpoilersDescription": "Gör miniatyrer suddiga och dölj beskrivningar för avsnitt du inte har sett ännu",
     "playerBackend": "Spelarmotor",

--- a/lib/i18n/zh.i18n.json
+++ b/lib/i18n/zh.i18n.json
@@ -116,6 +116,8 @@
     "showUnwatchedCountDescription": "在剧集和季上显示未观看的集数",
     "showEpisodeNumberOnCards": "在卡片上显示集数",
     "showEpisodeNumberOnCardsDescription": "在剧集卡片上，季号旁同时显示集数（例如 S2 E3）",
+    "showSeasonPostersOnTabs": "在选项卡上显示季海报",
+    "showSeasonPostersOnTabsDescription": "在剧集详情页中，每个季选项卡的上方显示该季的海报",
     "hideSpoilers": "隐藏未看剧集的剧透内容",
     "hideSpoilersDescription": "模糊未观看剧集的缩略图并隐藏其描述",
     "playerBackend": "播放器引擎",

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -54,6 +54,7 @@ class SettingsProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   bool get alwaysKeepSidebarOpen => _read(SettingsService.alwaysKeepSidebarOpen, false);
   bool get showUnwatchedCount => _read(SettingsService.showUnwatchedCount, true);
   bool get showEpisodeNumberOnCards => _read(SettingsService.showEpisodeNumberOnCards, true);
+  bool get showSeasonPostersOnTabs => _read(SettingsService.showSeasonPostersOnTabs, false);
   bool get hideSpoilers => _read(SettingsService.hideSpoilers, false);
   bool get showNavBarLabels => _read(SettingsService.showNavBarLabels, true);
   bool get liveTvDefaultFavorites => _read(SettingsService.liveTvDefaultFavorites, false);
@@ -72,6 +73,7 @@ class SettingsProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   Future<void> setAlwaysKeepSidebarOpen(bool value) => _set(SettingsService.alwaysKeepSidebarOpen, value);
   Future<void> setShowUnwatchedCount(bool value) => _set(SettingsService.showUnwatchedCount, value);
   Future<void> setShowEpisodeNumberOnCards(bool value) => _set(SettingsService.showEpisodeNumberOnCards, value);
+  Future<void> setShowSeasonPostersOnTabs(bool value) => _set(SettingsService.showSeasonPostersOnTabs, value);
   Future<void> setHideSpoilers(bool value) => _set(SettingsService.hideSpoilers, value);
   Future<void> setShowNavBarLabels(bool value) => _set(SettingsService.showNavBarLabels, value);
   Future<void> setLiveTvDefaultFavorites(bool value) => _set(SettingsService.liveTvDefaultFavorites, value);

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -1786,6 +1786,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
   /// Build inline season tab chips with LEFT/RIGHT/DOWN focus navigation
   Widget _buildSeasonTabs() {
+    final showPosters = context.select<SettingsProvider, bool>((p) => p.showSeasonPostersOnTabs);
     return HorizontalScrollWithArrows(
       controller: _seasonTabsScrollController,
       builder: (scrollController) => SingleChildScrollView(
@@ -1798,7 +1799,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
             Offset? tapPosition;
             final posterPath = season.thumb;
             Widget? topImage;
-            if (posterPath != null && posterPath.isNotEmpty) {
+            if (showPosters && posterPath != null && posterPath.isNotEmpty) {
               const posterWidth = 72.0;
               const posterHeight = 108.0;
               final dpr = PlexImageHelper.effectiveDevicePixelRatio(context);

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -1796,6 +1796,39 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
             final season = _seasons[index];
             final contextMenuKey = _seasonContextMenuKeys.putIfAbsent(index, () => GlobalKey<MediaContextMenuState>());
             Offset? tapPosition;
+            final posterPath = season.thumb;
+            Widget? topImage;
+            if (posterPath != null && posterPath.isNotEmpty) {
+              const posterWidth = 72.0;
+              const posterHeight = 108.0;
+              final dpr = PlexImageHelper.effectiveDevicePixelRatio(context);
+              final client = _getClientForMetadata(context);
+              final imageUrl = PlexImageHelper.getOptimizedImageUrl(
+                client: client,
+                thumbPath: posterPath,
+                maxWidth: posterWidth,
+                maxHeight: posterHeight,
+                devicePixelRatio: dpr,
+                imageType: ImageType.poster,
+              );
+              final (memWidth, _) = PlexImageHelper.getMemCacheDimensions(
+                displayWidth: (posterWidth * dpr).round(),
+                displayHeight: (posterHeight * dpr).round(),
+                imageType: ImageType.poster,
+              );
+              topImage = SizedBox(
+                width: posterWidth,
+                height: posterHeight,
+                child: CachedNetworkImage(
+                  imageUrl: imageUrl,
+                  cacheManager: PlexImageCacheManager.instance,
+                  fit: BoxFit.cover,
+                  memCacheWidth: memWidth,
+                  placeholder: (context, url) => const PlaceholderContainer(),
+                  errorWidget: (context, url, error) => const PlaceholderContainer(),
+                ),
+              );
+            }
             return Padding(
               padding: const EdgeInsets.only(right: 8),
               child: MediaContextMenu(
@@ -1819,6 +1852,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                   child: FocusableTabChip(
                     label: season.title!,
                     isSelected: index == _selectedSeasonIndex,
+                    topImage: topImage,
                     focusNode: _seasonTabFocusNodes.length > index ? _seasonTabFocusNodes[index] : null,
                     onSelect: () {
                       if (index == _selectedSeasonIndex) return;

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -62,6 +62,7 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
             _buildViewModeSelector(),
             _buildEpisodePosterModeSelector(),
             _buildShowEpisodeNumberOnCards(),
+            _buildShowSeasonPostersOnTabs(),
 
             // --- Home Screen ---
             SettingsSectionHeader(t.settings.homeScreen),
@@ -218,6 +219,14 @@ class _AppearanceSettingsScreenState extends State<AppearanceSettingsScreen> {
     subtitle: t.settings.showEpisodeNumberOnCardsDescription,
     getter: (p) => p.showEpisodeNumberOnCards,
     setter: (p, v) => p.setShowEpisodeNumberOnCards(v),
+  );
+
+  Widget _buildShowSeasonPostersOnTabs() => _buildBoolToggle(
+    icon: Symbols.image_rounded,
+    title: t.settings.showSeasonPostersOnTabs,
+    subtitle: t.settings.showSeasonPostersOnTabsDescription,
+    getter: (p) => p.showSeasonPostersOnTabs,
+    setter: (p, v) => p.setShowSeasonPostersOnTabs(v),
   );
 
   /// Shared scaffolding for the bool toggles on this screen. Each toggle

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -312,6 +312,7 @@ class SettingsService extends BaseSharedPreferencesService {
   static const alwaysKeepSidebarOpen = BoolPref('always_keep_sidebar_open');
   static const showUnwatchedCount = BoolPref('show_unwatched_count', defaultValue: true);
   static const showEpisodeNumberOnCards = BoolPref('show_episode_number_on_cards', defaultValue: true);
+  static const showSeasonPostersOnTabs = BoolPref('show_season_posters_on_tabs');
   static const hideSpoilers = BoolPref('hide_spoilers');
   static const showNavBarLabels = BoolPref('show_nav_bar_labels', defaultValue: true);
   static const globalShaderPreset = StringPref('global_shader_preset', defaultValue: 'none');
@@ -678,6 +679,7 @@ class SettingsService extends BaseSharedPreferencesService {
     alwaysKeepSidebarOpen.key,
     showUnwatchedCount.key,
     showEpisodeNumberOnCards.key,
+    showSeasonPostersOnTabs.key,
     hideSpoilers.key,
     showNavBarLabels.key,
     globalShaderPreset.key,

--- a/lib/widgets/focusable_tab_chip.dart
+++ b/lib/widgets/focusable_tab_chip.dart
@@ -36,6 +36,10 @@ class FocusableTabChip extends StatefulWidget {
   /// Called when SELECT key is held (D-pad long press).
   final VoidCallback? onLongPress;
 
+  /// Optional image to show above the label (e.g. a poster).
+  /// When provided, the chip lays out vertically with image on top, label below.
+  final Widget? topImage;
+
   const FocusableTabChip({
     super.key,
     required this.label,
@@ -47,6 +51,7 @@ class FocusableTabChip extends StatefulWidget {
     this.onNavigateDown,
     this.onBack,
     this.onLongPress,
+    this.topImage,
   });
 
   @override
@@ -123,20 +128,38 @@ class _FocusableTabChipState extends State<FocusableTabChip> with FocusableChipS
 
     final isHighlighted = showFocus || widget.isSelected;
 
+    final label = Text(
+      widget.label,
+      style: Theme.of(context).textTheme.labelLarge?.copyWith(
+        color: foregroundColor,
+        fontWeight: isHighlighted ? FontWeight.w600 : FontWeight.normal,
+      ),
+    );
+
+    final hasImage = widget.topImage != null;
     return FocusBuilders.buildFocusableChip(
       context: context,
       focusNode: focusNode,
       onKeyEvent: _handleKeyEvent,
       onTap: widget.onSelect,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: hasImage
+          ? const EdgeInsets.all(8)
+          : const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       backgroundColor: backgroundColor,
-      child: Text(
-        widget.label,
-        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-          color: foregroundColor,
-          fontWeight: isHighlighted ? FontWeight.w600 : FontWeight.normal,
-        ),
-      ),
+      borderRadius: hasImage ? 12 : 20,
+      child: hasImage
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(6),
+                  child: widget.topImage!,
+                ),
+                const SizedBox(height: 6),
+                label,
+              ],
+            )
+          : label,
     );
   }
 }


### PR DESCRIPTION
I really like the tab-style navigation for seasons and how you get a flat list of episodes by default, but I was lamenting that I don't really see season posters anymore, so I was trying to find a way to integrate them without taking up too much vertical real estate. Notably, this change does not affect navigation or anything like that. If this is to much and/or you don't like it, no worries, at all. Just an idea. 😊

https://github.com/user-attachments/assets/70e0f49b-6d1d-4b33-8c30-d591f472f273