### PR TITLE
fix(ios): unfreeze video after pause/resume from background

### DIFF
--- a/ios/Runner/MpvPlayer/MpvPlayerCore.swift
+++ b/ios/Runner/MpvPlayer/MpvPlayerCore.swift
@@ -196,22 +196,13 @@ class MpvPlayerCore: MpvPlayerCoreBase {
     guard !isPipActive else { return }
 
     refreshExternalDisplayAttachment()
-    recoverDisplayLayerIfNeeded()
+    // Pre-emptively flush the display layer. The set_property reply for
+    // vid=auto can fire before mpv has tried to submit a frame, so a
+    // conditional check on requiresFlushToResumeDecoding / .failed may miss
+    // the post-background state the layer is about to enter.
+    videoLayer?.flush()
     updateEDRMode(sigPeak: lastSigPeak)
     if isPaused { forceDraw() }
-  }
-
-  private func recoverDisplayLayerIfNeeded() {
-    guard let videoLayer else { return }
-
-    var requiresFlush = false
-    if #available(iOS 14.0, tvOS 14.0, *) {
-      requiresFlush = videoLayer.requiresFlushToResumeDecoding
-    }
-    let status = videoLayer.status
-    guard requiresFlush || status == .failed else { return }
-
-    videoLayer.flush()
   }
 
   override func updateEDRMode(sigPeak: Double) {
@@ -622,8 +613,15 @@ class MpvPlayerCore: MpvPlayerCoreBase {
         return
       }
 
-      setProperty("vid", value: "auto")
-      restoreVideoPresentation()
+      // Restore after the async vid=auto command is acknowledged by MPV so that
+      // the layer flush and forceDraw run with video actually enabled.
+      setPropertyAsync("vid", value: "auto") { [weak self] result in
+        if case .failure(let error) = result {
+          print("[MpvPlayerCore] Re-enabling video track failed: \(error)")
+        }
+        guard let self, !self.isBackgrounded else { return }
+        self.restoreVideoPresentation()
+      }
     }
   #endif
 }


### PR DESCRIPTION
## What

On iOS, pausing a video and returning from a background/lock-screen caused audio to resume normally but the video frame to stay frozen. Manually scrubbing unfroze it. tvOS is unaffected (`sceneDidActivate` is `#if os(iOS)`).

## Root cause

`sceneDidActivate` called `restoreVideoPresentation()` synchronously on the line immediately after enqueuing `vid=auto` via `setProperty` (which wraps `mpv_set_property_async` — fire-and-forget). When `forceDraw()` ran, MPV was still processing `vid=no` from `enterBackground()`. The `seek 0 relative+exact` was a no-op while the video track was disabled. By the time MPV eventually processed `vid=auto` and re-enabled the track, `AVSampleBufferDisplayLayer` had entered a `.failed` state from the background interruption and rejected the first frame.

`recoverDisplayLayerIfNeeded()` had a similar race: the SET_PROPERTY_REPLY for `vid=auto` fires when mpv applies it to its property store, which can precede the first frame submit attempt. So the layer looked healthy at check time, the flush was skipped, and the next submit failed.

## Fix

Two coordinated changes in `MpvPlayerCore.swift`:

**1. Gate `restoreVideoPresentation()` on the `vid=auto` completion.** Move the call into the completion block of `setPropertyAsync`, so the layer flush and `forceDraw` only run after MPV has acknowledged the property change. The completion logs failures and bails early if the scene re-entered background before the reply arrived. (`setPropertyAsync` completions are already dispatched to the main thread via `completeVoidRequest`.)

**2. Flush the display layer unconditionally on foreground recovery.** Replace the conditional `recoverDisplayLayerIfNeeded()` with a direct `videoLayer?.flush()` inside `restoreVideoPresentation()`. The old conditional check was unreliable because the layer can still appear healthy at SET_PROPERTY_REPLY time even though it will reject the very next frame. An unconditional flush is cheap (discards pending decode state) and closes the race regardless of whether the failure has surfaced yet. With no remaining callers, `recoverDisplayLayerIfNeeded()` is removed.

Note: `vid=auto` is now enqueued twice per foreground transition (once in `enterForeground()` via `willEnterForegroundNotification`, once in `sceneDidActivate()`). This is harmless — the command is idempotent — and helps because the first enqueue gets additional event-loop iterations to take effect before the second one's completion fires.

Background: RyoShinzo/plezy#3