### PR TITLE
Respect episode/season grouping type when browsing library

### DIFF
--- a/lib/screens/libraries/tabs/library_browse_tab.dart
+++ b/lib/screens/libraries/tabs/library_browse_tab.dart
@@ -626,9 +626,10 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
   @override
   Future<LibraryPage<MediaItem>> fetchPage(int start, int size, AbortController? abort) async {
     final client = context.getMediaClientForLibrary(widget.library);
+    final filterParams = _buildFilterParams();
     final query = libraryQueryFromPlexMap(
-      map: _buildFilterParams(),
-      libraryKind: widget.library.kind,
+      map: filterParams,
+      libraryKind: filterParams.containsKey('type') ? null : widget.library.kind,
       offset: start,
       limit: size,
     );


### PR DESCRIPTION
I noticed that browsing a TV show library in episode grouping mode was showing shows instead, causing taps to open the show detail screen rather than playing the episode.

# Problem

When you switch a TV show library to episode grouping, the app was still fetching shows from Plex, so the grid looked identical to show mode, and tapping a card opened the show detail screen instead of playing the episode.

# Root cause

Introduced in d0bd919f. The browse tab builds a filter that tells Plex which content type to fetch based on the selected grouping. But a separate "library kind" hint (always set to "show" for TV libraries) was being applied at higher priority, overwriting the grouping's type before the request went out.

# Fix

Only use the library kind as a fallback when the grouping hasn't already specified a type. Should also benefit Jellyfin since it goes through the same code path.