### PR TITLE
feat(desktop): improve snackbar presentation on desktop

### DIFF
--- a/lib/utils/snackbar_helper.dart
+++ b/lib/utils/snackbar_helper.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'layout_constants.dart';
+import 'platform_detector.dart';
 
 /// Global key for the root ScaffoldMessenger, allowing snackbars to survive navigation.
 final rootScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
@@ -12,20 +13,100 @@ final mainScaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 /// Types of snackbars available in the app
 enum SnackBarType { info, success, error }
 
+const double _kDesktopSnackBarWidth = 480.0;
+
+/// Builds a [SnackBar] with desktop-aware width and optional dismiss button.
+///
+/// [dismissible] : null = auto (shows X on desktop), true/false to override.
+SnackBar _buildSnackBar(
+  ScaffoldMessengerState messenger, {
+  required Widget content,
+  required Color? backgroundColor,
+  required Duration duration,
+  bool? dismissible,
+}) {
+  final isDesktop = PlatformDetector.isDesktopOS();
+  final showX = dismissible ?? isDesktop;
+
+  final body = showX
+      ? Row(
+          children: [
+            Expanded(child: content),
+            Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(
+                  onTap: messenger.hideCurrentSnackBar,
+                  borderRadius: BorderRadius.circular(16),
+                  splashColor: Colors.white30,
+                  hoverColor: Colors.white24,
+                  highlightColor: Colors.white38,
+                  child: const Padding(
+                    padding: EdgeInsets.all(4),
+                    child: Icon(Icons.close, size: 18, color: Colors.white70),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        )
+      : content;
+
+  return SnackBar(
+    content: body,
+    backgroundColor: backgroundColor,
+    duration: duration,
+    behavior: isDesktop ? SnackBarBehavior.floating : null,
+    width: isDesktop ? _kDesktopSnackBarWidth : null,
+  );
+}
+
+(Color?, Duration) _snackBarStyle(SnackBarType type) => switch (type) {
+      SnackBarType.info => (null, AppDurations.snackBarDefault),
+      SnackBarType.success => (Colors.green, AppDurations.snackBarDefault),
+      SnackBarType.error => (Colors.red, AppDurations.snackBarLong),
+    };
+
 /// Utility functions for showing snackbars throughout the application
 
-void showSnackBar(BuildContext context, String message, {SnackBarType type = SnackBarType.info, Duration? duration}) {
+void showSnackBar(
+  BuildContext context,
+  String message, {
+  SnackBarType type = SnackBarType.info,
+  Duration? duration,
+  bool? dismissible,
+}) {
   if (!context.mounted) return;
+  final (backgroundColor, defaultDuration) = _snackBarStyle(type);
+  final messenger = ScaffoldMessenger.of(context);
+  messenger.showSnackBar(_buildSnackBar(
+    messenger,
+    content: Text(message),
+    backgroundColor: backgroundColor,
+    duration: duration ?? defaultDuration,
+    dismissible: dismissible,
+  ));
+}
 
-  final (backgroundColor, defaultDuration) = switch (type) {
-    SnackBarType.info => (null, AppDurations.snackBarDefault),
-    SnackBarType.success => (Colors.green, AppDurations.snackBarDefault),
-    SnackBarType.error => (Colors.red, AppDurations.snackBarLong),
-  };
-
-  ScaffoldMessenger.of(context).showSnackBar(
-    SnackBar(content: Text(message), backgroundColor: backgroundColor, duration: duration ?? defaultDuration),
-  );
+/// Shows a snackbar with a custom widget as content.
+void showWidgetSnackBar(
+  BuildContext context,
+  Widget content, {
+  SnackBarType type = SnackBarType.info,
+  Duration? duration,
+  bool? dismissible,
+}) {
+  if (!context.mounted) return;
+  final (backgroundColor, defaultDuration) = _snackBarStyle(type);
+  final messenger = ScaffoldMessenger.of(context);
+  messenger.showSnackBar(_buildSnackBar(
+    messenger,
+    content: content,
+    backgroundColor: backgroundColor,
+    duration: duration ?? defaultDuration,
+    dismissible: dismissible,
+  ));
 }
 
 void showAppSnackBar(BuildContext context, String message, {Duration? duration}) {
@@ -38,9 +119,14 @@ void showErrorSnackBar(BuildContext context, String message) {
 
 /// Shows an error snackbar using the root ScaffoldMessenger (survives navigation).
 void showGlobalErrorSnackBar(String message) {
-  rootScaffoldMessengerKey.currentState?.showSnackBar(
-    SnackBar(content: Text(message), backgroundColor: Colors.red, duration: AppDurations.snackBarLong),
-  );
+  final messenger = rootScaffoldMessengerKey.currentState;
+  if (messenger == null) return;
+  messenger.showSnackBar(_buildSnackBar(
+    messenger,
+    content: Text(message),
+    backgroundColor: Colors.red,
+    duration: AppDurations.snackBarLong,
+  ));
 }
 
 /// Shows an info snackbar through the main-screen messenger when available
@@ -48,9 +134,15 @@ void showGlobalErrorSnackBar(String message) {
 /// messenger when the main screen is not mounted.
 void showMainSnackBar(String message, {Duration duration = AppDurations.snackBarDefault}) {
   final messenger = mainScaffoldMessengerKey.currentState ?? rootScaffoldMessengerKey.currentState;
+  if (messenger == null) return;
   messenger
-    ?..removeCurrentSnackBar()
-    ..showSnackBar(SnackBar(content: Text(message), duration: duration));
+    ..removeCurrentSnackBar()
+    ..showSnackBar(_buildSnackBar(
+      messenger,
+      content: Text(message),
+      backgroundColor: null,
+      duration: duration,
+    ));
 }
 
 void showSuccessSnackBar(BuildContext context, String message) {


### PR DESCRIPTION
This PR slightly tweaks how snackbars work on desktop.
1. The width is fixed (full width snackbars look funny on desktop).
2. An `X` button is added which allows the user to manually close/dismiss the snackbar (since swiping it away is not intuitive on desktop).

For the demo video, I just manually showed a snackbar on each library navigation.

https://github.com/user-attachments/assets/7b639e13-d9b2-4710-a460-44e769626414