### PR TITLE
fix(tvos): restore focus after deleting profile from switch screen

### DIFF
--- a/lib/screens/profile/profile_switch_screen.dart
+++ b/lib/screens/profile/profile_switch_screen.dart
@@ -167,20 +167,36 @@ class _ProfileSwitchScreenState extends State<ProfileSwitchScreen> with MountedS
   }
 
   void _pruneProfileFocusResources(Set<String> activeIds) {
+    var removedFocusedNode = false;
     for (final id in _profileFocusNodes.keys.toList()) {
       if (!activeIds.contains(id)) {
-        _profileFocusNodes.remove(id)?.dispose();
+        final node = _profileFocusNodes.remove(id);
+        if (node != null) {
+          if (node.hasFocus) removedFocusedNode = true;
+          node.dispose();
+        }
       }
     }
     for (final id in _profileMenuFocusNodes.keys.toList()) {
       if (!activeIds.contains(id)) {
-        _profileMenuFocusNodes.remove(id)?.dispose();
+        final node = _profileMenuFocusNodes.remove(id);
+        if (node != null) {
+          if (node.hasFocus) removedFocusedNode = true;
+          node.dispose();
+        }
       }
     }
     for (final id in _profileMenuKeys.keys.toList()) {
       if (!activeIds.contains(id)) {
         _profileMenuKeys.remove(id);
       }
+    }
+    // Disposing a focused FocusNode orphans the D-pad cursor — happens on
+    // tvOS when the focused tile (or its menu button) is the one being
+    // deleted. Re-arm autofocus so the next build moves focus to the first
+    // remaining tile.
+    if (removedFocusedNode) {
+      _focusRequested = false;
     }
   }
 


### PR DESCRIPTION
## Summary

On tvOS, deleting a profile from the Profile Switch screen via the three-dots menu leaves the D-pad with no focus anchor, requiring an app restart. See RyoShinzo/plezy#5 for the symptom write-up.

`_pruneProfileFocusResources` in `lib/screens/profile/profile_switch_screen.dart` disposes the deleted profile's `FocusNode`s when the `ProfilesView` stream emits. If one of those nodes currently holds primary focus (the menu button does, since Flutter restored focus there when the confirm dialog closed), disposing it orphans the focus tree. `_focusRequested` is a one-shot guard, so the autofocus path on the first remaining tile never re-engages.

The fix: detect whether any of the disposed nodes had focus (or a focused descendant — `hasFocus` covers both the tile wrapper and the inner menu button). If so, reset `_focusRequested = false`. The next sliver build re-schedules `requestFocus()` on the first remaining tile via the existing `addPostFrameCallback` path.

Scoped to the bug — focus is only re-armed when the focused tile itself is removed, not when unrelated profiles are pruned.

## Test plan

- [ ] Delete a non-active profile via the three-dots menu on tvOS → focus lands on the first remaining tile.
- [ ] Delete the active profile → first remaining tile becomes focused.
- [ ] Delete the last local profile (only one left, active) → empty-state appears; no crash.
- [ ] Delete a non-focused profile (e.g. via long-press on a different tile than the focused one) → focus stays where it was, not stolen to the first tile.
- [ ] Phone/tablet/desktop unaffected (touch and pointer paths don't depend on focus re-arming).