### PR TITLE
feat(jellyfin): add Unwatched boolean filter to library browser

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,287 @@
+# Plezy Architecture
+
+This document is the long-form companion to `README.md` (user-facing) and `CONTRIBUTING.md` (workflow). It explains how the codebase is shaped and why — aimed at new contributors and anyone wading into an unfamiliar part of the app.
+
+For the lean, agent-facing rule sheet, see `CLAUDE.md`.
+
+## Project shape
+
+Plezy is a Flutter client for Plex and Jellyfin. One codebase ships to:
+
+- **Desktop** — Windows, macOS, Linux (native windows, mpv playback)
+- **Mobile** — iOS, Android (ExoPlayer on Android, mpv on iOS)
+- **TV** — Android TV / Fire TV (leanback), Apple TV (tvOS, via a custom engine fork — see [tvOS](#tvos))
+
+The Flutter SDK is pinned to **3.44.0** in CI (`.github/workflows/ci.yml`) and `tvos/engine.version` must track the same version. Dart constraint is `>=3.12.0 <4.0.0`.
+
+State management uses `provider` (not Riverpod). Persistence is split between `drift` (SQLite) for structured data and `SharedPreferences` (wrapped by a typed `SettingsService`) for user preferences.
+
+## Backend abstraction
+
+Plezy talks to two media backends with substantially different APIs, but the rest of the app sees only one shape. The key file is `lib/media/media_server_client.dart`:
+
+```
+       UI / providers / mixins
+                 │
+                 ▼
+       MediaServerClient    ← backend-neutral interface
+                ╱ ╲
+               ╱   ╲
+        PlexClient   JellyfinClient
+            │              │
+   plex/parts/*    jellyfin/parts/*    ← topic split as Dart `part of` files
+            │              │
+            ▼              ▼
+        Plex HTTP     Jellyfin HTTP
+```
+
+### Conventions on the interface
+
+- **Read methods are prefixed `fetch*`** (e.g. `fetchLibraries`, `fetchHubItems`). This makes "is this a read or a write?" obvious at call sites.
+- **Plex-only operations stay on `PlexClient`** under their original `get*` / verb names — DVR tuning, metadata edit, plex-match. Do not lift them onto `MediaServerClient`, even if you "could" stub them on the Jellyfin side. The interface is supposed to be backend-neutral.
+- **Write methods follow a strict error contract** (documented in the file header):
+  - HTTP 4xx/5xx → throw `MediaServerHttpException`
+  - Network/IO failure → throw the underlying exception
+  - "Not applicable to this backend" (e.g. wrong-backend item handed to a write) → return `false`, do not throw
+  - Success → return the created entity / `true`
+
+### Backend discriminator
+
+Two types serve slightly different roles:
+
+- `MediaBackend` (`lib/media/media_backend.dart`) — used on **neutral domain types** (a `MediaItem` carries its backend so consumers can branch).
+- `ConnectionKind` (`lib/connection/connection.dart`) — lighter-weight, used in **DB columns and auth-shape decisions**.
+
+Both serialize via an explicit `.id` string mapping. **Never use `.name`** — see [Persisted enum stability](#persisted-enum-stability) below.
+
+### Per-backend partitioning
+
+Each client is split across multiple files via Dart's `part of` mechanism, grouped by topic:
+
+- `lib/services/jellyfin_client/parts/` — `browse`, `collections`, `file_info`, `images_downloads`, `live_tv`, `playback`, `playlists`, `watch_state`
+- `lib/services/plex_client/parts/` — `live_tv` (most of `PlexClient` is still monolithic at the time of writing)
+
+When adding a new operation, place it with its topic neighbours rather than growing the root file.
+
+## Identity model: Connection → Profile → ProfileConnection
+
+This is the part of the app that tends to confuse newcomers, because the three concepts look similar on the surface but mean different things:
+
+```
+            Profile (LocalProfile or PlexHomeProfile)
+                │
+                │  owns 1..n via the profile_connections join
+                ▼
+        ProfileConnection ── carries the per-profile user-level TOKEN ──┐
+                │                                                       │
+                ▼                                                       │
+            Connection (PlexAccountConnection or JellyfinConnection) ◄──┘
+                │
+                ▼
+        Servers / users discovered via that auth unit
+```
+
+### Connection
+
+A `Connection` (`lib/connection/connection.dart`, sealed) is **one auth unit the user added**:
+
+- `PlexAccountConnection` — a single Plex account, plus the servers discovered through it, plus an optional active Plex Home user.
+- `JellyfinConnection` — a single Jellyfin server with a single user.
+
+Most users only ever have one Connection.
+
+### Profile
+
+A `Profile` (`lib/profiles/profile.dart`, sealed) is the **user-facing identity** in the app:
+
+- `LocalProfile` — a Plezy-only profile the user created. Optional 4-digit PIN, hashed client-side (`computePinHash`); the raw PIN is never persisted.
+- `PlexHomeProfile` — auto-surfaced from a connected Plex account's Home users. PIN protection here is **server-side via Plex** (`/home/users/{uuid}/switch`); the local `pinHash` field is unused.
+
+### ProfileConnection
+
+The join row between a Profile and a Connection. It carries the **per-profile user-level token** for talking to that connection. The crucial gotcha: a connection has *N* tokens in flight, one per profile that activates it. Code that wants to make a request must resolve the token via the **active profile's** join row, not via the connection alone.
+
+Orchestration of "which profile is active right now" lives in `lib/profiles/active_profile_binder.dart` and `active_profile_provider.dart`.
+
+## Persistence
+
+### Drift (SQLite)
+
+`lib/database/app_database.dart` and `tables.dart` define the schema. Tables:
+
+| Table | Purpose |
+|---|---|
+| `DownloadedMedia`, `DownloadOwners`, `DownloadQueue` | Offline downloads |
+| `ApiCache` | Persistent HTTP response cache |
+| `OfflineWatchProgress` | Watch-state actions queued while offline |
+| `SyncRules` | Auto-download rules |
+| `Connections`, `Profiles`, `ProfileConnections` | Identity model (see above) |
+
+### Persisted enum stability
+
+Enums that get written to SQLite columns or JSON **must** define an explicit `String get id` mapping plus a `fromId` reverse, and use those for serialization. Example from `OfflineActionType`:
+
+```dart
+String get id => switch (this) {
+  OfflineActionType.progress => 'progress',
+  OfflineActionType.watched => 'watched',
+  OfflineActionType.unwatched => 'unwatched',
+};
+```
+
+The reason is in the source comment: if you used `.name`, a future rename like `progress → inProgress` would silently corrupt every existing row in the database. The `.id` map decouples the on-disk identifier from the Dart symbol.
+
+This pattern is used throughout — `MediaBackend`, `ConnectionKind`, `OfflineActionType`, etc. Mirror it for any new persisted enum.
+
+### SharedPreferences (typed)
+
+`lib/services/settings_service.dart` exposes `Pref<T>` accessors (`BoolPref`, `IntPref`, `JsonPref`, `EnumPref`, etc.). Read with `settings.read(SettingsService.someKey)` and write with `settings.write(...)`. The base implementation in `base_shared_preferences_service.dart` handles the platform plumbing.
+
+### API caches
+
+In addition to the persistent `ApiCache` table, there are per-backend in-memory caches: `lib/services/plex_api_cache.dart` and `jellyfin_api_cache.dart`. These exist because the access patterns (and TTLs) for the two backends differ enough that one shared cache would be either overly broad or full of conditionals.
+
+### Credentials and logging
+
+Tokens live in `lib/services/credential_vault.dart`. The shared logger (`lib/utils/app_logger.dart`) redacts `Authorization` and `Password` patterns automatically — this is the safety net, not the primary defense. `avoid_print` is enforced, so all logging goes through `appLogger` by construction.
+
+## Code generation
+
+The project leans heavily on codegen:
+
+| Tool | Outputs | Used for |
+|---|---|---|
+| `freezed` | `*.freezed.dart` | Sealed unions, data classes with `copyWith` |
+| `json_serializable` | `*.g.dart` | DTOs (Plex/Jellyfin API shapes) |
+| `drift_dev` | `app_database.g.dart` | Generated DAO + table classes |
+| `slang` (+ `slang_build_runner`) | `lib/i18n/strings*.g.dart` | Type-safe i18n |
+
+`scripts/codegen.sh` chains `dart run slang` then `dart run build_runner build --delete-conflicting-outputs`. Note that `slang_build_runner` is **disabled** in `build.yaml` — `slang` is run as a separate step to keep build times predictable.
+
+`build.yaml` defaults worth knowing: `explicit_to_json: true`, `field_rename: none`, `include_if_null: true`. Don't override these per-file unless you have a real reason.
+
+### CI enforcement
+
+The CI analyze job runs `scripts/codegen.sh` and then fails if `git diff lib/` is non-empty. In other words: **generated files are committed**, and getting them out of sync is a build break, not a warning. `scripts/ci_checks.sh` does the same locally and is what the pre-commit hook calls.
+
+## Internationalization
+
+Source of truth: `lib/i18n/*.i18n.json`. `en.i18n.json` is the base locale.
+
+`slang.yaml` sets `fallback_strategy: base_locale`, which means a missing key in a non-base locale silently falls back to English. The pragmatic effect:
+
+- You can land a new English string without touching the other 14 locale files. Translations land later via the normal translation flow.
+- Without this setting, every locale would need every key declared up-front and codegen would fail with "class is missing implementations for…".
+
+After editing JSON, run `dart run slang` (or `scripts/codegen.sh`, which chains it). Use translations in code as `t.section.key`.
+
+## Playback
+
+`lib/mpv/` wraps libmpv (`player_native.dart` + per-platform parts under `mpv/player/platform/`). Android falls back to ExoPlayer paths inside the same player abstraction.
+
+User-visible playback features that have non-trivial code paths:
+
+- **Subtitles** — full ASS/SSA via libass, with style overrides controlled by `SubAssOverride` (no / yes / scale / force / strip).
+- **Shaders** — GLSL presets under `assets/shaders/{nvscaler,artcnn,anime4k}/`, loaded by `lib/services/shader_service.dart`. Not available on iOS/tvOS.
+- **HDR / Dolby Vision** — `DvConversionModePreference` selects auto / disabled / DV 8.1 / HEVC-strip. Not available on Linux.
+- **Picture-in-Picture** — Android (`PipService`), iOS/macOS via OS hooks.
+- **Refresh-rate matching** — `DisplayModeService`, Windows/Android/tvOS only.
+
+The `MediaServerClient` provides playback-init data (URLs, transcode params, subtitle/audio streams) via `playback_initialization_types.dart`; the player consumes those and reports back through `PlaybackProgressTracker` and `PlaybackReportSession`.
+
+## Focus / TV input
+
+`lib/focus/` is a sizeable subsystem because Plezy targets D-pad, keyboard, gamepad, and Siri Remote inputs — all funnelled into Flutter's focus tree.
+
+Key files:
+
+- `dpad_navigator.dart` — directional focus traversal
+- `input_mode_tracker.dart` — knows whether the user is currently in pointer or focus-driven mode (affects hover / highlight)
+- `focusable_*.dart` — wrappers for `Button`, `Slider`, `TextField`, etc., that integrate with the navigator
+- `focus_memory_tracker.dart` — restores focus position when returning to a screen
+- `key_event_utils.dart`, `key_repeat_helper.dart`, `key_event_simulator.dart`
+
+Many widgets in `lib/widgets/` have `focusable_*` variants (`focusable_list_tile`, `focusable_media_card`, `focusable_popup_menu_button`, etc.). On code paths reachable from TV, prefer the focusable variant over the raw Material widget; otherwise the focus tree will skip the widget and D-pad navigation will feel broken.
+
+Tab-aware focus memory (e.g. library tabs remembering which item was focused when you come back) is covered by mixins in `lib/mixins/`: `library_tab_focus_mixin`, `library_tab_state`, `tab_navigation_mixin`, `tab_visibility_aware`.
+
+## tvOS
+
+Upstream Flutter does not target tvOS. Plezy ships to Apple TV by using a **custom prebuilt engine** from [edde746/flutter-tvos](https://github.com/edde746/flutter-tvos), pinned to the same version as the main Flutter SDK (`tvos/engine.version`, currently `3.44.0`).
+
+This is *not* a widely-used community Flutter distribution — it's effectively a project-specific fork (`edde746` is the upstream Plezy author). Practically that means: if it stops being maintained or falls behind a Flutter SDK version, the tvOS target is on its own.
+
+### What the port required
+
+The Dart side did not need a rewrite — the app was already TV-aware for Android TV (focus subsystem, layouts, D-pad). The tvOS-specific Dart additions are small:
+
+- `lib/services/apple_tv_remote_touch_service.dart` — bridges Siri Remote touch-surface gestures (`flutter/gamepadtouchevent` channel) into focus-tree key events
+- A compile-time `TVOS_BUILD` flag (read in `TvDetectionService`)
+- An `_AppleTvScale` overscan-correction wrapper in `main.dart`
+- A handful of `Platform.isIOS` branches that also check the tvOS flag (because `Platform.isIOS` is true on tvOS — see [Gotcha](#gotcha-platformisios-on-tvos))
+
+The build system, on the other hand, is **entirely hand-rolled** under `tvos/` — Flutter's tool emits nothing for tvOS:
+
+- **~1,000 lines of build scripts** under `tvos/scripts/`. The big ones: `xcode_appletv.sh` (454 lines, orchestrates the whole build), `fetch_engine.sh` (downloads the prebuilt engine), `wire_plugins.rb` and `wire_mpv.rb` (patch the Xcode project), `copy_assets.sh` and `copy_framework.sh` (reuse iOS build output), `switch_target.sh` and `set_tvos_target_*.sh` (retarget pods/runner between iOS and appletvos).
+- **Hand-written `tvos/Podfile`**. Only a small whitelist of plugins is podded normally (`universal_gamepad`, `os_media_controls`, `wakelock_plus` — i.e. the ones whose upstream podspecs already declare tvOS). The rest are **vendored as source copies** under `tvos/Runner/Plugins/`: currently `connectivity_plus`, `device_info_plus`, `package_info_plus`, `path_provider`, `shared_preferences_foundation`. Updating one of these means re-vendoring.
+- **Manual plugin registration in two places**:
+  - `tvos/Runner/AppDelegate.swift` — Swift `register(with:)` calls for each plugin
+  - `_registerTvosPlatformPlugins()` in `lib/main.dart` — Dart-side `registerWith()` calls for plugins that have a Dart-side platform store (currently `SharedPreferencesFoundation`)
+  When adding a tvOS-used plugin, wire it in **both** places.
+- **iOS-first asset reuse** — `tvos/scripts/copy_assets.sh` copies the `flutter_assets` folder produced by the iOS build into the tvOS bundle. Consequence: **iOS must be built first** or the tvOS build has nothing to ship.
+
+The engine itself is fetched by `tvos/scripts/fetch_engine.sh` and cached at `~/.cache/flutter-tvos-engine` by default. Override with `FLUTTER_TVOS_ENGINE_CACHE` (cache location) and `FLUTTER_TVOS_RELEASES_URL` (release source) if you maintain a private mirror.
+
+### Gotcha: `Platform.isIOS` on tvOS
+
+`dart:io`'s `Platform.isIOS` returns `true` on tvOS. Always branch on `TvDetectionService.isAppleTVSync()` or `PlatformDetector.isAppleTV()` for tvOS-specific behaviour. The `TVOS_BUILD` compile-time flag is the source of truth at app start; runtime device-info detection covers cases where the flag isn't set.
+
+## Auxiliary projects
+
+Three trees in the repo are *not* part of the Flutter build:
+
+- `server/` — Go WebSocket relay for Watch Together. Built and tested with the usual Go toolchain (`go build`, `go test ./...`). Deployed via `docker-compose.yml` + `Dockerfile`.
+- `website/` — SvelteKit static site for plezy.app, built with Bun (`bun install`, `bun run dev`, `bun run check`, `bun run build`). Output goes to `build/` (git-ignored).
+- `shared/` — Native C++ shared between iOS/macOS/tvOS targets (currently `MpvPlayer`).
+
+Don't run `flutter` commands inside any of these.
+
+## Conventions and tooling
+
+### Static analysis
+
+`analysis_options.yaml` extends `package:flutter_lints/flutter.yaml` and adds:
+
+- **Required**: `unawaited_futures`, `cancel_subscriptions`, `close_sinks`, `use_super_parameters`, `prefer_final_locals`, `prefer_final_in_for_each`, `avoid_print`
+- **`dart_code_linter`** with the recommended preset plus Flutter-specific extras (`avoid-border-all`, `avoid-shrink-wrap-in-lists`, `prefer-const-border-radius`, `use-setstate-synchronously`, etc.)
+- `// ignore:` and `// ignore_for_file:` must include a reason (`prefer-commenting-analyzer-ignores`)
+
+### Formatting
+
+- Dart: `dart format .`, **`page_width: 120`** (set in `analysis_options.yaml`). CI's format check excludes `.g.dart` and `.freezed.dart`.
+- Kotlin / Swift / C++ / Obj-C / native headers: `scripts/format_native.sh --check` (CI) or `--fix` (local). Uses ktlint (auto-downloaded), clang-format, and swift-format.
+
+### Pre-commit
+
+`scripts/setup_hooks.sh` points `core.hooksPath` at `.githooks/`. The hook runs `scripts/ci_checks.sh`, which is byte-for-byte the same pipeline as the CI analyze job (format, codegen freshness, native format, analyze, unused code, unused files).
+
+Bypass with `SKIP_HOOKS=1 git commit ...` only when you have a real reason — merges and reverts are auto-skipped by the hook.
+
+## Bootstrap and lifecycle
+
+`lib/main.dart` is intentionally a single long file (~1,400 lines). It walks through:
+
+1. Pre-binding setup (zero-offset pointer guard for iPadOS 26.1 modal bug, manual tvOS plugin registration)
+2. Sentry init (gated by `--dart-define=ENABLE_SENTRY=true`)
+3. `_bootstrapApp()`:
+   - Settings + locale + date formatting
+   - One-shot legacy cleanups (e.g. old `plexImageCache` directory)
+   - Image cache sizing (different budgets desktop vs. mobile)
+   - Platform-specific window/services init (window_manager, PiP, native fullscreen hooks)
+   - Logger configuration
+   - Download storage initialization
+   - Gamepad service start
+   - Provider tree assembly
+   - App run
+
+All top-level providers and service singletons are wired in `_bootstrapApp()`. When adding a new global service, that's where it goes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+See `ARCHITECTURE.md` for the human-readable deep dive.
+
+## Stack
+
+Flutter app for Plex/Jellyfin. Desktop + mobile + TV (incl. tvOS via a custom engine fork).
+
+- Flutter SDK: **3.44.0** (pinned in CI and `tvos/engine.version`)
+- Dart: `>=3.12.0 <4.0.0`
+- State: `provider` (not Riverpod)
+- DB: `drift` (SQLite)
+- Codegen: `freezed`, `json_serializable`, `drift_dev`, `slang`
+- Playback: `mpv` everywhere except Android (ExoPlayer)
+
+## Commands
+
+```bash
+flutter pub get
+scripts/codegen.sh                    # slang + build_runner (delete-conflicting-outputs)
+flutter run
+flutter test                          # all
+flutter test test/path/foo_test.dart  # one file
+flutter analyze
+dart format .                         # page_width 120; ignores .g.dart / .freezed.dart
+scripts/format_native.sh --check      # add --fix to apply
+scripts/ci_checks.sh                  # full pre-commit pipeline (= CI analyze job)
+scripts/setup_hooks.sh                # install pre-commit
+```
+
+## Hard rules
+
+- **Run `scripts/codegen.sh` after touching anything generated and commit the result.** CI runs codegen and fails if `git diff lib/` is non-empty.
+- **Analyzer warnings fail CI** (not just errors). So do `dart_code_linter` `check-unused-code` and `check-unused-files` hits on `lib/`.
+- **Never use `enum.name` for persisted enum values.** Tables and JSON use an explicit `.id` string mapping (e.g. `OfflineActionType.id` in `lib/database/app_database.dart`); renaming an enum value would corrupt every row.
+- **Plex-only operations live on `PlexClient` directly, not on `MediaServerClient`.** The interface is backend-neutral; do not pollute it with backend-specific calls. Read methods use `fetch*` prefix; write methods follow the error contract in `lib/media/media_server_client.dart`.
+- **Plugin registration for tvOS is manual in both** `tvos/Runner/AppDelegate.swift` and `_registerTvosPlatformPlugins()` in `lib/main.dart`. Wire any new tvOS-used plugin in both places.
+- **`Platform.isIOS` is true on tvOS too.** Branch on `TvDetectionService` / `PlatformDetector.isAppleTV()`, not `Platform`.
+- **iOS must be built before tvOS** — `tvos/scripts/copy_assets.sh` reuses `flutter_assets` from the iOS build.
+- **Tokens are sensitive.** Use `appLogger` (`lib/utils/app_logger.dart`); it redacts `Authorization`/`Password`. `avoid_print` is enforced.
+- Pre-commit bypass: `SKIP_HOOKS=1 git commit ...` (auto-skipped during merge/revert).
+
+## Code map
+
+- `lib/media/media_server_client.dart` — backend-neutral interface (Plex/Jellyfin)
+- `lib/services/plex_client.dart`, `lib/services/jellyfin_client.dart` (+ `*_client/parts/*` as Dart `part of` files)
+- `lib/connection/connection.dart` — sealed `Connection` (Plex account / Jellyfin server)
+- `lib/profiles/profile.dart` — sealed `Profile` (LocalProfile / PlexHomeProfile); 1..n connections via `profile_connections` join, **per-profile token per connection**
+- `lib/database/app_database.dart`, `tables.dart` — drift
+- `lib/services/settings_service.dart` — typed `Pref<T>` over SharedPreferences
+- `lib/services/credential_vault.dart` — token storage
+- `lib/mpv/` — libmpv wrapper (Android uses ExoPlayer paths)
+- `lib/focus/` — D-pad / keyboard / gamepad focus; many `widgets/focusable_*` variants
+- `lib/i18n/` — slang JSON; `en.i18n.json` is base; `fallback_strategy: base_locale`
+- `lib/utils/platform_detector.dart` — `TvDetectionService`, `PlatformDetector`
+
+## Generated/derived files
+
+- `*.g.dart` (json_serializable, drift), `*.freezed.dart` (freezed) — produced by `scripts/codegen.sh`, **committed**
+- `lib/i18n/strings*.g.dart` — produced by `dart run slang` (chained in `scripts/codegen.sh`); `slang_build_runner` is disabled in `build.yaml`
+
+## Auxiliary trees (separate toolchains)
+
+- `server/` — Go WebSocket relay for Watch Together; `go test ./...`, `docker-compose.yml`
+- `website/` — SvelteKit (Bun): `bun install`, `bun run dev|check|build`
+- `shared/` — Apple/native C++ shared by iOS/macOS/tvOS
+- `tvos/` — see `ARCHITECTURE.md#tvos`
+
+Do not run `flutter` commands inside these.
+
+## Conventions
+
+- Analyzer extras: `unawaited_futures`, `cancel_subscriptions`, `close_sinks`, `prefer_final_locals`, `avoid_print`
+- `// ignore:` requires a reason (`prefer-commenting-analyzer-ignores`)
+- `build.yaml`: `explicit_to_json: true`, `field_rename: none`, `include_if_null: true`
+- Top-level providers + service singletons are wired in `_bootstrapApp()` in `lib/main.dart`

--- a/ios/Runner/MpvPlayer/MpvPlayerCore.swift
+++ b/ios/Runner/MpvPlayer/MpvPlayerCore.swift
@@ -622,8 +622,11 @@ class MpvPlayerCore: MpvPlayerCoreBase {
         return
       }
 
-      setProperty("vid", value: "auto")
-      restoreVideoPresentation()
+      // Restore after the async vid=auto command is acknowledged by MPV so that
+      // recoverDisplayLayerIfNeeded and forceDraw run with video actually enabled.
+      setPropertyAsync("vid", value: "auto") { [weak self] _ in
+        self?.restoreVideoPresentation()
+      }
     }
   #endif
 }

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -705,7 +705,8 @@
       "genre": "Genre",
       "year": "Year",
       "contentRating": "Content Rating",
-      "tag": "Tag"
+      "tag": "Tag",
+      "unwatched": "Unwatched"
     },
     "sortLabels": {
       "title": "Title",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 15
-/// Strings: 17565 (1171 per locale)
+/// Strings: 17566 (1171 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -3775,6 +3775,9 @@ class TranslationsLibrariesFilterCategoriesEn {
 
 	/// en: 'Tag'
 	String get tag => 'Tag';
+
+	/// en: 'Unwatched'
+	String get unwatched => 'Unwatched';
 }
 
 // Path: libraries.sortLabels
@@ -4801,6 +4804,7 @@ extension on Translations {
 			'libraries.filterCategories.year' => 'Year',
 			'libraries.filterCategories.contentRating' => 'Content Rating',
 			'libraries.filterCategories.tag' => 'Tag',
+			'libraries.filterCategories.unwatched' => 'Unwatched',
 			'libraries.sortLabels.title' => 'Title',
 			'libraries.sortLabels.dateAdded' => 'Date Added',
 			'libraries.sortLabels.releaseDate' => 'Release Date',
@@ -5173,9 +5177,9 @@ extension on Translations {
 			'metadataEdit.summary' => 'Summary',
 			'metadataEdit.poster' => 'Poster',
 			'metadataEdit.background' => 'Background',
-			'metadataEdit.logo' => 'Logo',
 			_ => null,
 		} ?? switch (path) {
+			'metadataEdit.logo' => 'Logo',
 			'metadataEdit.squareArt' => 'Square Art',
 			'metadataEdit.selectPoster' => 'Select Poster',
 			'metadataEdit.selectBackground' => 'Select Background',

--- a/lib/media/media_server_client.dart
+++ b/lib/media/media_server_client.dart
@@ -127,7 +127,9 @@ abstract class MediaServerClient {
   /// fetches values lazily per category); Jellyfin returns both in a single
   /// `/Items/Filters` call and pre-populates [LibraryFilterResult.cachedValues].
   /// Backends that have no filter listing return [LibraryFilterResult.empty].
-  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId);
+  /// [libraryType] lets backends gate kind-specific filters (e.g. Jellyfin's
+  /// `unwatched` toggle only makes sense for movie/show libraries).
+  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId, {String? libraryType});
 
   /// Backend-aware sort options for [libraryId]. Plex hits
   /// `/library/sections/{id}/sorts`; Jellyfin returns a hardcoded list

--- a/lib/screens/libraries/library_filter_sort_loader.dart
+++ b/lib/screens/libraries/library_filter_sort_loader.dart
@@ -33,7 +33,7 @@ class LibraryFilterSortLoader {
   Future<LoadedFiltersAndSorts> load(MediaLibrary library) async {
     final client = clientFor(library);
     final results = await Future.wait([
-      client.fetchLibraryFiltersWithValues(library.id),
+      client.fetchLibraryFiltersWithValues(library.id, libraryType: library.kind.id),
       client.fetchSortOptions(library.id, libraryType: library.kind.id),
     ]);
     final filterResult = results[0] as LibraryFilterResult;

--- a/lib/screens/libraries/tabs/library_browse_tab.dart
+++ b/lib/screens/libraries/tabs/library_browse_tab.dart
@@ -536,7 +536,7 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
     final client = context.getMediaClientForLibrary(widget.library);
     unawaited(
       client
-          .fetchLibraryFiltersWithValues(widget.library.id)
+          .fetchLibraryFiltersWithValues(widget.library.id, libraryType: widget.library.kind.id)
           .then((result) {
             if (generation != _contentRequestId || !mounted) return;
             setState(() {

--- a/lib/services/jellyfin_client/parts/browse.dart
+++ b/lib/services/jellyfin_client/parts/browse.dart
@@ -173,6 +173,15 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
       }
       values[key] = sorted.map((v) => MediaFilterValue(key: v, title: v)).toList();
     }
+    filters.add(
+      MediaFilter(
+        filter: 'unwatched',
+        filterType: 'boolean',
+        key: 'jellyfin:unwatched',
+        title: t.libraries.filterCategories.unwatched,
+        type: 'filter',
+      ),
+    );
     return LibraryFilterResult(filters: filters, cachedValues: values);
   }
 

--- a/lib/services/jellyfin_client/parts/browse.dart
+++ b/lib/services/jellyfin_client/parts/browse.dart
@@ -133,7 +133,7 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
   /// `MediaFilter.key` is prefixed `jellyfin:` so FiltersBottomSheet can
   /// recognise it as cached and skip the per-category value fetch.
   @override
-  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId) async {
+  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId, {String? libraryType}) async {
     final data = await _safeFetchFilterPayload(libraryId);
     if (data == null) return LibraryFilterResult.empty;
     List<String> stringList(Object? raw) {
@@ -173,15 +173,17 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
       }
       values[key] = sorted.map((v) => MediaFilterValue(key: v, title: v)).toList();
     }
-    filters.add(
-      MediaFilter(
-        filter: 'unwatched',
-        filterType: 'boolean',
-        key: 'jellyfin:unwatched',
-        title: t.libraries.filterCategories.unwatched,
-        type: 'filter',
-      ),
-    );
+    if (libraryType == 'movie' || libraryType == 'show') {
+      filters.add(
+        MediaFilter(
+          filter: 'unwatched',
+          filterType: 'boolean',
+          key: 'jellyfin:unwatched',
+          title: t.libraries.filterCategories.unwatched,
+          type: 'filter',
+        ),
+      );
+    }
     return LibraryFilterResult(filters: filters, cachedValues: values);
   }
 

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -3413,7 +3413,7 @@ class PlexClient
   /// when the user opens a filter. The result has empty [LibraryFilterResult.cachedValues];
   /// the FiltersBottomSheet hits the per-category endpoint on demand.
   @override
-  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId) async {
+  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId, {String? libraryType}) async {
     final filters = await getLibraryFilters(libraryId);
     return LibraryFilterResult(filters: filters, cachedValues: const {});
   }

--- a/lib/widgets/video_controls/parts/markers.dart
+++ b/lib/widgets/video_controls/parts/markers.dart
@@ -137,6 +137,12 @@ extension _PlexVideoControlsMarkerMethods on _PlexVideoControlsState {
         _skipButtonDismissed = true;
       });
       _cancelAutoSkipTimer();
+      // Mirror _updateCurrentMarker(null): the skip button may have held primary
+      // focus on TV while controls were hidden. Hand focus back to _focusNode so
+      // its onKeyEvent stays live for the next d-pad press.
+      if (PlatformDetector.isTV() && _skipMarkerFocusNode.hasPrimaryFocus && !_showControls) {
+        _focusNode.requestFocus();
+      }
     });
   }
 

--- a/lib/widgets/video_controls/parts/markers.dart
+++ b/lib/widgets/video_controls/parts/markers.dart
@@ -31,6 +31,12 @@ extension _PlexVideoControlsMarkerMethods on _PlexVideoControlsState {
     if (foundMarker == null) {
       _cancelAutoSkipTimer();
       _cancelSkipButtonDismissTimer();
+      // On TV the skip button may have held primary focus while controls were
+      // hidden (see _hideControls). Hand focus back to _focusNode so its
+      // onKeyEvent stays live for the next d-pad press.
+      if (PlatformDetector.isTV() && _skipMarkerFocusNode.hasPrimaryFocus && !_showControls) {
+        _focusNode.requestFocus();
+      }
       return;
     }
 

--- a/lib/widgets/video_controls/parts/visibility.dart
+++ b/lib/widgets/video_controls/parts/visibility.dart
@@ -70,11 +70,13 @@ extension _PlexVideoControlsVisibilityMethods on _PlexVideoControlsState {
   /// Shared hide logic: hides controls, notifies parent, updates traffic lights, restores focus.
   void _hideControls() {
     if (!mounted || !_showControls || _forceShowControls) return;
+    // On TV, keep the skip button visible after controls hide so center still skips.
+    // On other platforms, dismiss with controls (auto-skip off → also covered by the 7 s timer).
+    final keepSkipButton = _currentMarker != null && PlatformDetector.isTV();
     _setControlsState(() {
       _showControls = false;
       _isContentStripVisible = false;
-      // Dismiss skip button with controls — after this it only re-appears with controls
-      if (_currentMarker != null) {
+      if (_currentMarker != null && !keepSkipButton) {
         _skipButtonDismissed = true;
       }
     });
@@ -89,15 +91,17 @@ extension _PlexVideoControlsVisibilityMethods on _PlexVideoControlsState {
     // sheet navigation (e.g. the compact sync bar).
     final sheetOpen = OverlaySheetController.maybeOf(context)?.isOpen ?? false;
     if (!sheetOpen) {
-      // Always request primary focus on _focusNode — not just when hasFocus is
-      // false. hasFocus is true when a descendant (e.g. play/pause) has focus,
-      // but we need _focusNode itself to hold primary focus so its onKeyEvent
-      // fires for the next d-pad press (otherwise focus escapes to the screen-
-      // level self-heal handler which shows controls with play/pause focus).
-      _focusNode.requestFocus();
+      // On TV with an active skip marker, hand focus to the skip button so the
+      // center key skips without having to show controls first.
+      // Otherwise, always reclaim _focusNode primary focus so its onKeyEvent
+      // fires for the next d-pad press (prevents focus escaping to the
+      // screen-level self-heal handler which would show controls with
+      // play/pause focus instead).
+      final focusTarget = keepSkipButton ? _skipMarkerFocusNode : _focusNode;
+      focusTarget.requestFocus();
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && !_focusNode.hasPrimaryFocus) {
-          _focusNode.requestFocus();
+        if (mounted && !focusTarget.hasPrimaryFocus) {
+          focusTarget.requestFocus();
         }
       });
     }

--- a/lib/widgets/video_controls/parts/visibility.dart
+++ b/lib/widgets/video_controls/parts/visibility.dart
@@ -72,7 +72,9 @@ extension _PlexVideoControlsVisibilityMethods on _PlexVideoControlsState {
     if (!mounted || !_showControls || _forceShowControls) return;
     // On TV, keep the skip button visible after controls hide so center still skips.
     // On other platforms, dismiss with controls (auto-skip off → also covered by the 7 s timer).
-    final keepSkipButton = _currentMarker != null && PlatformDetector.isTV();
+    // Skip the keepSkipButton path if the button is already dismissed (the 7 s timer
+    // fired earlier with controls hidden) — otherwise we'd hand focus to an unmounted node.
+    final keepSkipButton = _currentMarker != null && !_skipButtonDismissed && PlatformDetector.isTV();
     _setControlsState(() {
       _showControls = false;
       _isContentStripVisible = false;

--- a/lib/widgets/video_controls/widgets/skip_marker_button.dart
+++ b/lib/widgets/video_controls/widgets/skip_marker_button.dart
@@ -3,11 +3,12 @@ import 'package:flutter/services.dart' show KeyDownEvent, LogicalKeyboardKey;
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../../focus/focusable_wrapper.dart';
+import '../../../focus/input_mode_tracker.dart';
 import '../../../media/media_source_info.dart';
 import '../../../theme/mono_tokens.dart';
 import '../../app_icon.dart';
 
-class SkipMarkerButton extends StatelessWidget {
+class SkipMarkerButton extends StatefulWidget {
   final MediaMarker marker;
   final Duration playerDuration;
   final bool hasNextEpisode;
@@ -36,11 +37,50 @@ class SkipMarkerButton extends StatelessWidget {
   });
 
   @override
+  State<SkipMarkerButton> createState() => _SkipMarkerButtonState();
+}
+
+class _SkipMarkerButtonState extends State<SkipMarkerButton> {
+  bool _isFocused = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isFocused = widget.focusNode.hasFocus;
+    widget.focusNode.addListener(_onFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(SkipMarkerButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focusNode != oldWidget.focusNode) {
+      oldWidget.focusNode.removeListener(_onFocusChanged);
+      _isFocused = widget.focusNode.hasFocus;
+      widget.focusNode.addListener(_onFocusChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.focusNode.removeListener(_onFocusChanged);
+    super.dispose();
+  }
+
+  void _onFocusChanged() {
+    final hasFocus = widget.focusNode.hasFocus;
+    if (hasFocus != _isFocused) {
+      setState(() => _isFocused = hasFocus);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final isCredits = marker.isCredits;
+    final isCredits = widget.marker.isCredits;
     final creditsAtEnd =
-        isCredits && playerDuration > Duration.zero && (playerDuration - marker.endTime).inMilliseconds <= 1000;
-    final showNextEpisode = creditsAtEnd && hasNextEpisode;
+        isCredits &&
+        widget.playerDuration > Duration.zero &&
+        (widget.playerDuration - widget.marker.endTime).inMilliseconds <= 1000;
+    final showNextEpisode = creditsAtEnd && widget.hasNextEpisode;
     String baseButtonText;
     if (showNextEpisode) {
       baseButtonText = 'Next Episode';
@@ -50,24 +90,33 @@ class SkipMarkerButton extends StatelessWidget {
       baseButtonText = 'Skip Intro';
     }
 
-    final remainingSeconds = isAutoSkipActive && shouldShowAutoSkip
-        ? (autoSkipDelay - (autoSkipProgress * autoSkipDelay)).ceil().clamp(0, autoSkipDelay)
+    final remainingSeconds = widget.isAutoSkipActive && widget.shouldShowAutoSkip
+        ? (widget.autoSkipDelay - (widget.autoSkipProgress * widget.autoSkipDelay)).ceil().clamp(
+            0,
+            widget.autoSkipDelay,
+          )
         : 0;
 
-    final buttonText = isAutoSkipActive && shouldShowAutoSkip && remainingSeconds > 0
+    final buttonText = widget.isAutoSkipActive && widget.shouldShowAutoSkip && remainingSeconds > 0
         ? '$baseButtonText ($remainingSeconds)'
         : baseButtonText;
     final buttonIcon = showNextEpisode ? Symbols.skip_next_rounded : Symbols.fast_forward_rounded;
 
+    final showFocused = _isFocused && InputModeTracker.isKeyboardMode(context);
+    final primary = Theme.of(context).colorScheme.primary;
+    final buttonBgColor = showFocused ? primary : Colors.white.withValues(alpha: 0.9);
+    final contentColor = showFocused ? Colors.white : Colors.black;
+
     return FocusableWrapper(
-      focusNode: focusNode,
+      focusNode: widget.focusNode,
       onSelect: _activate,
       borderRadius: tokens(context).radiusSm,
-      useBackgroundFocus: true,
+      useBackgroundFocus: false,
+      disableScale: true,
       autoScroll: false,
       onKeyEvent: (node, event) {
         if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowDown) {
-          onFocusDown();
+          widget.onFocusDown();
           return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;
@@ -79,10 +128,11 @@ class SkipMarkerButton extends StatelessWidget {
           borderRadius: BorderRadius.circular(tokens(context).radiusSm),
           child: Stack(
             children: [
-              Container(
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                 decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.9),
+                  color: buttonBgColor,
                   borderRadius: BorderRadius.circular(tokens(context).radiusSm),
                   boxShadow: [
                     BoxShadow(color: Colors.black.withValues(alpha: 0.3), blurRadius: 8, offset: const Offset(0, 2)),
@@ -93,30 +143,31 @@ class SkipMarkerButton extends StatelessWidget {
                   children: [
                     Text(
                       buttonText,
-                      style: const TextStyle(color: Colors.black, fontSize: 16, fontWeight: FontWeight.w600),
+                      style: TextStyle(color: contentColor, fontSize: 16, fontWeight: FontWeight.w600),
                     ),
                     const SizedBox(width: 8),
-                    AppIcon(buttonIcon, fill: 1, color: Colors.black, size: 20),
+                    AppIcon(buttonIcon, fill: 1, color: contentColor, size: 20),
                   ],
                 ),
               ),
-              if (isAutoSkipActive && shouldShowAutoSkip)
+              if (widget.isAutoSkipActive && widget.shouldShowAutoSkip)
                 Positioned.fill(
                   child: ClipRRect(
                     borderRadius: BorderRadius.circular(tokens(context).radiusSm),
                     child: Row(
                       children: [
                         Expanded(
-                          flex: (autoSkipProgress * 100).round(),
-                          child: Container(
+                          flex: (widget.autoSkipProgress * 100).round(),
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 150),
                             decoration: BoxDecoration(
-                              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+                              color: (showFocused ? Colors.white : primary).withValues(alpha: 0.25),
                               borderRadius: BorderRadius.circular(tokens(context).radiusSm),
                             ),
                           ),
                         ),
                         Expanded(
-                          flex: ((1.0 - autoSkipProgress) * 100).round(),
+                          flex: ((1.0 - widget.autoSkipProgress) * 100).round(),
                           child: Container(decoration: const BoxDecoration(color: Colors.transparent)),
                         ),
                       ],
@@ -131,9 +182,9 @@ class SkipMarkerButton extends StatelessWidget {
   }
 
   void _activate() {
-    if (isAutoSkipActive) {
-      onCancelAutoSkip();
+    if (widget.isAutoSkipActive) {
+      widget.onCancelAutoSkip();
     }
-    onPerformAutoSkip();
+    widget.onPerformAutoSkip();
   }
 }


### PR DESCRIPTION
> **⚠️ Closed — superseded by #1129**

---

Closes #1116

## Summary

- Adds a hardcoded boolean `MediaFilter` for **Unwatched** to Jellyfin's `fetchLibraryFiltersWithValues`, gated to `movie` and `show` library types
- Threads `{String? libraryType}` through `MediaServerClient.fetchLibraryFiltersWithValues` (mirrors the existing `fetchSortOptions` pattern); Plex implementation accepts the param but ignores it — its filter list is server-driven
- Both call sites (`LibraryFilterSortLoader` and `LibraryBrowseTab`) pass `library.kind.id`
- The translation layer already maps `includeWatched: false` → `Filters=IsUnplayed` and the filter UI already renders `filterType == 'boolean'` as a toggle switch, so no changes needed there

## Test plan

- [ ] Jellyfin movie library — Unwatched toggle visible and filters correctly
- [ ] Jellyfin show library — Unwatched toggle visible and filters correctly
- [ ] Jellyfin music/photo library — Unwatched toggle absent
- [ ] Plex library — no regression in filter list
- `dart format` clean, `flutter analyze` clean on touched files, `flutter test` green (1795 tests)
- Verified on Linux desktop against a live Jellyfin server
