### PR TITLE
Fix media version label tests

### DIFF
--- a/lib/media/media_version.dart
+++ b/lib/media/media_version.dart
@@ -8,14 +8,12 @@ int? bitrateKbpsFromBps(int? bps) {
   return (bps / 1000).round();
 }
 
-final _videoResolution = RegExp(r'^(\d+)(k?)$', caseSensitive: false);
+final _numericVideoResolution = RegExp(r'^\d+$');
 
-/// Plex uses numeric heights for SD/HD and values like `4k`/`8k` for UHD+.
+/// Plex may return numeric heights (`1080`) or named resolution labels (`sd`, `4k`).
 String _videoResolutionDisplayLabel(String resolution) {
   final value = resolution.trim();
-  final match = _videoResolution.firstMatch(value);
-  if (match == null) return value;
-  return match.group(2)!.isEmpty ? '${match.group(1)}p' : '${match.group(1)}K';
+  return _numericVideoResolution.hasMatch(value) ? '${value}p' : value.toUpperCase();
 }
 
 /// A single media variant available for an item — represents one quality level

--- a/test/models/plex_media_version_test.dart
+++ b/test/models/plex_media_version_test.dart
@@ -118,7 +118,7 @@ void main() {
       for (final resolution in ['8k', '8K']) {
         expect(displayLabel(resolution), startsWith('8K '));
       }
-      expect(displayLabel('sd'), startsWith('sd '));
+      expect(displayLabel('sd'), startsWith('SD '));
     });
   });
 }


### PR DESCRIPTION
Apologies, I was too hasty before. I saw the whitespace in the test but trusted Cursor more than I should've...

This should resolve the unit test error in CI, and make the fix itself more robust.

## Summary
- Fix the `MediaVersion.displayLabel` test expectation that failed after #952 merged.
- Uppercase non-numeric Plex resolution labels like `sd`, while preserving numeric labels like `1080p`.

## Testing
Verified locally with:
```sh
flutter test test/models/plex_media_version_test.dart
```