### PR TITLE
fix(linux): persistent HTTP/1.1 connection pool to prevent parallel-request timeout

### DIFF
--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -214,13 +214,9 @@ class PlexClient with MediaServerCacheMixin implements MediaServerClient {
       client._serverTranscoderCached = seedTranscoderVideoSupport;
     }
     await client._initMediaProviders();
-    // If the connection race didn't seed the capability, warm the cache in
-    // the background so the first playback doesn't pay the probe cost on its
-    // hot path.
-    if (seedTranscoderVideoSupport == null) {
-      unawaited(client.serverSupportsVideoTranscoding());
-    }
-    // Don't fire background work if the caller already timed out
+    // If the connection race didn't seed the capability, or if the caller
+    // already timed out, warm the cache in the background so the first playback
+    // doesn't pay the probe cost on its hot path
     if (isCancelled?.call() != true && seedTranscoderVideoSupport == null) {
       unawaited(client.serverSupportsVideoTranscoding());
     }

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -173,6 +173,7 @@ class PlexClient {
     Future<void> Function(String newBaseUrl)? onEndpointChanged,
     VoidCallback? onAllEndpointsExhausted,
     bool? seedTranscoderVideoSupport,
+    bool Function()? isCancelled,
   }) async {
     final client = PlexClient._(
       config,
@@ -190,6 +191,10 @@ class PlexClient {
     // the background so the first playback doesn't pay the probe cost on its
     // hot path.
     if (seedTranscoderVideoSupport == null) {
+      unawaited(client.serverSupportsVideoTranscoding());
+    }
+    // Don't fire background work if the caller already timed out
+    if (isCancelled?.call() != true && seedTranscoderVideoSupport == null) {
       unawaited(client.serverSupportsVideoTranscoding());
     }
     return client;
@@ -308,7 +313,7 @@ class PlexClient {
   /// This discovers individually shared items that don't appear in /library/sections.
   Future<void> _initMediaProviders() async {
     try {
-      final response = await _getWithFailover('/media/providers');
+      final response = await _getWithFailover('/media/providers'); //.timeout(const Duration(seconds: 6));
       final container = _getMediaContainer(response);
       if (container == null) {
         _providerLibraries = [];

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -200,6 +200,7 @@ class PlexClient with MediaServerCacheMixin implements MediaServerClient {
     Future<void> Function(String newBaseUrl)? onEndpointChanged,
     VoidCallback? onAllEndpointsExhausted,
     bool? seedTranscoderVideoSupport,
+    bool Function()? isCancelled,
   }) async {
     final client = PlexClient._(
       config,
@@ -217,6 +218,10 @@ class PlexClient with MediaServerCacheMixin implements MediaServerClient {
     // the background so the first playback doesn't pay the probe cost on its
     // hot path.
     if (seedTranscoderVideoSupport == null) {
+      unawaited(client.serverSupportsVideoTranscoding());
+    }
+    // Don't fire background work if the caller already timed out
+    if (isCancelled?.call() != true && seedTranscoderVideoSupport == null) {
       unawaited(client.serverSupportsVideoTranscoding());
     }
     return client;

--- a/lib/utils/media_server_http_client.dart
+++ b/lib/utils/media_server_http_client.dart
@@ -184,7 +184,7 @@ class MediaServerHttpClient {
   /// Send a streamed request (for image cache etc).
   Future<http.StreamedResponse> sendStreamed(http.BaseRequest request) => _client.send(request);
 
-  void close() => _client.close();
+  void close() => platform.closePlexClient(_client);
 
   Future<MediaServerResponse> _send(
     String method,

--- a/lib/utils/platform_http_client_io.dart
+++ b/lib/utils/platform_http_client_io.dart
@@ -1,4 +1,4 @@
-import 'dart:io' show Platform;
+import 'dart:io' show Platform, HttpClient;
 
 import 'package:cronet_http/cronet_http.dart';
 import 'package:cupertino_http/cupertino_http.dart';
@@ -12,6 +12,14 @@ import 'app_logger.dart';
 CronetEngine? _sharedEngine;
 
 bool _loggedPlatformClient = false;
+
+HttpClient? _linuxSingleton;
+
+HttpClient _getLinuxSingleton() {
+  return _linuxSingleton ??= HttpClient()
+    ..maxConnectionsPerHost = 12
+    ..idleTimeout = const Duration(seconds: 90);
+}
 
 void _logPlatformClient(String platform, String client) {
   if (_loggedPlatformClient) return;
@@ -54,6 +62,22 @@ http.Client createPlatformClient() {
       return IOClient();
     }
   }
+  // Explicit Linux singleton — HTTP/2 unavailable on Linux (dart-lang/http#1385),
+  // so we hold a persistent pool to avoid repeated TLS handshakes.
+  if (Platform.isLinux) {
+    _logPlatformClient('linux', 'IOClient (singleton)');
+    return IOClient(_getLinuxSingleton());
+  }
+  // Unknown/future platform — plain disposable IOClient.
   _logPlatformClient(Platform.operatingSystem, 'IOClient');
   return IOClient();
 }
+
+/// No-op on Linux — singleton must never be destroyed.
+void closePlexClient(http.Client client) {
+  if (Platform.isLinux) return;
+  client.close();
+}
+
+/// Fresh throwaway client for probes and connection tests.
+http.Client createProbeClient() => IOClient();

--- a/lib/utils/platform_http_client_io.dart
+++ b/lib/utils/platform_http_client_io.dart
@@ -78,6 +78,3 @@ void closePlexClient(http.Client client) {
   if (Platform.isLinux) return;
   client.close();
 }
-
-/// Fresh throwaway client for probes and connection tests.
-http.Client createProbeClient() => IOClient();

--- a/lib/utils/platform_http_client_stub.dart
+++ b/lib/utils/platform_http_client_stub.dart
@@ -3,3 +3,7 @@ import 'package:http/http.dart' as http;
 /// Fallback stub — should never be called; actual implementation is selected
 /// via conditional imports in `plex_http_client.dart`.
 http.Client createPlatformClient() => throw UnsupportedError('No platform HTTP client available');
+
+void closePlexClient(http.Client client) => throw UnsupportedError('No platform HTTP client available');
+
+http.Client createProbeClient() => throw UnsupportedError('No platform HTTP client available');

--- a/lib/utils/platform_http_client_stub.dart
+++ b/lib/utils/platform_http_client_stub.dart
@@ -3,3 +3,7 @@ import 'package:http/http.dart' as http;
 /// Fallback stub — should never be called; actual implementation is selected
 /// via conditional imports in `media_server_http_client.dart`.
 http.Client createPlatformClient() => throw UnsupportedError('No platform HTTP client available');
+
+void closePlexClient(http.Client client) => throw UnsupportedError('No platform HTTP client available');
+
+http.Client createProbeClient() => throw UnsupportedError('No platform HTTP client available');

--- a/lib/utils/platform_http_client_stub.dart
+++ b/lib/utils/platform_http_client_stub.dart
@@ -4,4 +4,4 @@ import 'package:http/http.dart' as http;
 /// via conditional imports in `media_server_http_client.dart`.
 http.Client createPlatformClient() => throw UnsupportedError('No platform HTTP client available');
 
-void closePlexClient(http.Client client) => throw UnsupportedError('No platform HTTP client available');
+void closePlexClient(http.Client _) => throw UnsupportedError('No platform HTTP client available');

--- a/lib/utils/platform_http_client_stub.dart
+++ b/lib/utils/platform_http_client_stub.dart
@@ -5,5 +5,3 @@ import 'package:http/http.dart' as http;
 http.Client createPlatformClient() => throw UnsupportedError('No platform HTTP client available');
 
 void closePlexClient(http.Client client) => throw UnsupportedError('No platform HTTP client available');
-
-http.Client createProbeClient() => throw UnsupportedError('No platform HTTP client available');

--- a/lib/utils/plex_http_client.dart
+++ b/lib/utils/plex_http_client.dart
@@ -186,7 +186,7 @@ class PlexHttpClient {
   /// Send a streamed request (for image cache etc).
   Future<http.StreamedResponse> sendStreamed(http.BaseRequest request) => _client.send(request);
 
-  void close() => _client.close();
+  void close() => platform.closePlexClient(_client);
 
   // ---------------------------------------------------------------------------
   // Core send implementation


### PR DESCRIPTION
Problem: Linux lacks a native HTTP/2 client in the Dart ecosystem ([dart-lang/http#1385](https://github.com/dart-lang/http/issues/1385)). Every PlexHttpClient created a fresh IOClient, meaning each of the 10+ parallel home-screen requests (on-deck, hubs, metadata) opened a separate TCP+TLS handshake. Dart's default maxConnectionsPerHost = 6 caused trailing requests to queue past the 10s connect timeout, triggering spurious failover to unreachable LAN/plex.direct candidates.

Additionally, PlexHttpClient.close() called IOClient.close() which called HttpClient.close() internally - destroying all keep-alive connections and forcing cold handshakes on every reconnect.

Fix:

- Added a file-level HttpClient singleton for Linux with maxConnectionsPerHost = 12 and idleTimeout = 90s. createPlatformClient() wraps it so all PlexHttpClient instances share one pool.

- Added closePlexClient() - no-op on Linux, normal close() elsewhere. PlexHttpClient.close() now delegates to this instead of calling _client.close() directly.

- ~~Added createProbeClient() - returns a fresh, disposable IOClient for connection testing that cannot accidentally close the singleton pool.~~

- Stub versions of all three functions added to platform_http_client_stub.dart for web compile compatibility.

Android/iOS/Windows behaviour is unchanged.

Also fixes #929 in my testing.