### PR TITLE
feat(jellyfin): add Unwatched filter when browsing libraries

### DIFF
--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -705,7 +705,8 @@
       "genre": "Genre",
       "year": "Year",
       "contentRating": "Content Rating",
-      "tag": "Tag"
+      "tag": "Tag",
+      "unwatched": "Unwatched"
     },
     "sortLabels": {
       "title": "Title",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 15
-/// Strings: 17565 (1171 per locale)
+/// Strings: 17566 (1171 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -3775,6 +3775,9 @@ class TranslationsLibrariesFilterCategoriesEn {
 
 	/// en: 'Tag'
 	String get tag => 'Tag';
+
+	/// en: 'Unwatched'
+	String get unwatched => 'Unwatched';
 }
 
 // Path: libraries.sortLabels
@@ -4801,6 +4804,7 @@ extension on Translations {
 			'libraries.filterCategories.year' => 'Year',
 			'libraries.filterCategories.contentRating' => 'Content Rating',
 			'libraries.filterCategories.tag' => 'Tag',
+			'libraries.filterCategories.unwatched' => 'Unwatched',
 			'libraries.sortLabels.title' => 'Title',
 			'libraries.sortLabels.dateAdded' => 'Date Added',
 			'libraries.sortLabels.releaseDate' => 'Release Date',
@@ -5173,9 +5177,9 @@ extension on Translations {
 			'metadataEdit.summary' => 'Summary',
 			'metadataEdit.poster' => 'Poster',
 			'metadataEdit.background' => 'Background',
-			'metadataEdit.logo' => 'Logo',
 			_ => null,
 		} ?? switch (path) {
+			'metadataEdit.logo' => 'Logo',
 			'metadataEdit.squareArt' => 'Square Art',
 			'metadataEdit.selectPoster' => 'Select Poster',
 			'metadataEdit.selectBackground' => 'Select Background',

--- a/lib/media/media_server_client.dart
+++ b/lib/media/media_server_client.dart
@@ -127,7 +127,9 @@ abstract class MediaServerClient {
   /// fetches values lazily per category); Jellyfin returns both in a single
   /// `/Items/Filters` call and pre-populates [LibraryFilterResult.cachedValues].
   /// Backends that have no filter listing return [LibraryFilterResult.empty].
-  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId);
+  /// [libraryType] lets backends gate kind-specific filters (e.g. Jellyfin's
+  /// `unwatched` toggle only makes sense for movie/show libraries).
+  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId, {String? libraryType});
 
   /// Backend-aware sort options for [libraryId]. Plex hits
   /// `/library/sections/{id}/sorts`; Jellyfin returns a hardcoded list

--- a/lib/screens/libraries/library_filter_sort_loader.dart
+++ b/lib/screens/libraries/library_filter_sort_loader.dart
@@ -33,7 +33,7 @@ class LibraryFilterSortLoader {
   Future<LoadedFiltersAndSorts> load(MediaLibrary library) async {
     final client = clientFor(library);
     final results = await Future.wait([
-      client.fetchLibraryFiltersWithValues(library.id),
+      client.fetchLibraryFiltersWithValues(library.id, libraryType: library.kind.id),
       client.fetchSortOptions(library.id, libraryType: library.kind.id),
     ]);
     final filterResult = results[0] as LibraryFilterResult;

--- a/lib/screens/libraries/tabs/library_browse_tab.dart
+++ b/lib/screens/libraries/tabs/library_browse_tab.dart
@@ -536,7 +536,7 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
     final client = context.getMediaClientForLibrary(widget.library);
     unawaited(
       client
-          .fetchLibraryFiltersWithValues(widget.library.id)
+          .fetchLibraryFiltersWithValues(widget.library.id, libraryType: widget.library.kind.id)
           .then((result) {
             if (generation != _contentRequestId || !mounted) return;
             setState(() {

--- a/lib/services/jellyfin_client/parts/browse.dart
+++ b/lib/services/jellyfin_client/parts/browse.dart
@@ -133,7 +133,7 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
   /// `MediaFilter.key` is prefixed `jellyfin:` so FiltersBottomSheet can
   /// recognise it as cached and skip the per-category value fetch.
   @override
-  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId) async {
+  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId, {String? libraryType}) async {
     final data = await _safeFetchFilterPayload(libraryId);
     if (data == null) return LibraryFilterResult.empty;
     List<String> stringList(Object? raw) {
@@ -172,6 +172,17 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
         sorted.sort();
       }
       values[key] = sorted.map((v) => MediaFilterValue(key: v, title: v)).toList();
+    }
+    if (libraryType == 'movie' || libraryType == 'show') {
+      filters.add(
+        MediaFilter(
+          filter: 'unwatched',
+          filterType: 'boolean',
+          key: 'jellyfin:unwatched',
+          title: t.libraries.filterCategories.unwatched,
+          type: 'filter',
+        ),
+      );
     }
     return LibraryFilterResult(filters: filters, cachedValues: values);
   }

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -3426,7 +3426,7 @@ class PlexClient
   /// when the user opens a filter. The result has empty [LibraryFilterResult.cachedValues];
   /// the FiltersBottomSheet hits the per-category endpoint on demand.
   @override
-  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId) async {
+  Future<LibraryFilterResult> fetchLibraryFiltersWithValues(String libraryId, {String? libraryType}) async {
     final filters = await getLibraryFilters(libraryId);
     return LibraryFilterResult(filters: filters, cachedValues: const {});
   }


### PR DESCRIPTION
## Summary

Jellyfin's library filter panel currently exposes only Genre, Year, Content Rating, and Tag — no way to filter to unwatched movies/shows. Plex already exposes this as a boolean toggle. This PR brings parity by adding an "Unwatched" toggle for Jellyfin libraries.

## What was discovered

`JellyfinClient.fetchLibraryFiltersWithValues` (`lib/services/jellyfin_client/parts/browse.dart`) builds its filter list purely from Jellyfin's `/Items/Filters` response, which has no boolean-toggle equivalent. But the surrounding plumbing was already in place:

- `JellyfinLibraryQueryTranslator.toQueryParameters` already maps `includeWatched: false` → `Filters=IsUnplayed`.
- `filters_bottom_sheet.dart` already renders `filterType == 'boolean'` entries as toggle switches.
- `PlexLibraryQueryTranslator` already uses the key `unwatched`.

So the filter could be added with a small hardcoded entry — no translator changes, no UI changes.

## How it was resolved

`fetchLibraryFiltersWithValues` injects a hardcoded `MediaFilter(key: 'unwatched', filterType: 'boolean', ...)` into its returned list, modeled on how `fetchSortOptions` hardcodes its options. The key matches the existing Plex key so the shared translator picks it up.

To keep the toggle off music/photo libraries where `IsUnplayed` is meaningless, a `libraryType` parameter was threaded through `MediaServerClient.fetchLibraryFiltersWithValues` (mirroring the existing `fetchSortOptions` pattern). The Jellyfin implementation only emits the Unwatched filter when `libraryType == 'movie' || libraryType == 'show'`. Both call sites (`LibraryFilterSortLoader`, `LibraryBrowseTab._loadJellyfinFiltersInBackground`) pass `library.kind.id`. The Plex implementation accepts the param and ignores it — Plex's filter list is server-driven.

## What to look out for in review

- **Interface change**: `MediaServerClient.fetchLibraryFiltersWithValues` gained an optional `String? libraryType`. Both backends and both call sites are updated; no other callers exist.
- **i18n**: adds one new string (`en.i18n.json`) for the toggle label; regenerated `strings*.g.dart` is included.
- **Filter key coupling**: the literal `'unwatched'` is shared between the Plex translator (existing) and the new Jellyfin entry. Renaming it would require updating both sides.
- **Verification**: code-review + `dart format` + `flutter analyze` clean on touched files + full `flutter test` (1795 tests) green. **Manually verified on Linux desktop only** (toggle appears on movie/show libraries, hidden on others, filters correctly). Contributor doesn't have access to iOS/tvOS for visual retest — the code paths are platform-independent (no platform branching in the diff) so behaviour should be uniform, but flagging in case the maintainer wants to spot-check.

Background: [RyoShinzo/plezy#1](https://github.com/RyoShinzo/plezy/issues/1)
