### PR TITLE
feat(tracker): implement watch state authority for trackers

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,9 +36,8 @@ import 'services/discord_rpc_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'services/image_cache_service.dart';
 import 'services/gamepad_service.dart';
-import 'services/trakt/trakt_scrobble_service.dart';
-import 'services/trakt/trakt_sync_service.dart';
-import 'services/trackers/tracker_coordinator.dart';
+import 'services/trackers/tracker_lifecycle.dart';
+import 'services/trackers/watch_state_overlay.dart';
 import 'providers/trakt_account_provider.dart';
 import 'providers/trackers_provider.dart';
 import 'providers/user_profile_provider.dart';
@@ -245,7 +244,7 @@ Future<void> _bootstrapApp() async {
     unawaited(DiscordRPCService.instance.initialize());
   }
 
-  await TraktScrobbleService.instance.initialize();
+  await TrackerLifecycle.initializeScrobble();
 
   _registerShaderLicenses();
 
@@ -483,9 +482,7 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
 
     _offlineWatchSyncService = OfflineWatchSyncService(database: _appDatabase, serverManager: _serverManager);
 
-    // Trakt sync service (subscribes to WatchStateNotifier, requires serverManager
-    // to resolve PlexClients for GUID lookups).
-    TraktSyncService.instance.initialize(serverManager: _serverManager);
+    TrackerLifecycle.initializeWithServerManager(_serverManager);
 
     _appLifecycleListener = AppLifecycleListener(
       onExitRequested: () async {
@@ -505,9 +502,8 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
     _memoryCheckTimer?.cancel();
 
     _downloadManager.dispose();
-    TrackerCoordinator.instance.cancelInFlight();
-    TraktScrobbleService.instance.cancelInFlight();
-    await TraktSyncService.instance.dispose();
+    TrackerLifecycle.cancelInFlight();
+    await TrackerLifecycle.dispose();
 
     await _serverManager.disconnectAllGracefully();
     await Future.wait([
@@ -566,6 +562,8 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
           if (transitioned) {
             appLogger.d('Connectivity moved onto WiFi/Ethernet — triggering sync pass');
             _autoDeleteAndSync(downloadProvider);
+            // Drain any offline scrobbles queued while the network was unavailable.
+            unawaited(WatchStateOverlay.instance.flushOfflineQueue());
           }
         });
       } catch (e) {
@@ -633,7 +631,7 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
       case AppLifecycleState.resumed:
         // App came back to foreground - trigger sync check
         _offlineWatchSyncService.onAppResumed();
-        TraktSyncService.instance.flushQueue();
+        TrackerLifecycle.flushQueue();
         // Re-probe servers — mobile OS may have dropped TCP connections during doze/sleep.
         // On desktop, resumed fires on every window focus (alt-tab), so apply a cooldown
         // to avoid piling up network probes from rapid alt-tabbing.
@@ -864,7 +862,7 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
                 final trackers = context.read<TrackersProvider>();
                 return _TrackerProfileBootstrap(
                   onProfileChanged: [trakt.onActiveProfileChanged, trackers.onActiveProfileChanged],
-                  onFirstMount: TrackerCoordinator.instance.initialize,
+                  onFirstMount: TrackerLifecycle.initializeCoordinator,
                   child: Listener(
                     onPointerDown: (event) {
                       if ((event.buttons & kBackMouseButton) != 0) {
@@ -1223,6 +1221,7 @@ class _SetupScreenState extends State<SetupScreen> with MountedSetStateMixin {
     // Wire the per-server status listener before either branch so the splash
     // checkmarks fill in even while the user is choosing a profile.
     _bindServerStatusListener(activeProfile, _serverManagerFromContext);
+    _initTrackerStatus();
 
     // Start only after network/offline startup has been decided and the
     // active profile snapshot is hydrated. This prevents an eager binder
@@ -1301,6 +1300,22 @@ class _SetupScreenState extends State<SetupScreen> with MountedSetStateMixin {
   }
 
   MultiServerManager _serverManagerFromContext() => context.read<MultiServerProvider>().serverManager;
+
+  void _initTrackerStatus() {
+    final overlay = WatchStateOverlay.instance;
+    if (!overlay.hasActiveAuthority) return;
+
+    final trackerName = overlay.activeTrackerName ?? 'Tracker';
+    final username = context.read<TraktAccountProvider>().username;
+    final label = username != null ? '$trackerName: $username' : trackerName;
+    setState(() => _serverStatus['tracker'] = (label, null));
+
+    // Flip to checkmark once the cache finishes loading from disk (fast path).
+    // Navigation is not blocked — this is fire-and-forget.
+    overlay.cacheReady.then((_) {
+      if (mounted) setState(() => _serverStatus['tracker'] = (label, true));
+    }).catchError((_) {/* ignore — row stays as spinner */});
+  }
 
   @override
   void dispose() {

--- a/lib/mixins/tracker_sync_aware.dart
+++ b/lib/mixins/tracker_sync_aware.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import '../media/media_item.dart';
+import '../services/trackers/tracker_sync_notifier.dart';
+import '../services/trackers/watch_state_overlay.dart';
+
+/// Mixin for screens that need to react to tracker authority sync events
+/// (e.g. Trakt re-sync after playback).
+///
+/// Handles [TrackerSyncNotifier] subscription lifecycle automatically.
+/// Override [onTrackerSyncChanged] to respond to sync notifications.
+/// Use [hasTrackerAuthority], [applyOverlay], and [applyOverlayAll] to
+/// re-apply the active tracker's watch state without importing [WatchStateOverlay].
+mixin TrackerSyncAware<T extends StatefulWidget> on State<T> {
+  @override
+  void initState() {
+    super.initState();
+    TrackerSyncNotifier.instance.addListener(_handleTrackerSync);
+  }
+
+  @override
+  void dispose() {
+    TrackerSyncNotifier.instance.removeListener(_handleTrackerSync);
+    super.dispose();
+  }
+
+  void _handleTrackerSync() {
+    if (!mounted) return;
+    onTrackerSyncChanged();
+  }
+
+  /// Whether a tracker authority is currently active.
+  bool get hasTrackerAuthority => WatchStateOverlay.instance.hasActiveAuthority;
+
+  /// Re-applies the active tracker overlay to a single item.
+  MediaItem applyOverlay(MediaItem item) => WatchStateOverlay.instance.apply(item);
+
+  /// Re-applies the active tracker overlay to a list of items.
+  List<MediaItem> applyOverlayAll(List<MediaItem> items) =>
+      WatchStateOverlay.instance.applyAll(items);
+
+  /// Called when the tracker authority notifies a sync or state change.
+  /// The widget is guaranteed to be mounted at the point this is called.
+  /// If the implementation awaits any async operation, check [mounted]
+  /// again before calling [setState] — the widget may have been disposed
+  /// while the future was in flight.
+  void onTrackerSyncChanged();
+}

--- a/lib/providers/trakt_account_provider.dart
+++ b/lib/providers/trakt_account_provider.dart
@@ -5,12 +5,16 @@ import 'package:flutter/foundation.dart';
 import '../mixins/disposable_change_notifier_mixin.dart';
 import '../models/trackers/device_code.dart';
 import '../services/trackers/tracker_connect_runner.dart';
+import '../services/trackers/tracker_constants.dart';
 import '../services/trakt/trakt_account_store.dart';
 import '../services/trakt/trakt_auth_service.dart';
 import '../services/trakt/trakt_client.dart';
 import '../services/trakt/trakt_scrobble_service.dart';
 import '../services/trakt/trakt_session.dart';
 import '../services/trakt/trakt_sync_service.dart';
+import '../services/trakt/trakt_watch_state_provider.dart';
+import '../services/settings_service.dart';
+import '../services/trackers/tracker_sync_notifier.dart';
 import '../utils/app_logger.dart';
 
 /// Owns the active Trakt session for the currently-selected Plex profile.
@@ -41,8 +45,12 @@ class TraktAccountProvider extends ChangeNotifier with DisposableChangeNotifierM
 
   /// Called whenever the active Plex profile changes (or on initial load).
   Future<void> onActiveProfileChanged(String? newUserUuid) async {
+    appLogger.d('TraktAccountProvider: active profile changed to $newUserUuid');
     _activeUserUuid = newUserUuid ?? '';
     final loaded = await _store.load(_activeUserUuid);
+    appLogger.d(
+      'TraktAccountProvider: loaded session for $_activeUserUuid: ${loaded != null ? "connected" : "disconnected"}',
+    );
     _setSessionAndRebind(loaded);
   }
 
@@ -107,19 +115,152 @@ class TraktAccountProvider extends ChangeNotifier with DisposableChangeNotifierM
 
   void _setSessionAndRebind(TraktSession? session) {
     _session = session;
+    // Scrobble service
     TraktScrobbleService.instance.rebindToProfile(session, onSessionInvalidated: _handleSessionInvalidated);
+    // Sync service
     TraktSyncService.instance.rebindToProfile(
       _activeUserUuid,
       session,
       onSessionInvalidated: _handleSessionInvalidated,
     );
+    // After each successful history-add, trigger a lightweight playback refresh
+    // so the next episode appears in Continue Watching without waiting for the
+    // next app-launch sync.
+    TraktSyncService.instance.setOnHistoryAdded(
+      session != null ? TraktWatchStateProvider.instance.schedulePlaybackRefresh : null,
+    );
+    // After offline reconnect progress push, refresh playback cache so Continue
+    // Watching reflects the offline position without waiting for the next full sync.
+    TraktSyncService.instance.setOnProgressPushed(
+      session != null ? TraktWatchStateProvider.instance.schedulePlaybackRefresh : null,
+    );
+    // After scrobble stop, stamp the local playback cache with paused_at = now
+    // so the 2-second post-playback sync always sees the correct episode as most
+    // recently paused — even if Trakt's server hasn't processed the stop yet.
+    TraktScrobbleService.instance.setOnPlaybackStopped(
+      session != null ? TraktWatchStateProvider.instance.touchPlaybackEntryByIds : null,
+    );
+    // Bind the watch-state provider. The future resolves once the in-memory
+    // caches reflect the new profile; authority activation chains off it so
+    // the overlay is never re-activated while the prior profile's caches are
+    // still in memory.
+    final bindFuture = TraktWatchStateProvider.instance.bindSession(
+      session,
+      userUuid: _activeUserUuid,
+      onSessionInvalidated: _handleSessionInvalidated,
+    );
+    // Whenever enrichment adds a new Plex show to the bridge map, notify
+    // listeners so Continue Watching thumbnails update without waiting for the
+    // next full sync cycle.
+    TraktWatchStateProvider.instance.setOnBridgeMapUpdated(session != null ? safeNotifyListeners : null);
+    // Register background ID fetcher so movies with missing Plex Guid arrays
+    // can still be matched against Trakt after a one-shot async resolve.
+    TraktWatchStateProvider.instance.setExternalIdsFetcher(
+      session != null
+          ? (plexKey, serverId) => TraktSyncService.instance.resolveMovieIds(plexKey, serverId)
+          : null,
+    );
+    if (session != null) {
+      // Connected: activation must wait for bindSession's in-memory reset
+      // (profile switch) to complete; then load cached data and sync.
+      // safeNotifyListeners() at the bottom of this method already notifies
+      // session-state subscribers — the post-sync notification only fans out
+      // to TrackerSyncAware screens so they re-apply the now-fresh overlay.
+      unawaited(bindFuture
+          .then((_) {
+            _applyWatchStateAuthority();
+            return TraktWatchStateProvider.instance.loadFromCache();
+          })
+          .then((_) => TraktWatchStateProvider.instance.syncWatchState())
+          .then((_) => TrackerSyncNotifier.instance.notifySync())
+          .catchError((Object e) {
+            appLogger.w('TraktWatchState: bind/sync chain failed', error: e);
+          }));
+    } else {
+      // Disconnected: deactivate immediately so the overlay stops serving
+      // any data. bindSession's disk wipe runs in the background.
+      unawaited(bindFuture.catchError((Object e) {
+        appLogger.w('TraktWatchStateProvider: bindSession(null) failed', error: e);
+      }));
+      TrackerSyncNotifier.instance.deactivateAuthority();
+      TrackerSyncNotifier.instance.notifySync();
+    }
     safeNotifyListeners();
+  }
+
+  void setWatchStateAuthorityEnabled(bool enabled) {
+    _setWatchStateAuthority(enabled);
+    safeNotifyListeners();
+  }
+
+  void _applyWatchStateAuthority() {
+    final enabled = SettingsService.instanceOrNull?.read(SettingsService.trackerStateAuthority) == TrackerService.trakt.name;
+    _setWatchStateAuthority(enabled);
+  }
+
+  void _setWatchStateAuthority(bool enabled) {
+    if (enabled && _session != null) {
+      TrackerSyncNotifier.instance.activateAuthority(
+        TraktWatchStateProvider.instance,
+        triggerPostPlaybackSync: triggerPostPlaybackSync,
+        forceSyncWatchState: forceSyncWatchState,
+        syncIfStale: syncIfStale,
+      );
+    } else {
+      TrackerSyncNotifier.instance.deactivateAuthority();
+    }
+  }
+
+  /// Refresh the local Trakt watch state cache after playback ends so
+  /// Continue Watching and library badges update without waiting for the
+  /// next app launch. Fire-and-forget — never blocks the caller.
+  void triggerPostPlaybackSync() {
+    if (!isConnected) return;
+    unawaited(
+      TraktWatchStateProvider.instance
+          // force=true bypasses the last_activities timestamp check — Trakt's
+          // server may not have updated it within the 2-second delay window,
+          // so we must always re-fetch /sync/playback after a watch session.
+          .syncWatchState(force: true)
+          .then((_) {
+            TrackerSyncNotifier.instance.notifySync();
+            safeNotifyListeners();
+          })
+          .catchError((Object e) {
+            appLogger.d('Trakt: post-playback sync failed (non-critical)', error: e);
+          }),
+    );
+  }
+
+  /// Sync Trakt watch state if remote data has changed since last sync.
+  /// Uses the last_activities check — cheap when nothing changed externally,
+  /// full re-sync when the user made changes on another device or the website.
+  Future<void> syncIfStale() async {
+    if (!isConnected) return;
+    try {
+      await TraktWatchStateProvider.instance.syncWatchState(force: false);
+    } catch (e) {
+      appLogger.d('Trakt: stale-check sync failed (non-critical)', error: e);
+    }
+  }
+
+  /// Manually trigger a full sync from Trakt, ignoring activity timestamps.
+  Future<void> forceSyncWatchState() async {
+    await TraktWatchStateProvider.instance.syncWatchState(force: true);
+    notifyListeners();
+    TrackerSyncNotifier.instance.notifySync();
+  }
+
+  /// Clear all cached Trakt watch state (in-memory and persistent).
+  Future<void> invalidateWatchStateCache() async {
+    await TraktWatchStateProvider.instance.invalidateCache();
+    notifyListeners();
   }
 
   /// Called by [TraktClient] when refresh fails permanently. Clears local state
   /// so the UI shows "not connected" and the user can re-link.
-  void _handleSessionInvalidated() {
-    _store.clear(_activeUserUuid);
+  Future<void> _handleSessionInvalidated() async {
+    await _store.clear(_activeUserUuid);
     _setSessionAndRebind(null);
   }
 

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -26,7 +26,6 @@ import '../providers/libraries_provider.dart';
 import '../providers/playback_state_provider.dart';
 import '../widgets/hub_section.dart';
 import '../widgets/clickable_cursor.dart';
-import '../widgets/loading_indicator_box.dart';
 import '../widgets/profile_switching_overlay.dart';
 import 'profile/profile_switch_screen.dart';
 import '../connection/connection_registry.dart';
@@ -65,6 +64,10 @@ import 'libraries/content_state_builder.dart';
 import 'main_screen.dart';
 import '../watch_together/watch_together.dart';
 import '../providers/companion_remote_provider.dart';
+import '../mixins/tracker_sync_aware.dart';
+import '../services/trackers/tracker_sync_notifier.dart';
+import '../services/trackers/tracker_ui_helper.dart' show resolveTrackerItemForAction;
+import '../services/trackers/watch_state_overlay.dart';
 import '../widgets/companion_remote/remote_session_dialog.dart';
 import 'companion_remote/mobile_remote_screen.dart';
 
@@ -81,6 +84,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
         FullRefreshable,
         ItemUpdatable,
         WatchStateAware,
+        TrackerSyncAware,
         TabVisibilityAware,
         FocusableTab,
         WidgetsBindingObserver {
@@ -143,6 +147,9 @@ class _DiscoverScreenState extends State<DiscoverScreen>
   LibrariesProvider? _librariesProvider;
   Set<String> _lastSeenHiddenKeys = {};
   List<String> _lastSeenLibraryOrderKeys = const [];
+  bool _isCWRefreshing = false;
+  DateTime? _lastTrackerSyncCheck;
+  static const _syncDebounce = Duration(seconds: 60);
 
   // WatchStateAware: watch on-deck items and their parent shows/seasons
   @override
@@ -452,6 +459,18 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     }
   }
 
+  @override
+  void onTrackerSyncChanged() {
+    unawaited(_refreshContinueWatching());
+    if (hasTrackerAuthority && _hubs.isNotEmpty) {
+      setState(() {
+        _hubs = _hubs
+            .map((hub) => hub.copyWith(items: applyOverlayAll(hub.items)))
+            .toList();
+      });
+    }
+  }
+
   void _onHiddenLibrariesChanged() {
     final currentKeys = _hiddenLibrariesProvider?.hiddenLibraryKeys ?? {};
     if (currentKeys.length == _lastSeenHiddenKeys.length && currentKeys.containsAll(_lastSeenHiddenKeys)) {
@@ -514,7 +533,12 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       },
       onSelect: () {
         if (_onDeck.isNotEmpty && _currentHeroIndex < _onDeck.length) {
-          navigateToVideoPlayer(context, metadata: _onDeck[_currentHeroIndex]);
+          unawaited(() async {
+            final resolved = await resolveTrackerItemForAction(context, _onDeck[_currentHeroIndex]);
+            if (resolved != null && mounted) {
+              unawaited(navigateToVideoPlayer(context, metadata: resolved));
+            }
+          }());
         }
       },
     )(node, event);
@@ -682,7 +706,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     return 8.0; // Normal size
   }
 
-  Future<void> _loadContent() async {
+  Future<void> _loadContent({bool forceRefresh = false}) async {
     appLogger.d('Loading discover content from all servers');
     setState(() {
       _isLoading = true;
@@ -710,109 +734,145 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       if (!mounted) return;
       _lastSeenHiddenKeys = Set.of(hiddenLibrariesProvider.hiddenLibraryKeys);
 
-      // Let aggregation service fetch libraries internally; the LibrariesProvider
-      // stores neutral MediaLibrary objects.
+      // Capture before async gaps
+      await SettingsService.getInstance();
 
-      // Start OnDeck and hubs fetch in parallel
-      final useGlobalHubs = context.settingsRead(SettingsService.useGlobalHubs);
-      final onDeckFuture = multiServerProvider.aggregationService.getOnDeckFromAllServers(
-        limit: _continueWatchingProbeLimit,
-        hiddenLibraryKeys: hiddenLibrariesProvider.hiddenLibraryKeys,
-      );
-      final hubsFuture = multiServerProvider.aggregationService.getHubsFromAllServers(
-        hiddenLibraryKeys: hiddenLibrariesProvider.hiddenLibraryKeys,
-        useGlobalHubs: useGlobalHubs,
-        includePlaybackHubs: false,
-      );
-
-      // Wait for OnDeck to complete and show it immediately
-      final fetchedOnDeck = await onDeckFuture;
-      final hasMoreContinueWatching = fetchedOnDeck.length > _continueWatchingPreviewLimit;
-      final onDeck = hasMoreContinueWatching
-          ? fetchedOnDeck.take(_continueWatchingPreviewLimit).toList()
-          : fetchedOnDeck;
-
-      if (!mounted) return;
-      setState(() {
-        _onDeck = onDeck;
-        _hasMoreContinueWatching = hasMoreContinueWatching;
-        _isLoading = false; // Show content, but hubs still loading
-
-        // Reset hero index to avoid sync issues
-        _currentHeroIndex = 0;
-
-        // Create continue watching hub key if needed
-        if (_onDeck.isNotEmpty) {
-          _continueWatchingHubKey ??= GlobalKey<HubSectionState>();
-        }
-      });
-      _applyPendingTvBrowseRailFocus();
-
-      // Focus hero section now that it's visible, but only if no modal route is on top
-      if (!PlatformDetector.isTV() && onDeck.isNotEmpty && (ModalRoute.of(context)?.isCurrent ?? false)) {
-        _heroFocusNode.requestFocus();
-      }
-
-      // Sync to Android TV Watch Next row
-      if (Platform.isAndroid) {
-        unawaited(_syncWatchNext(onDeck));
-      }
-
-      // Sync PageController to first page after OnDeck loads
-      if (_heroController.hasClients && onDeck.isNotEmpty) {
-        _heroController.jumpToPage(0);
-      }
-
-      // On initial load, focus the hero so the user starts on content (not the toolbar)
-      if (!_initialLoadComplete && onDeck.isNotEmpty) {
-        _initialLoadComplete = true;
-        if (PlatformDetector.isTV()) {
-          _focusTvBrowseRailWhenReady();
-        } else {
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (!mounted || !(ModalRoute.of(context)?.isCurrent ?? false)) return;
-            if (_heroFocusNode.canRequestFocus) {
-              _heroFocusNode.requestFocus();
-            }
+      // Force tracker cache refresh so manual reload always reflects latest
+      // external changes (e.g. marked watched on the tracker website).
+      if (WatchStateOverlay.instance.hasActiveAuthority) {
+        // Show the previous sync's in-memory items immediately (already loaded
+        // from ApiCache on boot) so the screen is never blank on repeat visits.
+        final cached = WatchStateOverlay.instance.getContinueWatchingItems();
+        if (cached.isNotEmpty && _onDeck.isEmpty) {
+          if (!mounted) return;
+          setState(() {
+            _onDeck = cached.map((e) => e.metadata).toList();
+            _isLoading = false;
+            _currentHeroIndex = 0;
+            _continueWatchingHubKey ??= GlobalKey<HubSectionState>();
           });
         }
+        // Sync in background — TrackerSyncNotifier fires onTrackerSyncChanged
+        // → _refreshContinueWatching when complete, updating the UI.
+        unawaited(TrackerSyncNotifier.instance.forceSyncWatchState());
+        if (!mounted) return;
+        _lastTrackerSyncCheck = DateTime.now(); // reset debounce — data is fresh
       }
 
-      // Wait for global hubs
-      final allHubs = await hubsFuture;
-
-      if (!mounted) return;
-
-      // Filter out playback-progress hubs handled by the top Continue Watching row.
-      final filteredHubs = allHubs.where((hub) {
-        final hubId = hub.identifier?.toLowerCase() ?? '';
-        final title = hub.title.toLowerCase();
-        return !hubId.contains('ondeck') &&
-            !hubId.contains('continue') &&
-            !hubId.contains('nextup') &&
-            !title.contains('continue watching') &&
-            !title.contains('on deck') &&
-            !title.contains('next up');
-      }).toList();
-
+      // Start OnDeck and hubs fetch in parallel.
+      // Capture context-dependent values before any further async gaps.
+      final useGlobalHubs = context.settingsRead(SettingsService.useGlobalHubs);
       final libraryOrder = context.read<LibrariesProvider>().libraries;
-      sortMediaHubsByLibraryOrder(filteredHubs, libraryOrder);
+      // Skip CW fetch when tracker already showed cached items — the background
+      // forceSyncWatchState → _refreshContinueWatching chain handles the update.
+      // Never skip on forceRefresh (manual reload / profile switch — user expects fresh data).
+      final bool trackerServedFromCache = !forceRefresh &&
+          WatchStateOverlay.instance.hasActiveAuthority && _onDeck.isNotEmpty;
+      final onDeckFuture = trackerServedFromCache
+          ? null
+          : multiServerProvider.aggregationService.getOnDeckFromAllServers(
+              limit: _continueWatchingProbeLimit,
+              hiddenLibraryKeys: hiddenLibrariesProvider.hiddenLibraryKeys,
+            );
 
-      appLogger.d('Received ${onDeck.length} on deck items and ${filteredHubs.length} global hubs from all servers');
-      if (!mounted) return;
-      setState(() {
-        _hubs = filteredHubs;
-        _areHubsLoading = false;
-        _updateHubKeys();
-      });
-      _applyPendingTvBrowseRailFocus();
+      // Hubs process independently so Recently Added / recommendations appear
+      // as soon as their data arrives, without waiting for CW to resolve first.
+      unawaited(
+        multiServerProvider.aggregationService.getHubsFromAllServers(
+          hiddenLibraryKeys: hiddenLibrariesProvider.hiddenLibraryKeys,
+          useGlobalHubs: useGlobalHubs,
+          includePlaybackHubs: false,
+        ).then((allHubs) {
+          if (!mounted) return;
+          final filteredHubs = allHubs.where((hub) {
+            final hubId = hub.identifier?.toLowerCase() ?? '';
+            final title = hub.title.toLowerCase();
+            return !hubId.contains('ondeck') &&
+                !hubId.contains('continue') &&
+                !hubId.contains('nextup') &&
+                !title.contains('continue watching') &&
+                !title.contains('on deck') &&
+                !title.contains('next up');
+          }).toList();
+          sortMediaHubsByLibraryOrder(filteredHubs, libraryOrder);
+          appLogger.d('Received ${filteredHubs.length} global hubs from all servers');
+          setState(() {
+            _hubs = filteredHubs;
+            _areHubsLoading = false;
+            _updateHubKeys();
+          });
+          _applyPendingTvBrowseRailFocus();
+          if (PlatformDetector.isTV() && !_initialLoadComplete && filteredHubs.isNotEmpty) {
+            _initialLoadComplete = true;
+            _focusTvBrowseRailWhenReady();
+          }
+        }).catchError((Object e) {
+          appLogger.e('Failed to load hubs', error: e);
+          if (!mounted) return;
+          setState(() { _areHubsLoading = false; });
+        }),
+      );
 
-      if (PlatformDetector.isTV() && !_initialLoadComplete && filteredHubs.isNotEmpty) {
-        _initialLoadComplete = true;
-        _focusTvBrowseRailWhenReady();
+      if (onDeckFuture != null) {
+        // Wait for OnDeck to complete and show it immediately
+        final fetchedOnDeck = await onDeckFuture;
+        final hasMoreContinueWatching = fetchedOnDeck.length > _continueWatchingPreviewLimit;
+        final onDeck = hasMoreContinueWatching
+            ? fetchedOnDeck.take(_continueWatchingPreviewLimit).toList()
+            : fetchedOnDeck;
+
+        if (!mounted) return;
+        setState(() {
+          _onDeck = onDeck;
+          _hasMoreContinueWatching = hasMoreContinueWatching;
+          _isLoading = false; // Show content, but hubs still loading
+
+          // Reset hero index to avoid sync issues
+          _currentHeroIndex = 0;
+
+          // Create continue watching hub key if needed
+          if (_onDeck.isNotEmpty) {
+            _continueWatchingHubKey ??= GlobalKey<HubSectionState>();
+          }
+        });
+        _applyPendingTvBrowseRailFocus();
+
+        // Focus hero section now that it's visible, but only if no modal route is on top
+        if (!PlatformDetector.isTV() && onDeck.isNotEmpty && (ModalRoute.of(context)?.isCurrent ?? false)) {
+          _heroFocusNode.requestFocus();
+        }
+
+        // Sync to Android TV Watch Next row
+        if (Platform.isAndroid) {
+          unawaited(_syncWatchNext(onDeck));
+        }
+
+        // Sync PageController to first page after OnDeck loads
+        if (_heroController.hasClients && onDeck.isNotEmpty) {
+          _heroController.jumpToPage(0);
+        }
+
+        // On initial load, focus the hero so the user starts on content (not the toolbar)
+        if (!_initialLoadComplete && onDeck.isNotEmpty) {
+          _initialLoadComplete = true;
+          if (PlatformDetector.isTV()) {
+            _focusTvBrowseRailWhenReady();
+          } else {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted || !(ModalRoute.of(context)?.isCurrent ?? false)) return;
+              if (_heroFocusNode.canRequestFocus) {
+                _heroFocusNode.requestFocus();
+              }
+            });
+          }
+        }
+
+        appLogger.d('Received ${onDeck.length} on deck items from all servers');
+      } else if (_isLoading) {
+        // Tracker served from cache — cached items are already displayed, clear the loading flag.
+        if (!mounted) return;
+        setState(() { _isLoading = false; });
       }
-
-      appLogger.d('Discover content loaded successfully');
     } catch (e) {
       appLogger.e('Failed to load discover content', error: e);
       if (!mounted) return;
@@ -826,17 +886,44 @@ class _DiscoverScreenState extends State<DiscoverScreen>
 
   /// Refresh only the Continue Watching section in the background
   /// This is called when returning to the home screen to avoid blocking UI
-  Future<void> _refreshContinueWatching() async {
+  Future<void> _refreshContinueWatching({bool syncTracker = false}) async {
+    if (_isCWRefreshing) return;
+    _isCWRefreshing = true;
+    try {
+      await _doRefreshContinueWatching(syncTracker: syncTracker);
+    } finally {
+      _isCWRefreshing = false;
+    }
+  }
+
+  Future<void> _doRefreshContinueWatching({bool syncTracker = false}) async {
     appLogger.d('Refreshing Continue Watching in background from all servers');
 
-    try {
-      final multiServerProvider = context.read<MultiServerProvider>();
-      if (!multiServerProvider.hasConnectedServers) {
-        appLogger.w('No servers available for background refresh');
-        return;
-      }
+    final multiServerProvider = context.read<MultiServerProvider>();
+    final hiddenLibrariesProvider = context.read<HiddenLibrariesProvider>();
 
-      final hiddenLibrariesProvider = context.read<HiddenLibrariesProvider>();
+    if (!multiServerProvider.hasConnectedServers) {
+      appLogger.w('No servers available for background refresh');
+      return;
+    }
+
+    // Determine whether a tracker sync should be kicked off.
+    // Debounce to avoid hammering /sync/last_activities on rapid tab switches.
+    final now = DateTime.now();
+    final shouldSync = syncTracker &&
+        WatchStateOverlay.instance.hasActiveAuthority &&
+        (_lastTrackerSyncCheck == null ||
+            now.difference(_lastTrackerSyncCheck!) > _syncDebounce);
+
+    // Fire sync in background (non-blocking) so Phase 1 can show data immediately.
+    Future<void>? pendingSync;
+    if (shouldSync) {
+      _lastTrackerSyncCheck = now;
+      pendingSync = TrackerSyncNotifier.instance.syncIfStale();
+    }
+
+    // Phase 1 — show current cached state right away.
+    try {
       final fetchedOnDeck = await multiServerProvider.aggregationService.getOnDeckFromAllServers(
         limit: _continueWatchingProbeLimit,
         hiddenLibraryKeys: hiddenLibrariesProvider.hiddenLibraryKeys,
@@ -845,12 +932,10 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       final onDeck = hasMoreContinueWatching
           ? fetchedOnDeck.take(_continueWatchingPreviewLimit).toList()
           : fetchedOnDeck;
-
       if (mounted) {
         setState(() {
           _onDeck = onDeck;
           _hasMoreContinueWatching = hasMoreContinueWatching;
-          // Reset hero index if needed
           if (_currentHeroIndex >= onDeck.length) {
             _currentHeroIndex = 0;
             if (_heroController.hasClients && onDeck.isNotEmpty) {
@@ -858,17 +943,41 @@ class _DiscoverScreenState extends State<DiscoverScreen>
             }
           }
         });
-
-        // Sync to Android TV Watch Next row
-        if (Platform.isAndroid) {
-          unawaited(_syncWatchNext(onDeck));
-        }
-
-        appLogger.d('Continue Watching refreshed successfully');
+        if (Platform.isAndroid) unawaited(_syncWatchNext(onDeck));
+        appLogger.d('Continue Watching — phase 1 done (${onDeck.length} items)');
       }
     } catch (e) {
-      appLogger.w('Failed to refresh Continue Watching', error: e);
-      // Silently fail - don't show error to user for background refresh
+      appLogger.w('Failed to refresh Continue Watching (phase 1)', error: e);
+    }
+
+    // Phase 2 — once tracker sync finishes, re-fetch with updated state.
+    if (pendingSync != null) {
+      try {
+        await pendingSync;
+        if (!mounted) return;
+        final fetchedFresh = await multiServerProvider.aggregationService.getOnDeckFromAllServers(
+          limit: _continueWatchingProbeLimit,
+          hiddenLibraryKeys: hiddenLibrariesProvider.hiddenLibraryKeys,
+        );
+        final freshHasMore = fetchedFresh.length > _continueWatchingPreviewLimit;
+        final fresh = freshHasMore ? fetchedFresh.take(_continueWatchingPreviewLimit).toList() : fetchedFresh;
+        if (mounted) {
+          setState(() {
+            _onDeck = fresh;
+            _hasMoreContinueWatching = freshHasMore;
+            if (_currentHeroIndex >= fresh.length) {
+              _currentHeroIndex = 0;
+              if (_heroController.hasClients && fresh.isNotEmpty) {
+                _heroController.jumpToPage(0);
+              }
+            }
+          });
+          if (Platform.isAndroid) unawaited(_syncWatchNext(fresh));
+          appLogger.d('Continue Watching — phase 2 done (${fresh.length} items)');
+        }
+      } catch (e) {
+        appLogger.w('Failed to refresh Continue Watching (phase 2)', error: e);
+      }
     }
   }
 
@@ -902,8 +1011,19 @@ class _DiscoverScreenState extends State<DiscoverScreen>
   @override
   void refresh() {
     appLogger.d('DiscoverScreen.refresh() called');
-    // Only refresh Continue Watching in background, not full screen reload
-    _refreshContinueWatching();
+    // Explicit refresh (e.g. returning from player) always bypasses the
+    // background-tab debounce so tracker state is re-synced immediately.
+    _lastTrackerSyncCheck = null;
+    _refreshContinueWatching(syncTracker: true);
+    // Update hub watch-state badges inline (no network needed) so items like
+    // "Recently Added" reflect the latest tracker state immediately on return.
+    if (WatchStateOverlay.instance.hasActiveAuthority && _hubs.isNotEmpty) {
+      setState(() {
+        _hubs = _hubs
+            .map((h) => h.copyWith(items: applyOverlayAll(h.items)))
+            .toList();
+      });
+    }
   }
 
   // Public method to fully reload all content (for profile switches)
@@ -911,7 +1031,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
   void fullRefresh() {
     appLogger.d('DiscoverScreen.fullRefresh() called - reloading all content');
     // Reload all content including On Deck and content hubs
-    _loadContent();
+    _loadContent(forceRefresh: true);
   }
 
   /// Get icon for hub based on its title
@@ -1260,7 +1380,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                       FocusableAction(
                         icon: Symbols.refresh_rounded,
                         iconColor: foregroundColor,
-                        onPressed: _loadContent,
+                        onPressed: () => _loadContent(forceRefresh: true),
                       ),
                       // Watch Together
                       FocusableAction(
@@ -1418,10 +1538,46 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                   );
                 },
               ),
-              if (_isLoading) LoadingIndicatorBox.sliver,
-              if (_errorMessage != null) SliverErrorState(message: _errorMessage!, onRetry: _loadContent),
-              if (!_isLoading && _errorMessage == null) ...[
-                // On Deck / Continue Watching
+              if (_errorMessage != null) SliverErrorState(message: _errorMessage!, onRetry: () => _loadContent(forceRefresh: true)),
+              if (_errorMessage == null) ...[
+                // Continue Watching: skeleton while loading and nothing cached yet,
+                // content once items are available (from cache or network).
+                if (_isLoading && _onDeck.isEmpty)
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            width: 180,
+                            height: 24,
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.surfaceContainerHighest,
+                              borderRadius: const BorderRadius.all(Radius.circular(4)),
+                            ),
+                          ),
+                          const SizedBox(height: 16),
+                          SizedBox(
+                            height: 200,
+                            child: ListView.builder(
+                              scrollDirection: Axis.horizontal,
+                              physics: const NeverScrollableScrollPhysics(),
+                              itemCount: 4,
+                              itemBuilder: (_, _) => Container(
+                                margin: const EdgeInsets.only(right: 12),
+                                width: 140,
+                                decoration: BoxDecoration(
+                                  color: theme.colorScheme.surfaceContainerHighest,
+                                  borderRadius: BorderRadius.circular(tokens(context).radiusSm),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
                 if (_onDeck.isNotEmpty)
                   SliverToBoxAdapter(
                     child: HubSection(
@@ -1446,7 +1602,9 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                     ),
                   ),
 
-                // Recommendation Hubs (Trending, Top in Genre, etc.)
+                // Recommendation Hubs (Trending, Top in Genre, etc.) — load
+                // independently of Continue Watching so Recently Added appears
+                // immediately while CW is still resolving.
                 for (int i = 0; i < _hubs.length; i++)
                   SliverToBoxAdapter(
                     child: HubSection(
@@ -1502,7 +1660,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                       ),
                     ),
 
-                if (_onDeck.isEmpty && _hubs.isEmpty && !_areHubsLoading)
+                if (_onDeck.isEmpty && _hubs.isEmpty && !_areHubsLoading && !_isLoading)
                   SliverFillRemaining(
                     child: Center(
                       child: Column(
@@ -1597,7 +1755,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                   const SizedBox(height: 16),
                   Text(_errorMessage!),
                   const SizedBox(height: 16),
-                  FilledButton(onPressed: _loadContent, child: Text(t.common.retry)),
+                  FilledButton(onPressed: () => _loadContent(forceRefresh: true), child: Text(t.common.retry)),
                 ],
               ),
             ),
@@ -1807,9 +1965,12 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       hint: t.accessibility.tapToPlay,
       child: ClickableCursor(
         child: GestureDetector(
-          onTap: () {
+          onTap: () async {
             appLogger.d('Navigating to VideoPlayerScreen for: ${heroItem.title}');
-            navigateToVideoPlayer(context, metadata: heroItem);
+            final resolved = await resolveTrackerItemForAction(context, heroItem);
+            if (resolved != null && mounted) {
+              unawaited(navigateToVideoPlayer(context, metadata: resolved));
+            }
           },
           child: Stack(
             fit: StackFit.expand,
@@ -2088,9 +2249,11 @@ class _DiscoverScreenState extends State<DiscoverScreen>
         final backgroundColor = showFocus ? colorScheme.primary : Colors.white;
         final foregroundColor = showFocus ? colorScheme.onPrimary : Colors.black;
         return InkWell(
-          onTap: () {
+          onTap: () async {
             appLogger.d('Playing: ${heroItem.title}');
-            navigateToVideoPlayer(context, metadata: heroItem);
+            final resolved = await resolveTrackerItemForAction(context, heroItem);
+            if (!context.mounted || resolved == null) return;
+            unawaited(navigateToVideoPlayer(context, metadata: resolved));
           },
           borderRadius: BorderRadius.all(Radius.circular(isTv ? 32 : 24)),
           child: AnimatedContainer(

--- a/lib/screens/libraries/libraries_screen.dart
+++ b/lib/screens/libraries/libraries_screen.dart
@@ -20,6 +20,8 @@ import '../../media/media_server_client.dart';
 import '../../providers/hidden_libraries_provider.dart';
 import '../../providers/libraries_provider.dart';
 import '../../services/settings_service.dart';
+import '../../services/trackers/tracker_sync_notifier.dart';
+import '../../services/trackers/watch_state_overlay.dart';
 import '../../widgets/settings_builder.dart';
 import '../../utils/app_logger.dart';
 import '../../utils/dialogs.dart';
@@ -40,6 +42,7 @@ import 'tabs/library_browse_tab.dart';
 import 'tabs/library_recommended_tab.dart';
 import 'tabs/library_collections_tab.dart';
 import 'tabs/library_playlists_tab.dart';
+import 'tabs/library_tracker_playlists_tab.dart';
 
 enum LibraryTabType { recommended, browse, collections, playlists }
 
@@ -420,13 +423,30 @@ class _LibrariesScreenState extends State<LibrariesScreen>
         onDataLoaded: () => _handleTabDataLoaded(tabIndex),
         onBack: focusTabBar,
       ),
-      LibraryTabType.playlists => LibraryPlaylistsTab(
-        key: _playlistsTabKey,
-        library: library,
-        isActive: isActive,
-        suppressAutoFocus: suppressAutoFocus,
-        onDataLoaded: () => _handleTabDataLoaded(tabIndex),
-        onBack: focusTabBar,
+      LibraryTabType.playlists => ListenableBuilder(
+        // Rebuild on activate/deactivate so the tab swaps to the tracker's
+        // curated list (and back) without remounting the parent.
+        listenable: TrackerSyncNotifier.instance,
+        builder: (_, _) {
+          if (WatchStateOverlay.instance.hasActiveAuthority) {
+            return LibraryTrackerPlaylistsTab(
+              key: _playlistsTabKey,
+              library: library,
+              isActive: isActive,
+              suppressAutoFocus: suppressAutoFocus,
+              onDataLoaded: () => _handleTabDataLoaded(tabIndex),
+              onBack: focusTabBar,
+            );
+          }
+          return LibraryPlaylistsTab(
+            key: _playlistsTabKey,
+            library: library,
+            isActive: isActive,
+            suppressAutoFocus: suppressAutoFocus,
+            onDataLoaded: () => _handleTabDataLoaded(tabIndex),
+            onBack: focusTabBar,
+          );
+        },
       ),
     };
   }

--- a/lib/screens/libraries/tabs/library_browse_tab.dart
+++ b/lib/screens/libraries/tabs/library_browse_tab.dart
@@ -57,8 +57,10 @@ import '../../../utils/global_key_utils.dart';
 import '../../../utils/watch_state_notifier.dart';
 import '../../../utils/platform_detector.dart';
 import '../../../i18n/strings.g.dart';
+import '../../../mixins/tracker_sync_aware.dart';
 import '../../main_screen.dart';
 import 'base_library_tab.dart';
+import '../../../services/trackers/watch_state_overlay.dart';
 
 /// Browse tab for library screen
 /// Shows library items with grouping, filtering, and sorting
@@ -90,6 +92,7 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
         LibraryTabFocusMixin,
         GridFocusNodeMixin,
         WatchStateAware,
+        TrackerSyncAware,
         DeletionAware,
         PaginatedItemLoader<MediaItem, LibraryBrowseTab> {
   @override
@@ -336,6 +339,21 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
     _isScrollActive.dispose();
     disposeGridFocusNodes();
     super.dispose();
+  }
+
+  @override
+  void onTrackerSyncChanged() {
+    if (loadedItems.isEmpty) return;
+    if (!hasTrackerAuthority) {
+      unawaited(loadItems());
+      return;
+    }
+    setState(() {
+      for (final key in loadedItems.keys.toList()) {
+        final item = loadedItems[key];
+        if (item != null) loadedItems[key] = applyOverlay(item);
+      }
+    });
   }
 
   // Override tryFocus to use loadedItems instead of base class items list
@@ -652,11 +670,20 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
       offset: start,
       limit: size,
     );
-    return client.fetchLibraryPagedContent(
+    final page = await client.fetchLibraryPagedContent(
       widget.library.id,
       query: query,
       libraryKind: widget.library.kind,
       abort: abort,
+    );
+    return LibraryPage(
+      items: WatchStateOverlay.instance.applyAll(
+        page.items.map((item) {
+          return item.copyWith(serverId: widget.library.serverId, serverName: widget.library.serverName);
+        }).toList(),
+      ),
+      totalCount: page.totalCount,
+      offset: page.offset,
     );
   }
 

--- a/lib/screens/libraries/tabs/library_recommended_tab.dart
+++ b/lib/screens/libraries/tabs/library_recommended_tab.dart
@@ -7,8 +7,10 @@ import '../../../i18n/strings.g.dart';
 import '../../../media/media_hub.dart';
 import '../../../media/media_item.dart';
 import '../../../mixins/item_updatable.dart';
+import '../../../mixins/tracker_sync_aware.dart';
 import '../../../mixins/watch_state_aware.dart';
 import '../../../services/settings_service.dart';
+import '../../../services/trackers/watch_state_overlay.dart';
 import '../../../utils/global_key_utils.dart';
 import '../../../utils/layout_constants.dart';
 import '../../../utils/platform_detector.dart';
@@ -41,7 +43,7 @@ class LibraryRecommendedTab extends BaseLibraryTab<MediaHub> {
 }
 
 class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryRecommendedTab>
-    with ItemUpdatable, WatchStateAware {
+    with ItemUpdatable, WatchStateAware, TrackerSyncAware {
   /// GlobalKeys for each hub section to enable vertical navigation
   final List<GlobalKey<HubSectionState>> _hubKeys = [];
   final _tvBrowseRailKey = GlobalKey<TvBrowseRailState>();
@@ -66,6 +68,20 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
   void _setSpotlightItem(MediaItem item) {
     if (_spotlightItem?.globalKey == item.globalKey) return;
     setState(() => _spotlightItem = item);
+  }
+
+  @override
+  void onTrackerSyncChanged() {
+    if (items.isEmpty) return;
+    if (!hasTrackerAuthority) {
+      unawaited(loadItems());
+      return;
+    }
+    setState(() {
+      items = items
+          .map((hub) => hub.copyWith(items: applyOverlayAll(hub.items)))
+          .toList();
+    });
   }
 
   @override
@@ -189,14 +205,37 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
             ),
           );
 
+    // Apply watch state authority (Trakt, etc.) and server info.
+    // When Trakt authority is active: Continue Watching shows only items with
+    // Trakt in-progress data; Recently Watched shows only items Trakt has any
+    // record for. Items not in Trakt are excluded from both hubs.
+    final overlay = WatchStateOverlay.instance;
+    final overlaidHubs = hubs
+        .map((hub) {
+          final processedItems = hub.items
+              .map((item) => item.copyWith(serverId: widget.library.serverId, serverName: widget.library.serverName))
+              .toList();
+
+          // For Continue Watching hubs, filter to tracker-known items only when
+          // the tracker is the authority — prevents Plex-only in-progress items
+          // from leaking through when Trakt is managing watch state.
+          final overlaidItems = _isContinueWatchingHub(hub)
+              ? overlay.applyAllContinueWatching(processedItems)
+              : overlay.applyAll(processedItems);
+
+          return hub.copyWith(items: overlaidItems);
+        })
+        .where((hub) => hub.items.isNotEmpty)
+        .toList();
+
     // Move Continue Watching hub to the front if present
-    final cwIndex = hubs.indexWhere(_isContinueWatchingHub);
+    final cwIndex = overlaidHubs.indexWhere(_isContinueWatchingHub);
     if (cwIndex > 0) {
-      final cwHub = hubs.removeAt(cwIndex);
-      hubs.insert(0, cwHub);
+      final cwHub = overlaidHubs.removeAt(cwIndex);
+      overlaidHubs.insert(0, cwHub);
     }
 
-    return hubs;
+    return overlaidHubs;
   }
 
   /// Ensure we have enough GlobalKeys for all hubs

--- a/lib/screens/libraries/tabs/library_tracker_playlists_tab.dart
+++ b/lib/screens/libraries/tabs/library_tracker_playlists_tab.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../../../media/media_item.dart';
+import '../../../mixins/library_tab_focus_mixin.dart';
+import '../../../mixins/tracker_sync_aware.dart';
+import '../../../providers/multi_server_provider.dart';
+import '../../../services/plex_client.dart';
+import '../../../services/settings_service.dart';
+import '../../../services/trackers/watch_state_overlay.dart';
+import '../../../utils/grid_size_calculator.dart';
+import '../../../utils/layout_constants.dart';
+import '../../../widgets/focusable_media_card.dart';
+import '../../../widgets/media_grid_delegate.dart';
+import '../../../widgets/settings_builder.dart';
+import '../../../i18n/strings.g.dart';
+import '../../main_screen.dart';
+import 'base_library_tab.dart';
+
+/// Variant of the Playlists tab shown when a tracker watch-state authority is
+/// active. Renders the authority's primary curated list (e.g. Trakt watchlist,
+/// MAL/AniList "Plan to Watch") instead of Plex playlists — the parent screen
+/// swaps this widget in based on [SettingsService.trackerStateAuthority]. No
+/// pagination, no skeletons; the overlay returns an eager list resolved
+/// against the available Plex clients.
+class LibraryTrackerPlaylistsTab extends BaseLibraryTab<MediaItem> {
+  const LibraryTrackerPlaylistsTab({
+    super.key,
+    required super.library,
+    super.viewMode,
+    super.density,
+    super.onDataLoaded,
+    super.isActive,
+    super.suppressAutoFocus,
+    super.onBack,
+  });
+
+  @override
+  State<LibraryTrackerPlaylistsTab> createState() => _LibraryTrackerPlaylistsTabState();
+}
+
+class _LibraryTrackerPlaylistsTabState extends BaseLibraryTabState<MediaItem, LibraryTrackerPlaylistsTab>
+    with LibraryTabFocusMixin<LibraryTrackerPlaylistsTab>, TrackerSyncAware<LibraryTrackerPlaylistsTab> {
+  @override
+  String get focusNodeDebugLabel => 'tracker_playlists_first_item';
+
+  @override
+  int get itemCount => items.length;
+
+  @override
+  IconData get emptyIcon => Symbols.playlist_play_rounded;
+
+  @override
+  String get emptyMessage => t.playlists.noPlaylists;
+
+  @override
+  String get errorContext => t.playlists.title;
+
+  @override
+  Future<List<MediaItem>> loadData() => WatchStateOverlay.instance.getAuthorityListItems(_plexClients());
+
+  @override
+  void onTrackerSyncChanged() {
+    unawaited(loadItems());
+  }
+
+  Map<String, PlexClient> _plexClients() {
+    final manager = context.read<MultiServerProvider>().serverManager;
+    return Map.fromEntries(
+      manager.onlineClients.entries
+          .where((e) => e.value is PlexClient)
+          .map((e) => MapEntry(e.key, e.value as PlexClient)),
+    );
+  }
+
+  @override
+  Widget buildContent(List<MediaItem> items) {
+    return SettingsBuilder(
+      prefs: const [SettingsService.viewMode, SettingsService.libraryDensity],
+      builder: (context) {
+        final settings = SettingsService.instanceOrNull!;
+        final viewMode = settings.read(SettingsService.viewMode);
+        final density = settings.read(SettingsService.libraryDensity);
+        return CustomScrollView(
+          clipBehavior: Clip.none,
+          slivers: [
+            SliverOverlapInjector(handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context)),
+            if (viewMode == ViewMode.list) _buildListSliver(items) else _buildGridSliver(items, density),
+          ],
+        );
+      },
+    );
+  }
+
+  static const double _focusDecorationPadding = 3.0;
+
+  EdgeInsets get _effectivePadding {
+    final base = GridLayoutConstants.gridPadding;
+    return base.copyWith(top: base.top + _focusDecorationPadding);
+  }
+
+  Widget _buildListSliver(List<MediaItem> data) {
+    return SliverPadding(
+      padding: _effectivePadding,
+      sliver: SliverList.builder(
+        itemCount: data.length,
+        itemBuilder: (context, index) => _buildItemCard(data, index, isFirstColumn: true, disableScale: true),
+      ),
+    );
+  }
+
+  Widget _buildGridSliver(List<MediaItem> data, int density) {
+    return SliverPadding(
+      padding: _effectivePadding,
+      sliver: SliverLayoutBuilder(
+        builder: (context, constraints) {
+          final maxCrossAxisExtent = GridSizeCalculator.getMaxCrossAxisExtent(context, density);
+          final columnCount = GridSizeCalculator.getColumnCount(constraints.crossAxisExtent, maxCrossAxisExtent);
+          return SliverGrid.builder(
+            gridDelegate: MediaGridDelegate.createDelegate(context: context, density: density),
+            itemCount: data.length,
+            itemBuilder: (context, index) =>
+                _buildItemCard(data, index, isFirstColumn: GridSizeCalculator.isFirstColumn(index, columnCount)),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildItemCard(List<MediaItem> data, int index, {required bool isFirstColumn, bool disableScale = false}) {
+    final item = data[index];
+    return FocusableMediaCard(
+      key: Key(item.id),
+      item: item,
+      focusNode: index == 0 ? firstItemFocusNode : null,
+      disableScale: disableScale,
+      onListRefresh: loadItems,
+      onBack: widget.onBack,
+      onNavigateLeft: isFirstColumn ? _navigateToSidebar : null,
+    );
+  }
+
+  void _navigateToSidebar() {
+    MainScreenFocusScope.of(context, listen: false)?.focusSidebar();
+  }
+}

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -33,6 +33,7 @@ import '../i18n/strings.g.dart';
 import '../widgets/optimized_media_image.dart';
 import '../utils/media_image_helper.dart';
 import '../services/plex_client.dart';
+import '../services/plex_api_cache.dart';
 import '../media/media_server_client.dart';
 import '../services/media_list_playback_launcher.dart';
 import '../utils/content_utils.dart';
@@ -61,6 +62,7 @@ import '../widgets/horizontal_scroll_with_arrows.dart';
 import '../widgets/media_context_menu.dart';
 import '../widgets/overlay_sheet.dart';
 import '../widgets/placeholder_container.dart';
+import '../mixins/tracker_sync_aware.dart';
 import '../mixins/watch_state_aware.dart';
 import '../mixins/deletion_aware.dart';
 import '../mixins/mounted_set_state_mixin.dart';
@@ -75,6 +77,7 @@ import '../widgets/focusable_tab_chip.dart';
 import '../widgets/hub_section.dart';
 import '../widgets/ios_status_bar_tap_scroll_to_top.dart';
 import '../widgets/loading_indicator_box.dart';
+import '../services/trackers/watch_state_overlay.dart';
 import '../widgets/tv_browse_rail.dart';
 import '../widgets/tv_spotlight_background.dart';
 
@@ -124,7 +127,7 @@ PageRoute<bool> mediaDetailRoute({required MediaItem metadata, bool isOffline = 
 }
 
 class _MediaDetailScreenState extends State<MediaDetailScreen>
-    with WatchStateAware, DeletionAware, MountedSetStateMixin, ServerBoundMediaMixin, RouteAware {
+    with TrackerSyncAware, WatchStateAware, DeletionAware, MountedSetStateMixin, ServerBoundMediaMixin, RouteAware {
   /// Public input alias — used as the live source of truth until the detail
   /// fetch returns. Holds backend-neutral [MediaItem] data.
   MediaItem get _metadata => _fullMetadata ?? widget.metadata;
@@ -155,6 +158,11 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   bool _suppressBackAfterPop = false;
   bool _tvDetailRevealed = false;
   bool _tvDetailRevealScheduled = false;
+  // Captured by onPlaybackExit when the player pops; consumed once by
+  // _refreshFromLocalPlex. Instance-scoped so two MediaDetailScreens (PiP,
+  // multi-window) do not stomp on each other's exit state.
+  int? _pendingExitViewOffset;
+  String? _pendingExitRatingKey;
   bool _hasLoadedSeasons = false;
   bool _hasLoadedEpisodes = false;
   double? _tvDetailPendingRailHeight;
@@ -188,6 +196,16 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   bool _isSelectKeyDown = false;
   bool _longPressTriggered = false;
   static const _longPressDuration = Duration(milliseconds: 500);
+  MediaItem? _rawMetadata;
+  List<MediaItem> _rawSeasons = [];
+  // After post-playback, tracks the season/episode of the most-recently-played episode.
+  // _applyTrackerUpNextToOnDeck won't regress _onDeckEpisode behind this position, preventing
+  // Trakt's "up next" from overwriting a later episode the user just watched.
+  int? _postPlaybackMinSeason;
+  int? _postPlaybackMinEpisode;
+  // Guard against concurrent _applyTrackerUpNextToOnDeck calls — prevents multiple
+  // simultaneous getAllLeaves (Strategy 2) HTTP requests for the same show.
+  bool _isApplyingUpNext = false;
 
   // Context menu key for the three-dots button
   final _contextMenuKey = GlobalKey<MediaContextMenuState>();
@@ -660,13 +678,17 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       final metadata = result.item;
       final onDeckEpisode = result.onDeckEpisode;
       if (metadata != null) {
-        final refreshedMetadata = _applyLocalProgress(
-          _withFallbackLibrary(
-            metadata.copyWith(serverId: serverId, serverName: serverName ?? metadata.serverName),
-            _metadata,
+        final refreshedMetadata = WatchStateOverlay.instance.apply(
+          _applyLocalProgress(
+            _withFallbackLibrary(
+              metadata.copyWith(serverId: serverId, serverName: serverName ?? metadata.serverName),
+              _metadata,
+            ),
           ),
         );
-        final refreshedOnDeck = onDeckEpisode == null
+        final refreshedOnDeck = WatchStateOverlay.instance.hasActiveAuthority
+            ? null
+            : onDeckEpisode == null
             ? null
             : _applyLocalProgress(
                 _withFallbackLibrary(
@@ -715,6 +737,20 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
     if (_route != null) routeObserver.unsubscribe(this);
     _route = route;
     routeObserver.subscribe(this, route);
+  }
+
+  @override
+  void onTrackerSyncChanged() {
+    setStateIfMounted(() {
+      if (_rawMetadata != null) _fullMetadata = applyOverlay(_rawMetadata!);
+      if (_onDeckEpisode != null) _onDeckEpisode = applyOverlay(_onDeckEpisode!);
+      _seasons = applyOverlayAll(_rawSeasons.isNotEmpty ? _rawSeasons : _seasons);
+      if (_episodes.isNotEmpty) _episodes = applyOverlayAll(_episodes);
+    });
+    _episodeCache.clear();
+    if (hasTrackerAuthority) {
+      unawaited(_applyTrackerUpNextToOnDeck());
+    }
   }
 
   @override
@@ -814,6 +850,130 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
         ),
       ),
     );
+  }
+
+  /// Post-playback refresh: shows Plex's fresh local data immediately without
+  /// applying the tracker overlay. The overlay is re-applied by _onTrackerSyncChanged
+  /// once the post-playback tracker sync completes (~2 s later).
+  /// For offline mode, reads from PlexApiCache so cached state is shown.
+  Future<void> _refreshFromLocalPlex() async {
+    final exitOffset = _pendingExitViewOffset;
+    final playedRatingKey = _pendingExitRatingKey;
+    _pendingExitViewOffset = null;
+    _pendingExitRatingKey = null;
+
+    appLogger.d('[played_refresh] exitOffset=$exitOffset key=$playedRatingKey');
+
+    try {
+      MediaItem? rawMeta;
+      MediaItem? rawOnDeck;
+
+      if (widget.isOffline) {
+        rawMeta = await PlexApiCache.instance.getMetadata(widget.metadata.serverId ?? '', widget.metadata.id);
+      } else {
+        final client = _getMediaClientForMetadata(context);
+        if (client == null) {
+          appLogger.w('[played_refresh] no client — aborting');
+          return;
+        }
+        final result = await client.fetchItemWithOnDeck(_metadata.id);
+        final meta = result.item;
+        final fetchedOnDeck = result.onDeckEpisode;
+        if (meta != null) {
+          rawMeta = meta.copyWith(serverId: widget.metadata.serverId, serverName: widget.metadata.serverName);
+        } else {
+          appLogger.w('[played_refresh] Plex returned null show metadata');
+        }
+        if (fetchedOnDeck != null) {
+          rawOnDeck = fetchedOnDeck.copyWith(
+            serverId: widget.metadata.serverId,
+            serverName: widget.metadata.serverName,
+          );
+        }
+      }
+
+      if (!mounted) return;
+
+      if (exitOffset != null) {
+        rawMeta = (rawMeta ?? _rawMetadata ?? _fullMetadata ?? widget.metadata).copyWith(viewOffsetMs: exitOffset);
+
+        if (widget.metadata.isShow) {
+          MediaItem? playedEpisode;
+
+          if (playedRatingKey != null) {
+            if (playedRatingKey == _onDeckEpisode?.id) {
+              playedEpisode = _onDeckEpisode;
+            } else {
+              // 1. Loaded episodes for current season
+              playedEpisode = _episodes.where((e) => e.id == playedRatingKey).firstOrNull;
+
+              // 2. Episode cache (other seasons fetched this session)
+              if (playedEpisode == null) {
+                for (final eps in _episodeCache.values) {
+                  playedEpisode = eps.where((e) => e.id == playedRatingKey).firstOrNull;
+                  if (playedEpisode != null) break;
+                }
+              }
+              // 3. Plex's returned on-deck if it's the same episode — critical
+              //    when _onDeckEpisode=null (Trakt authority) and _episodes is empty
+              if (playedEpisode == null && rawOnDeck?.id == playedRatingKey) {
+                playedEpisode = rawOnDeck;
+              }
+              // 4. Last resort
+              playedEpisode ??= _onDeckEpisode;
+            }
+          } else {
+            playedEpisode = _onDeckEpisode;
+          }
+
+          if (playedEpisode != null) {
+            final base = (rawOnDeck?.id == playedEpisode.id) ? rawOnDeck! : playedEpisode;
+            rawOnDeck = base.copyWith(viewOffsetMs: exitOffset);
+          } else {
+            appLogger.w('[played_refresh] playedEpisode=null — cannot apply exit offset to onDeck');
+          }
+        }
+      }
+
+      if (rawMeta == null) {
+        appLogger.w('[played_refresh] rawMeta=null — aborting without UI update');
+        return;
+      }
+      _rawMetadata = rawMeta;
+      setStateIfMounted(() {
+        _fullMetadata = rawMeta;
+        if (widget.metadata.isShow && rawOnDeck != null) {
+          _onDeckEpisode = rawOnDeck;
+          _postPlaybackMinSeason = rawOnDeck.parentIndex;
+          _postPlaybackMinEpisode = rawOnDeck.index;
+        }
+      });
+
+      if (!widget.isOffline && widget.metadata.isShow) {
+        final client = _getMediaClientForMetadata(context);
+        if (client == null) return;
+        final seasons = await client.fetchChildren(_metadata.id);
+        if (!mounted) return;
+        final rawSeasons = seasons
+            .map((s) => s.copyWith(serverId: widget.metadata.serverId, serverName: widget.metadata.serverName))
+            .toList();
+        _rawSeasons = rawSeasons;
+        setStateIfMounted(() {
+          _seasons = rawSeasons;
+          _episodeCache.clear();
+        });
+        if (!_showEpisodesDirectly && _seasons.isNotEmpty) {
+          unawaited(_fetchSeasonEpisodes(_selectedSeasonIndex));
+        }
+        if (WatchStateOverlay.instance.hasActiveAuthority) {
+          unawaited(_applyTrackerUpNextToOnDeck());
+        }
+      }
+
+      appLogger.d('[played_refresh] done — onDeck="${_onDeckEpisode?.title}" viewOffsetMs=${_onDeckEpisode?.viewOffsetMs}');
+    } catch (e, st) {
+      appLogger.e('[played_refresh] ✖ ERROR — stale data kept', error: e, stackTrace: st);
+    }
   }
 
   @override
@@ -967,6 +1127,21 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
     // User rating chip (tappable)
     if (!widget.isOffline) {
       chips.add(_buildUserRatingChip(metadata));
+    }
+
+    // Tracker sync indicator — only when a tracker authority is active.
+    final trackerName = WatchStateOverlay.instance.activeTrackerName;
+    if (trackerName != null) {
+      final isSynced = WatchStateOverlay.instance.hasTrackerRecord(metadata);
+      final hasWatchData =
+          (metadata.viewCount ?? 0) > 0 ||
+          (metadata.viewedLeafCount ?? 0) > 0 ||
+          (metadata.viewOffsetMs ?? 0) > 0;
+      if (isSynced) {
+        chips.add(_buildMetadataChip(trackerName, icon: Symbols.cloud_done_rounded));
+      } else if (hasWatchData) {
+        chips.add(_buildMetadataChip('Not in $trackerName', icon: Symbols.cloud_off_rounded));
+      }
     }
 
     return chips;
@@ -1361,9 +1536,12 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
               ),
             );
 
+      _rawMetadata = base;
+      await WatchStateOverlay.instance.cacheReady;
+      if (!mounted) return;
       setState(() {
-        _fullMetadata = base;
-        _onDeckEpisode = onDeckWithServerId;
+        _fullMetadata = WatchStateOverlay.instance.apply(base);
+        _onDeckEpisode = WatchStateOverlay.instance.hasActiveAuthority ? null : onDeckWithServerId;
         _isLoadingMetadata = false;
       });
 
@@ -1428,13 +1606,26 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       final prefsFuture = (client is PlexClient && sectionId != null)
           ? client.getLibrarySectionPrefs(sectionId)
           : Future.value(<String, dynamic>{});
+      // Fire Trakt deep-fetch in the background — completion data refreshes
+      // episode checkmarks after episodes are already rendered, not before.
+      // The up-next position (for the play button) comes from cached stubs, so
+      // _applyTrackerUpNextToOnDeck() doesn't need to wait for this.
+      unawaited(
+        WatchStateOverlay.instance.fetchShowProgressIfNeeded(_fullMetadata ?? widget.metadata).then((newData) {
+          if (!newData || !mounted) return;
+          // New episode completion data arrived — clear episode cache and
+          // re-render the visible season with updated checkmarks/progress.
+          _episodeCache.clear();
+          unawaited(_fetchSeasonEpisodes(_selectedSeasonIndex));
+        }),
+      );
 
       final results = await Future.wait([seasonsFuture, prefsFuture]);
       final seasons = results[0] as List<MediaItem>;
       final prefs = results[1] as Map<String, dynamic>;
 
       // Preserve serverId for each season.
-      final seasonsWithServerId = seasons
+      final rawSeasons = seasons
           .map(
             (season) => _withFallbackLibrary(
               season.copyWith(serverId: serverId, serverName: _metadata.serverName ?? season.serverName),
@@ -1442,6 +1633,8 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
             ),
           )
           .toList();
+      _rawSeasons = rawSeasons;
+      final seasonsWithServerId = WatchStateOverlay.instance.applyAll(rawSeasons);
 
       // Plex can override the library season mode per show; Jellyfin falls
       // through to "flatten when there's a single season".
@@ -1481,6 +1674,9 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
           unawaited(_fetchSeasonEpisodes(onDeckSeasonIndex));
         }
       }
+
+      // If Trakt authority is active, replace Plex's on-deck with Trakt's up-next.
+      unawaited(_applyTrackerUpNextToOnDeck());
     } catch (e, st) {
       appLogger.w('Seasons load failed', error: e, stackTrace: st);
       setStateIfMounted(() {
@@ -1604,6 +1800,14 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       final idx = seasons.indexWhere((s) => s.index == widget.initialSeasonIndex);
       if (idx != -1) return idx;
     }
+    // When Trakt is the authority, use its up-next position to pre-select the right season.
+    if (WatchStateOverlay.instance.hasActiveAuthority) {
+      final pos = WatchStateOverlay.instance.getUpNextPosition(widget.metadata.id);
+      if (pos != null && seasons.isNotEmpty) {
+        final idx = seasons.indexWhere((s) => s.index == pos.season);
+        if (idx != -1) return idx;
+      }
+    }
     // Fall back to on-deck episode's season
     final onDeckEpisode = _onDeckEpisode;
     if (onDeckEpisode != null && seasons.isNotEmpty) {
@@ -1631,6 +1835,140 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   MediaItem? _defaultPlaybackSeason(List<MediaItem> seasons) {
     if (seasons.isEmpty) return null;
     return seasons[_defaultPlaybackSeasonIndex(seasons)];
+  }
+
+  /// Replaces Plex's on-deck episode with Trakt's up-next when authority is active.
+  ///
+  /// Plex on-deck can lag behind the active tracker (e.g. Plex shows S2E2, tracker knows S2E5).
+  /// Searches the already-fetched episode list for the tracker's up-next position.
+  /// Also switches the selected season tab if needed.
+  Future<void> _applyTrackerUpNextToOnDeck() async {
+    if (_isApplyingUpNext) return;
+    if (!WatchStateOverlay.instance.hasActiveAuthority) return;
+    _isApplyingUpNext = true;
+    try {
+      await _doApplyTrackerUpNextToOnDeck();
+    } finally {
+      _isApplyingUpNext = false;
+    }
+  }
+
+  Future<void> _doApplyTrackerUpNextToOnDeck() async {
+    if (!WatchStateOverlay.instance.hasActiveAuthority) return;
+    // Short-circuit: if _onDeckEpisode already matches the CW stub's resolved S/E,
+    // skip the full getUpNextPosition() + episode search pipeline.
+    if (_onDeckEpisode != null) {
+      final cwItem = WatchStateOverlay.instance
+          .getContinueWatchingItems()
+          .where((i) => i.metadata.grandparentId == widget.metadata.id)
+          .firstOrNull;
+      if (cwItem != null &&
+          cwItem.metadata.parentIndex == _onDeckEpisode!.parentIndex &&
+          cwItem.metadata.index == _onDeckEpisode!.index) {
+        return;
+      }
+    }
+    final pos = WatchStateOverlay.instance.getUpNextPosition(widget.metadata.id);
+    appLogger.d(
+      '_applyTrackerUpNextToOnDeck: showId=${widget.metadata.id} pos=$pos '
+      '_episodes=${_episodes.length} _episodeCache.keys=${_episodeCache.keys.toList()}',
+    );
+    if (pos == null) return;
+
+    // Strategy 1: S/E index — fast, works when Trakt and Plex numbering agree.
+    MediaItem? target = _episodes.where((e) => e.parentIndex == pos.season && e.index == pos.episode).firstOrNull;
+    if (target != null) {
+      appLogger.d('_applyTrackerUpNextToOnDeck: Strategy1 hit S${target.parentIndex}E${target.index} (${target.id}) offset=${target.viewOffsetMs} durationMs=${target.durationMs}');
+    }
+
+    // Also check cached episodes for other seasons.
+    if (target == null) {
+      for (final eps in _episodeCache.values) {
+        final hit = eps.where((e) => e.parentIndex == pos.season && e.index == pos.episode);
+        if (hit.isNotEmpty) {
+          target = hit.first;
+          appLogger.d('_applyTrackerUpNextToOnDeck: Strategy1-cache hit S${target.parentIndex}E${target.index} (${target.id}) offset=${target.viewOffsetMs}');
+          break;
+        }
+      }
+    }
+
+    // Strategy 2: ID match via getAllLeaves — used when S/E index finds nothing
+    // and episode IDs are available. Handles shows where Trakt and Plex use
+    // different numbering (e.g. Dan Da Dan S1E15 on Trakt = Plex S2E3).
+    if (target == null && widget.isOffline) return;
+    if (target == null && (pos.tvdb != null || pos.tmdb != null)) {
+      appLogger.d('_applyTrackerUpNextToOnDeck: Strategy2 — getAllLeaves tvdb=${pos.tvdb} tmdb=${pos.tmdb}');
+      final plexClient = getServerBoundPlexClient(context);
+      if (plexClient != null) {
+        final leaves = await plexClient.getAllLeaves(widget.metadata.id);
+        if (!mounted) return;
+        for (final ep in leaves) {
+          final guids = (ep.raw?['Guid'] as List? ?? [])
+              .map((g) => (g as Map?)?['id'] as String?)
+              .whereType<String>();
+          if (pos.tvdb != null && guids.contains('tvdb://${pos.tvdb}')) {
+            target = ep;
+            break;
+          }
+          if (pos.tmdb != null && guids.contains('tmdb://${pos.tmdb}')) {
+            target = ep;
+            break;
+          }
+        }
+        appLogger.d(
+          '_applyTrackerUpNextToOnDeck: Strategy2 result — '
+          '${target == null ? "NOT FOUND" : "found S${target.parentIndex}E${target.index} (${target.id}) offset=${target.viewOffsetMs}"}',
+        );
+      } else {
+        appLogger.d('_applyTrackerUpNextToOnDeck: Strategy2 skipped — no plexClient');
+      }
+    } else if (target == null) {
+      appLogger.d('_applyTrackerUpNextToOnDeck: Strategy2 skipped — pos.tvdb=${pos.tvdb} pos.tmdb=${pos.tmdb}');
+    }
+
+    if (target == null) {
+      // Season not yet loaded — trigger a fetch so this method is retried.
+      final newSeasonIdx = _seasons.indexWhere((s) => s.index == pos.season);
+      appLogger.d('_applyTrackerUpNextToOnDeck: target null — newSeasonIdx=$newSeasonIdx seasons=${_seasons.map((s) => s.index).toList()}');
+      if (newSeasonIdx != -1 && _episodeCache[_seasons[newSeasonIdx].id] == null) {
+        unawaited(_fetchSeasonEpisodes(newSeasonIdx));
+      }
+      return;
+    }
+    // Don't regress _onDeckEpisode behind the episode the user most recently
+    // played. Trakt's "up next" returns the first unwatched episode, which
+    // can be earlier than what the user just watched (e.g. user skips from
+    // S3E3 to S3E4 while S3E3 still has progress).
+    if (_postPlaybackMinSeason != null && _postPlaybackMinEpisode != null) {
+      final ts = target.parentIndex ?? 0;
+      final te = target.index ?? 0;
+      if (ts < _postPlaybackMinSeason! || (ts == _postPlaybackMinSeason && te < _postPlaybackMinEpisode!)) return;
+    }
+
+    // Switch season tab to Trakt's season if needed.
+    final newSeasonIdx = _seasons.indexWhere((s) => s.index == pos.season);
+
+    final t = target;
+    final overlaid = hasTrackerAuthority ? applyOverlay(t) : t;
+    appLogger.d(
+      '_applyTrackerUpNextToOnDeck: setting onDeck → S${overlaid.parentIndex}E${overlaid.index} '
+      '(${overlaid.id}) offset_before=${t.viewOffsetMs} offset_after=${overlaid.viewOffsetMs}',
+    );
+    setStateIfMounted(() {
+      // Apply Trakt overlay before setting as on-deck: ensures Trakt's resume
+      // offset is used, not Plex's raw viewOffsetMs. Critical when target came
+      // from getAllLeaves (Strategy 2 — raw Plex episode, no overlay applied).
+      _onDeckEpisode = overlaid;
+      if (newSeasonIdx != -1 && newSeasonIdx != _selectedSeasonIndex) {
+        _selectedSeasonIndex = newSeasonIdx;
+      }
+    });
+
+    // Fetch episodes for the new season if not already loaded.
+    if (newSeasonIdx != -1 && _episodeCache[_seasons[newSeasonIdx].id] == null) {
+      unawaited(_fetchSeasonEpisodes(newSeasonIdx));
+    }
   }
 
   /// Fetch episodes for a specific season by index, using cache when available
@@ -1698,7 +2036,13 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
             )
             .map(_applyLocalProgress)
             .toList();
-        _completeSeasonEpisodesLoad(seasonIndex: seasonIndex, seasonId: seasonId, episodes: episodesWithServerId);
+        final overlaidEpisodes = applyOverlayAll(episodesWithServerId);
+        _episodeCache[season.id] = overlaidEpisodes;
+        setStateIfMounted(() {
+          _episodes = List.of(overlaidEpisodes);
+          _isLoadingSeasonEpisodes = false;
+        });
+        unawaited(_applyTrackerUpNextToOnDeck());
       }
     } catch (e) {
       _completeSeasonEpisodesLoad(seasonIndex: seasonIndex, seasonId: seasonId, episodes: const <MediaItem>[]);
@@ -2636,8 +2980,9 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       final firstPage = await client.fetchPlayableDescendantsPage(_metadata.id, start: 0, size: _episodesPageSize);
       if (!mounted || generation != _episodesLoadGeneration) return;
       final enriched = _enrichPlayableEpisodes(firstPage.items, serverId);
+      final overlaid = applyOverlayAll(enriched);
       setStateIfMounted(() {
-        _episodes = enriched;
+        _episodes = overlaid;
         _isLoadingEpisodes = false;
         _isLoadingAllEpisodes = firstPage.items.length < firstPage.totalCount;
         _hasLoadedEpisodes = true;
@@ -2694,8 +3039,9 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
         if (!mounted || generation != _episodesLoadGeneration) return;
         if (page.items.isEmpty) break;
         final enriched = _enrichPlayableEpisodes(page.items, serverId);
+        final overlaid = applyOverlayAll(enriched);
         setStateIfMounted(() {
-          _episodes.addAll(enriched);
+          _episodes.addAll(overlaid);
         });
         offset += page.items.length;
         total = page.totalCount;
@@ -2790,7 +3136,11 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
           context,
           metadata: episodeWithServerId,
           isOffline: widget.isOffline,
-          onRefresh: _loadFullMetadata,
+          onPlaybackExit: (offset, ratingKey) {
+            _pendingExitViewOffset = offset;
+            _pendingExitRatingKey = ratingKey;
+          },
+          onRefresh: _refreshFromLocalPlex,
         );
       }
     } catch (e) {
@@ -4090,6 +4440,6 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       }
     }
 
-    return Symbols.play_arrow_rounded; // Default play icon
+    return Symbols.play_arrow_rounded;
   }
 }

--- a/lib/screens/settings/tracker_account_settings_body.dart
+++ b/lib/screens/settings/tracker_account_settings_body.dart
@@ -35,6 +35,12 @@ class TrackerAccountSettingsBody extends StatelessWidget {
   final String? accountSubtitle;
   final TrackerService service;
   final List<TrackerSettingsToggle> toggles;
+  /// Rendered immediately after the "Behavior" section header, before
+  /// [toggles]. Used by per-tracker screens to surface their primary setting
+  /// (e.g. Trakt's watch-state authority toggle) above the standard
+  /// scrobble/sync toggles.
+  final List<Widget> prefixChildren;
+  final List<Widget> extraChildren;
   final FutureOr<void> Function() onDisconnect;
 
   const TrackerAccountSettingsBody({
@@ -44,6 +50,8 @@ class TrackerAccountSettingsBody extends StatelessWidget {
     this.accountSubtitle,
     required this.service,
     required this.toggles,
+    this.prefixChildren = const [],
+    this.extraChildren = const [],
     required this.onDisconnect,
   });
 
@@ -58,6 +66,7 @@ class TrackerAccountSettingsBody extends StatelessWidget {
           subtitle: accountSubtitle != null ? Text(accountSubtitle!) : null,
         ),
         SettingsSectionHeader(t.settings.behavior),
+        ...prefixChildren,
         for (final toggle in toggles)
           SettingSwitchTile(
             pref: toggle.pref,
@@ -81,6 +90,7 @@ class TrackerAccountSettingsBody extends StatelessWidget {
             );
           },
         ),
+        ...extraChildren,
         const Divider(height: 32),
         ListTile(
           leading: AppIcon(Symbols.link_off_rounded, fill: 1, color: Theme.of(context).colorScheme.error),

--- a/lib/screens/settings/trackers_settings_screen.dart
+++ b/lib/screens/settings/trackers_settings_screen.dart
@@ -6,6 +6,8 @@ import 'package:provider/provider.dart';
 import '../../i18n/strings.g.dart';
 import '../../providers/trackers_provider.dart';
 import '../../providers/trakt_account_provider.dart';
+import '../../services/settings_service.dart';
+import '../../services/trackers/tracker_constants.dart';
 import '../../widgets/app_icon.dart';
 import '../../widgets/focused_scroll_scaffold.dart';
 import 'tracker_settings_screen.dart';
@@ -44,18 +46,33 @@ class TrackersSettingsScreen extends StatelessWidget {
   }
 
   Widget _trakt() => Consumer<TraktAccountProvider>(
-    builder: (context, account, _) => _TrackerHubRow(
-      leading: const _TrackerLogo('assets/trakt_circlemark.svg'),
-      title: t.trakt.title,
-      username: account.isConnected ? account.username : null,
-      onTap: () {
-        if (account.isConnected) {
-          Navigator.push(context, MaterialPageRoute(builder: (_) => const TraktSettingsScreen()));
-        } else {
-          startTraktConnection(context);
-        }
-      },
-    ),
+    builder: (context, account, _) {
+      final svc = SettingsService.instanceOrNull;
+      if (svc == null) {
+        return _TrackerHubRow(
+          leading: const _TrackerLogo('assets/trakt_circlemark.svg'),
+          title: t.trakt.title,
+          username: null,
+          onTap: () => startTraktConnection(context),
+        );
+      }
+      return ValueListenableBuilder<String>(
+        valueListenable: svc.listenable(SettingsService.trackerStateAuthority),
+        builder: (_, authorityValue, _) => _TrackerHubRow(
+          leading: const _TrackerLogo('assets/trakt_circlemark.svg'),
+          title: t.trakt.title,
+          username: account.isConnected ? account.username : null,
+          isAuthority: account.isConnected && authorityValue == TrackerService.trakt.name,
+          onTap: () {
+            if (account.isConnected) {
+              Navigator.push(context, MaterialPageRoute(builder: (_) => const TraktSettingsScreen()));
+            } else {
+              startTraktConnection(context);
+            }
+          },
+        ),
+      );
+    },
   );
 
   Widget _mal() => Consumer<TrackersProvider>(
@@ -120,16 +137,33 @@ class _TrackerHubRow extends StatelessWidget {
   /// Non-null when connected. When null, the subtitle shows "Not connected".
   final String? username;
 
+  /// True when this tracker is currently acting as watch-state authority.
+  final bool isAuthority;
+
   final VoidCallback onTap;
 
-  const _TrackerHubRow({required this.leading, required this.title, required this.username, required this.onTap});
+  const _TrackerHubRow({
+    required this.leading,
+    required this.title,
+    required this.username,
+    required this.onTap,
+    this.isAuthority = false,
+  });
 
   @override
   Widget build(BuildContext context) {
+    final String subtitle;
+    if (username != null) {
+      subtitle = isAuthority
+          ? '${t.trackers.connectedAs(username: username!)} · Watch history source'
+          : t.trackers.connectedAs(username: username!);
+    } else {
+      subtitle = t.trackers.notConnected;
+    }
     return ListTile(
       leading: leading,
       title: Text(title),
-      subtitle: Text(username != null ? t.trackers.connectedAs(username: username!) : t.trackers.notConnected),
+      subtitle: Text(subtitle),
       trailing: const AppIcon(Symbols.chevron_right_rounded, fill: 1),
       onTap: onTap,
     );

--- a/lib/screens/settings/trakt_settings_screen.dart
+++ b/lib/screens/settings/trakt_settings_screen.dart
@@ -10,6 +10,7 @@ import '../../services/trackers/tracker_constants.dart';
 import '../../services/trakt/trakt_scrobble_service.dart';
 import '../../services/trakt/trakt_sync_service.dart';
 import '../../utils/dialogs.dart';
+import '../../widgets/app_icon.dart';
 import '../../widgets/device_code_dialog.dart';
 import '../../widgets/settings_page.dart';
 import 'tracker_account_settings_body.dart';
@@ -51,8 +52,7 @@ class TraktSettingsScreen extends StatelessWidget {
     return Consumer<TraktAccountProvider>(
       builder: (context, account, _) {
         // Safety net: if we end up here while not connected (e.g. refresh failed
-        // in the background and cleared the session), bail out. The settings
-        // tile is the only supported entry point for the unauthed flow.
+        // in the background and cleared the session), bail out.
         if (!account.isConnected) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             if (context.mounted) Navigator.of(context).pop();
@@ -64,11 +64,31 @@ class TraktSettingsScreen extends StatelessWidget {
         }
 
         final username = account.username;
+        final svc = SettingsService.instanceOrNull!;
         return TrackerAccountSettingsBody(
           title: Text(t.trakt.title),
           accountTitle: username != null ? t.trakt.connectedAs(username: username) : t.trakt.connected,
           accountSubtitle: t.trakt.connected,
           service: TrackerService.trakt,
+          prefixChildren: [
+            ValueListenableBuilder<String>(
+              valueListenable: svc.listenable(SettingsService.trackerStateAuthority),
+              builder: (_, value, _) => SwitchListTile(
+                secondary: const AppIcon(Symbols.admin_panel_settings_rounded, fill: 1),
+                title: const Text('Use Trakt as the source for watch history'),
+                subtitle: const Text(
+                  'Trakt provides watched status, progress, Continue Watching, '
+                  'and the Playlists tab (watchlist). Scrobble + watched-sync '
+                  'below send your Plezy activity back to Trakt.',
+                ),
+                value: value == TrackerService.trakt.name,
+                onChanged: (v) async {
+                  await svc.write(SettingsService.trackerStateAuthority, v ? TrackerService.trakt.name : 'none');
+                  account.setWatchStateAuthorityEnabled(v);
+                },
+              ),
+            ),
+          ],
           toggles: [
             TrackerSettingsToggle(
               pref: SettingsService.enableTraktScrobble,

--- a/lib/screens/video_player/parts/episode_navigation.dart
+++ b/lib/screens/video_player/parts/episode_navigation.dart
@@ -71,8 +71,7 @@ extension _VideoPlayerEpisodeNavigationMethods on VideoPlayerScreenState {
     _isReplacingWithVideo = true;
 
     unawaited(DiscordRPCService.instance.stopPlayback());
-    unawaited(TraktScrobbleService.instance.stopPlayback());
-    unawaited(TrackerCoordinator.instance.stopPlayback());
+    unawaited(TrackerLifecycle.stopPlayback());
 
     if (player == null) {
       if (mounted) {
@@ -154,13 +153,18 @@ extension _VideoPlayerEpisodeNavigationMethods on VideoPlayerScreenState {
     final playbackState = context.read<PlaybackStateProvider>();
     final database = context.read<AppDatabase>();
 
+    // stopPlayback() must come before _sendStoppedProgressOnce() so that
+    // wasRecentlyStopped is true when TraktSyncService processes the
+    // progressUpdate event — prevents re-adding the skipped episode to
+    // Trakt's /sync/playback (Bug D). Both calls are unawaited so they
+    // run synchronously through their first await; _lastSentState = stop
+    // is set before notifyProgress() fires inside _sendStoppedProgressOnce.
+    unawaited(DiscordRPCService.instance.stopPlayback());
+    unawaited(TrackerLifecycle.stopPlayback());
     await _sendStoppedProgressOnce();
     _progressTracker?.stopTracking();
     _progressTracker?.dispose();
     _progressTracker = null;
-    unawaited(DiscordRPCService.instance.stopPlayback());
-    unawaited(TraktScrobbleService.instance.stopPlayback());
-    unawaited(TrackerCoordinator.instance.stopPlayback());
 
     _currentMetadata = episodeMetadata;
     VideoPlayerScreenState._activeId = episodeMetadata.id;
@@ -303,6 +307,15 @@ extension _VideoPlayerEpisodeNavigationMethods on VideoPlayerScreenState {
       _currentMetadata = previousMetadata;
       VideoPlayerScreenState._activeId = previousMetadata.id;
       appLogger.e('Failed to swap episode in PiP', error: e);
+    }
+    // Mirror what dispose() does for the non-PiP path: the PiP screen is never
+    // disposed between episodes, so triggerPostPlaybackSync must be scheduled
+    // here after each swap (covers both manual skip and auto-play completion).
+    if (mounted) {
+      Future.delayed(
+        const Duration(seconds: 2),
+        TrackerSyncNotifier.instance.triggerPostPlaybackSync,
+      );
     }
   }
 }

--- a/lib/screens/video_player/parts/playback_prompts.dart
+++ b/lib/screens/video_player/parts/playback_prompts.dart
@@ -15,7 +15,7 @@ extension _VideoPlayerPlaybackPromptMethods on VideoPlayerScreenState {
     unawaited(_progressTracker?.sendProgress('paused'));
     _updateMediaControlsPlaybackState();
     unawaited(DiscordRPCService.instance.pausePlayback());
-    unawaited(TraktScrobbleService.instance.pausePlayback());
+    TrackerLifecycle.pausePlayback();
     if (_autoPipEnabled) {
       unawaited(_videoPIPManager?.updateAutoPipState(isPlaying: false));
     }

--- a/lib/screens/video_player/parts/playback_services.dart
+++ b/lib/screens/video_player/parts/playback_services.dart
@@ -62,8 +62,7 @@ extension _VideoPlayerPlaybackServiceMethods on VideoPlayerScreenState {
     // neutral [MediaServerClient]; null short-circuits cleanly.
     if (mediaClient != null) {
       unawaited(DiscordRPCService.instance.startPlayback(metadata, mediaClient));
-      unawaited(TraktScrobbleService.instance.startPlayback(metadata, mediaClient, isLive: widget.isLive));
-      unawaited(TrackerCoordinator.instance.startPlayback(metadata, mediaClient, isLive: widget.isLive));
+      TrackerLifecycle.startPlayback(metadata, mediaClient, isLive: widget.isLive);
     }
   }
 
@@ -171,12 +170,10 @@ extension _VideoPlayerPlaybackServiceMethods on VideoPlayerScreenState {
         speed: currentPlayer.state.rate,
       );
       DiscordRPCService.instance.updatePosition(position);
-      TraktScrobbleService.instance.updatePosition(position);
-      TrackerCoordinator.instance.updatePosition(position);
+      TrackerLifecycle.updatePosition(position);
       // Keep Trakt's known duration current — mpv only emits on the duration
       // stream once per load, but this is cheap and avoids an extra listener.
-      TraktScrobbleService.instance.updateDuration(currentPlayer.state.duration);
-      TrackerCoordinator.instance.updateDuration(currentPlayer.state.duration);
+      TrackerLifecycle.updateDuration(currentPlayer.state.duration);
     });
 
     // Listen to playback rate changes for Discord Rich Presence
@@ -221,10 +218,10 @@ extension _VideoPlayerPlaybackServiceMethods on VideoPlayerScreenState {
     // Update Discord Rich Presence + Trakt scrobble
     if (isPlaying) {
       DiscordRPCService.instance.resumePlayback();
-      TraktScrobbleService.instance.resumePlayback();
+      TrackerLifecycle.resumePlayback();
     } else {
       DiscordRPCService.instance.pausePlayback();
-      TraktScrobbleService.instance.pausePlayback();
+      TrackerLifecycle.pausePlayback();
     }
 
     // Update auto-PiP readiness

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -38,8 +38,8 @@ import '../providers/companion_remote_provider.dart';
 import '../services/companion_remote/companion_remote_receiver.dart';
 import '../services/fullscreen_state_manager.dart';
 import '../services/discord_rpc_service.dart';
-import '../services/trackers/tracker_coordinator.dart';
-import '../services/trakt/trakt_scrobble_service.dart';
+import '../services/trackers/tracker_lifecycle.dart';
+import '../services/trackers/tracker_sync_notifier.dart';
 import '../services/episode_navigation_service.dart';
 import '../services/app_foreground_service.dart';
 import '../services/media_controls_manager.dart';
@@ -212,6 +212,15 @@ class VideoPlayerScreen extends StatefulWidget {
   final String? liveSessionIdentifier;
   final String? liveSessionPath;
 
+  /// Fires synchronously when the user exits playback, before [Navigator.pop].
+  /// Receives the player's final position (ms) and the rating-key of the item
+  /// that was playing — used by callers to apply a fresh resume position
+  /// without waiting for the post-playback tracker sync.
+  ///
+  /// Instance-scoped so concurrent players (PiP, multi-window) do not stomp on
+  /// each other's exit state.
+  final void Function(int viewOffsetMs, String ratingKey)? onPlaybackExit;
+
   const VideoPlayerScreen({
     super.key,
     required this.metadata,
@@ -234,6 +243,7 @@ class VideoPlayerScreen extends StatefulWidget {
     this.liveClient,
     this.liveSessionIdentifier,
     this.liveSessionPath,
+    this.onPlaybackExit,
   });
 
   @override
@@ -249,6 +259,12 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
 
   static String? get activeId => _activeId;
   static int? get activeMediaIndex => _activeMediaIndex;
+
+  /// Single pending post-playback Trakt sync. Static because rapid play→exit→
+  /// play cycles each call [dispose] on a different state instance; the prior
+  /// instance is gone before the next would naturally cancel its own timer.
+  /// Cancelling the prior timer here coalesces overlapping syncs into one.
+  static Timer? _postPlaybackSyncTimer;
 
   Player? player;
   bool _isPlayerInitialized = false;
@@ -997,6 +1013,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
             final navigator = Navigator.of(context);
             if (navigator.canPop()) {
               _isExiting.value = true;
+              _notifyPlaybackExit();
               await _sendStoppedProgressOnce();
               if (!mounted) return;
               navigator.pop(true);
@@ -1011,6 +1028,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
       final navigator = Navigator.of(context);
       if (navigator.canPop()) {
         _isExiting.value = true;
+        _notifyPlaybackExit();
         await _sendStoppedProgressOnce();
         if (!mounted) return;
         navigator.pop(true);
@@ -1018,6 +1036,15 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
     } finally {
       _isHandlingBack = false;
     }
+  }
+
+  /// Surface the current player position and rating-key to the caller via the
+  /// [VideoPlayerScreen.onPlaybackExit] callback. Safe to call when [player]
+  /// is null (no-op).
+  void _notifyPlaybackExit() {
+    final position = player?.state.position.inMilliseconds;
+    if (position == null) return;
+    widget.onPlaybackExit?.call(position, _currentMetadata.id);
   }
 
   @override
@@ -1101,8 +1128,15 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
     _mediaControlsManager?.dispose();
 
     DiscordRPCService.instance.stopPlayback();
-    TraktScrobbleService.instance.stopPlayback();
-    TrackerCoordinator.instance.stopPlayback();
+    unawaited(TrackerLifecycle.stopPlayback());
+    // Coalesce overlapping post-playback syncs: if a prior playback session
+    // exited within the last 2s and its timer hasn't fired yet, cancel it so
+    // we don't dispatch two redundant Trakt round-trips for the same window.
+    _postPlaybackSyncTimer?.cancel();
+    _postPlaybackSyncTimer = Timer(
+      const Duration(seconds: 2),
+      TrackerSyncNotifier.instance.triggerPostPlaybackSync,
+    );
 
     if (Platform.isWindows && _displayModeService != null) {
       FullscreenStateManager().removeListener(_onFullscreenChanged);

--- a/lib/services/api_cache.dart
+++ b/lib/services/api_cache.dart
@@ -85,6 +85,11 @@ abstract class ApiCache {
         );
   }
 
+  Future<void> delete(String serverId, String endpoint) async {
+    final key = _buildKey(serverId, endpoint);
+    await (_db.delete(_db.apiCache)..where((t) => t.cacheKey.equals(key))).go();
+  }
+
   Future<void> deleteForServer(String serverId) async {
     await (_db.delete(_db.apiCache)..where((t) => t.cacheKey.like('$serverId:%'))).go();
   }

--- a/lib/services/data_aggregation_service.dart
+++ b/lib/services/data_aggregation_service.dart
@@ -10,6 +10,9 @@ import '../utils/external_ids.dart';
 import '../utils/global_key_utils.dart';
 import '../utils/search_relevance.dart';
 import 'multi_server_manager.dart';
+import 'plex_client.dart';
+import 'trackers/tracker_ui_helper.dart';
+import 'trackers/watch_state_overlay.dart';
 
 /// Cross-server aggregation: fans calls out to every online client and
 /// merges the results. Single-server operations now go through the
@@ -44,8 +47,16 @@ class DataAggregationService {
 
   /// Fetch "On Deck" (Continue Watching) from all servers and merge by recency.
   /// Items are tagged with server info by the underlying client. Returns
-  /// neutral [MediaItem]s.
+  /// neutral [MediaItem]s. When a tracker authority is active (e.g. Trakt),
+  /// the authority is the sole source of truth for Continue Watching.
   Future<List<MediaItem>> getOnDeckFromAllServers({int? limit, Set<String>? hiddenLibraryKeys}) async {
+    await WatchStateOverlay.instance.cacheReady;
+
+    // When a tracker authority is active it is the sole source of truth.
+    if (WatchStateOverlay.instance.hasActiveAuthority) {
+      return _getOnDeckFromAuthority(limit: limit, hiddenLibraryKeys: hiddenLibraryKeys);
+    }
+
     final clients = _serverManager.onlineClients;
     if (clients.isEmpty) {
       appLogger.w('No online servers available for fetching on deck');
@@ -62,30 +73,30 @@ class DataAggregationService {
     });
     final allOnDeck = (await Future.wait(futures)).expand((l) => l).toList();
 
-    // Filter out items from hidden libraries
-    List<MediaItem> filteredOnDeck = allOnDeck;
+    // Re-check: if authority became active during the fetch, use it instead.
+    if (WatchStateOverlay.instance.hasActiveAuthority) {
+      return _getOnDeckFromAuthority(limit: limit, hiddenLibraryKeys: hiddenLibraryKeys);
+    }
+
+    List<MediaItem> result = allOnDeck;
     if (hiddenLibraryKeys != null && hiddenLibraryKeys.isNotEmpty) {
-      filteredOnDeck = allOnDeck.where((item) {
+      result = allOnDeck.where((item) {
         if (item.libraryId == null || item.serverId == null) return true;
         final globalKey = buildGlobalKey(item.serverId!, item.libraryId!);
         return !hiddenLibraryKeys.contains(globalKey);
       }).toList();
     }
 
-    // Sort by most recently viewed, falling back to addedAt for unwatched items
-    filteredOnDeck.sort((a, b) {
+    result.sort((a, b) {
       final aTime = a.lastViewedAt ?? a.addedAt ?? 0;
       final bTime = b.lastViewedAt ?? b.addedAt ?? 0;
-      return bTime.compareTo(aTime); // Descending (most recent first)
+      return bTime.compareTo(aTime);
     });
 
-    filteredOnDeck = await _deduplicateContinueWatching(filteredOnDeck);
+    result = await _deduplicateContinueWatching(result);
 
-    // Apply limit if specified
-    final result = limit != null && limit < filteredOnDeck.length ? filteredOnDeck.sublist(0, limit) : filteredOnDeck;
-
+    if (limit != null && limit < result.length) result = result.sublist(0, limit);
     appLogger.i('Fetched ${result.length} on deck items from all servers');
-
     return result;
   }
 
@@ -223,6 +234,49 @@ class DataAggregationService {
     return value.toLowerCase();
   }
 
+  Future<List<MediaItem>> _getOnDeckFromAuthority({int? limit, Set<String>? hiddenLibraryKeys}) async {
+    final plexClients = Map.fromEntries(
+      _serverManager.onlineClients.entries
+          .where((e) => e.value is PlexClient)
+          .map((e) => MapEntry(e.key, e.value as PlexClient)),
+    );
+    final fallbackServerId = plexClients.keys.firstOrNull;
+    // Await enrichment so not-found stubs are filtered before returning.
+    // Fast on subsequent calls (needsWork empty, returns immediately).
+    await Future.wait([
+      enrichTrackerStubs(fallbackServerId, plexClients),
+      resolveTrackerEpisodeDisplayPositions(plexClients, fallbackServerId),
+    ]);
+
+    var items = WatchStateOverlay.instance.getContinueWatchingItems().map((i) {
+      final meta = i.metadata;
+      if (meta.serverId != null || fallbackServerId == null) return meta;
+      return meta.copyWith(serverId: fallbackServerId);
+    }).toList();
+
+    if (hiddenLibraryKeys != null && hiddenLibraryKeys.isNotEmpty) {
+      items = items.where((item) {
+        if (item.libraryId == null || item.serverId == null) return true;
+        return !hiddenLibraryKeys.contains(buildGlobalKey(item.serverId!, item.libraryId!));
+      }).toList();
+    }
+
+    if (limit != null && limit < items.length) items = items.sublist(0, limit);
+    appLogger.i('Fetched ${items.length} on deck items from tracker authority');
+    return items;
+  }
+
+  /// Enriches Trakt stubs by searching Plex servers, populating the bridge map
+  /// so stub-to-Plex resolution is ready before the user taps an item.
+  Future<void> enrichTrackerStubsFromPlex(String? preferredServerId) {
+    final plexClients = Map.fromEntries(
+      _serverManager.onlineClients.entries
+          .where((e) => e.value is PlexClient)
+          .map((e) => MapEntry(e.key, e.value as PlexClient)),
+    );
+    return enrichTrackerStubs(preferredServerId, plexClients);
+  }
+
   /// Fetch recommendation hubs from all servers as neutral [MediaHub]s.
   /// When useGlobalHubs is true (default), rich-hub backends use their true
   /// home page hubs (Plex's promoted/global hub endpoint).
@@ -272,7 +326,12 @@ class DataAggregationService {
     for (final list in results) {
       all.addAll(list);
     }
-    return limit != null && limit < all.length ? all.sublist(0, limit) : all;
+    // Apply watch state overlay (Trakt authority, etc.) to all hub items.
+    await WatchStateOverlay.instance.cacheReady;
+    final overlaid = all
+        .map((hub) => hub.copyWith(items: WatchStateOverlay.instance.applyAll(hub.items)))
+        .toList();
+    return limit != null && limit < overlaid.length ? overlaid.sublist(0, limit) : overlaid;
   }
 
   /// Per-library hub fetch for a single client. Filters to visible
@@ -365,7 +424,8 @@ class DataAggregationService {
     });
 
     final allResults = (await Future.wait(futures)).expand((l) => l).toList();
-    final result = rankMediaSearchResults(allResults, query, limit: resultLimit);
+    final overlaid = allResults.map(WatchStateOverlay.instance.apply).toList();
+    final result = rankMediaSearchResults(overlaid, query, limit: resultLimit);
 
     appLogger.i('Found ${result.length} search results across all servers');
 

--- a/lib/services/offline_watch_sync_service.dart
+++ b/lib/services/offline_watch_sync_service.dart
@@ -550,7 +550,7 @@ class OfflineWatchSyncService extends ChangeNotifier {
     final emitsEvent =
         action.actionType == OfflineActionType.watched.id ||
         action.actionType == OfflineActionType.unwatched.id ||
-        (action.actionType == OfflineActionType.progress.id && action.shouldMarkWatched);
+        action.actionType == OfflineActionType.progress.id;
     MediaItem? item;
     if (emitsEvent) {
       try {
@@ -594,6 +594,13 @@ class OfflineWatchSyncService extends ChangeNotifier {
             appLogger.d('Offline progress: started call failed (continuing)', error: e);
           }
           await client.reportPlaybackStopped(itemId: action.ratingKey, position: position, duration: duration);
+          // Notify downstream listeners (Trakt) so they can update the resume
+          // position now that we're back online and IDs can be resolved.
+          WatchStateNotifier().notifyProgress(
+            item: item,
+            viewOffset: action.viewOffset!,
+            duration: action.duration!,
+          );
         }
 
         // If progress exceeded threshold, also mark as watched.

--- a/lib/services/playback_progress_tracker.dart
+++ b/lib/services/playback_progress_tracker.dart
@@ -12,6 +12,8 @@ import 'settings_service.dart';
 import 'track_selection_service.dart';
 import '../utils/app_logger.dart';
 import '../utils/watch_state_notifier.dart';
+import 'trackers/watch_state_overlay.dart';
+import 'plex_client.dart';
 
 /// Tracks playback progress and reports it to the active media server.
 ///
@@ -171,6 +173,15 @@ class PlaybackProgressTracker {
         // Queue progress update for later sync
         await _sendOfflineProgress(position, duration);
         _notifyProgressIfNeeded(position, duration, force: state == 'stopped');
+        // Mirror _maybeScrobble: queue a tracker scrobble the first time the
+        // watch threshold is crossed during offline playback.
+        if (!_scrobbled && WatchStateOverlay.instance.hasActiveAuthority && duration.inMilliseconds > 0) {
+          final pct = position.inMilliseconds / duration.inMilliseconds;
+          if (pct >= 0.9) {
+            _scrobbled = true;
+            unawaited(WatchStateOverlay.instance.queueOfflineScrobble(metadata, progressPercent: pct * 100));
+          }
+        }
       } else if (state == 'stopped') {
         // Stopped must complete before disposal
         final accepted = await _sendOnlineProgress(state, position, duration);
@@ -199,6 +210,27 @@ class PlaybackProgressTracker {
                 );
               }),
         );
+      }
+
+      // Emit watch state event on stop for UI updates across screens.
+      // Skip if already scrobbled — markAsWatched already emitted a watched event.
+      if (state == 'stopped' && position.inMilliseconds > 0 && !_scrobbled) {
+        final threshold = (client is PlexClient) ? (client as PlexClient).watchedThresholdPercent / 100.0 : 0.9;
+        WatchStateNotifier().notifyProgress(
+          item: metadata,
+          viewOffset: position.inMilliseconds,
+          duration: duration.inMilliseconds,
+          watchedThreshold: threshold,
+        );
+        // When Trakt authority is active, markAsWatched was skipped (Plex write
+        // guard). Emit a watched event so TraktSyncService can push addToHistory
+        // as a reliable fallback to the scrobble stop.
+        if (WatchStateOverlay.instance.hasActiveAuthority && duration.inMilliseconds > 0) {
+          final progressFraction = position.inMilliseconds / duration.inMilliseconds;
+          if (progressFraction >= threshold) {
+            WatchStateNotifier().notifyWatched(item: metadata, isNowWatched: true);
+          }
+        }
       }
     } catch (e) {
       if (!isOffline) {
@@ -245,6 +277,13 @@ class PlaybackProgressTracker {
   /// Send progress update to the active server through the unified
   /// [MediaServerClient.reportPlayback*] surface.
   Future<bool> _sendOnlineProgress(String state, Duration position, Duration duration) async {
+    // When a tracker is authoritative for watch state, skip Plex timeline
+    // updates so the tracker remains the single source of truth.
+    if (WatchStateOverlay.instance.hasActiveAuthority) {
+      appLogger.d('PlaybackProgress: skipping Plex timeline (tracker authority active)');
+      return false;
+    }
+
     final c = client;
     final session = _reportSession;
     if (c == null || session == null) return false;

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -888,6 +888,7 @@ class PlexClient
     AbortController? abort,
   }) async {
     final queryParams = _buildPaginationParams(start, size);
+    queryParams['includeGuids'] = 1;
     if (filters != null) queryParams.addAll(filters);
     final endpoint = sectionId == 'shared' ? '/library/shared/all' : '/library/sections/$sectionId/all';
     final response = await _getWithFailover(endpoint, queryParameters: queryParams, abort: abort);
@@ -1011,7 +1012,7 @@ class PlexClient
           cacheKey: cacheKey,
           networkCall: () => _http.get(
             '/library/metadata/$ratingKey',
-            queryParameters: {'includeChapters': 1, 'includeMarkers': 1, 'includeOnDeck': 1},
+            queryParameters: {'includeChapters': 1, 'includeMarkers': 1, 'includeOnDeck': 1, 'includeGuids': 1},
           ),
           parseCache: (cachedData) {
             final metadata = _parseMetadataWithImagesFromCachedResponse(cachedData);
@@ -1066,8 +1067,10 @@ class PlexClient
 
     return fetchWithCacheFallback<PlexMetadataDto>(
       cacheKey: cacheKey,
-      networkCall: () =>
-          _http.get('/library/metadata/$ratingKey', queryParameters: {'includeChapters': 1, 'includeMarkers': 1}),
+      networkCall: () => _http.get(
+        '/library/metadata/$ratingKey',
+        queryParameters: {'includeChapters': 1, 'includeMarkers': 1, 'includeGuids': 1},
+      ),
       parseCache: (cachedData) => _parseMetadataWithImagesFromCachedResponse(cachedData),
       parseResponse: (response) {
         final container = _getMediaContainer(response);
@@ -1283,6 +1286,7 @@ class PlexClient
         'searchTypes': 'movies,tv',
         'includeCollections': 1,
         'includeExternalMedia': 1,
+        'includeGuids': 1,
         'X-Plex-Container-Size': limit,
       },
     );
@@ -1311,6 +1315,155 @@ class PlexClient
     }
 
     return results;
+  }
+
+  /// Fetch all leaf (episode) items for a container (show), including their
+  /// secondary GUIDs. Used to resolve a specific episode by external ID when
+  /// /library/all?guid=... doesn't match episode-level GUIDs in plex:// libraries.
+  Future<List<MediaItem>> getAllLeaves(String ratingKey) async {
+    try {
+      final response = await _getWithFailover(
+        '/library/metadata/$ratingKey/allLeaves',
+        queryParameters: {'includeGuids': 1},
+      );
+      return _extractMetadataList(response).map(PlexMappers.mediaItem).toList();
+    } catch (e) {
+      appLogger.d('getAllLeaves failed for $ratingKey', error: e);
+      return [];
+    }
+  }
+
+  /// Direct GUID-based library lookup. Uses /library/all?guid=X&includeGuids=1.
+  /// The GUID value is embedded directly in the path (not via queryParameters)
+  /// so that `:` and `/` in scheme-like IDs (tvdb://X, imdb://X) are sent
+  /// as literal characters instead of being percent-encoded. Plex compares raw
+  /// strings and never matches `tvdb%3A%2F%2F73244`.
+  Future<List<MediaItem>> searchByExternalIdUri(String guid) async {
+    try {
+      final response = await _getWithFailover('/library/all?guid=$guid&includeGuids=1');
+      final results = _extractMetadataList(response).map(PlexMappers.mediaItem).toList();
+      appLogger.d(
+        'searchByExternalIdUri: guid=$guid → ${results.length} results: ${results.map((r) => r.id).toList()}',
+      );
+      return results;
+    } catch (e) {
+      appLogger.d('searchByExternalIdUri failed for $guid', error: e);
+      return [];
+    }
+  }
+
+  /// Section-based GUID lookup for secondary IDs (imdb://, tmdb://, tvdb://).
+  /// Plex's /library/all?guid=X only matches primary GUIDs (plex://show/UUID).
+  /// /library/sections/{id}/all?guid=X matches ALL GUIDs including secondary ones.
+  /// [sectionType] should be "show" or "movie" to limit which sections are searched.
+  Future<List<MediaItem>> searchSectionsByExternalIdUri(String guid, String sectionType) async {
+    try {
+      final libs = await _getLibraries();
+      appLogger.t(
+        'searchSectionsByExternalIdUri: guid=$guid sectionType=$sectionType — total libs=${libs.length} types=${libs.map((l) => "${l.key}:${l.type}:shared=${l.isShared}").toList()}',
+      );
+      final sections = libs.where((l) => l.type == sectionType && !l.isShared).toList();
+      appLogger.t(
+        'searchSectionsByExternalIdUri: matched ${sections.length} sections: ${sections.map((s) => "${s.key}(${s.title})").toList()}',
+      );
+      for (final section in sections) {
+        final path = '/library/sections/${section.key}/all?guid=$guid&includeGuids=1';
+        appLogger.t('searchSectionsByExternalIdUri: querying $path');
+        final response = await _getWithFailover(path);
+        final results = _extractMetadataList(response).map(PlexMappers.mediaItem).toList();
+        appLogger.t('searchSectionsByExternalIdUri: section=${section.key} raw results=${results.length}');
+        if (results.isNotEmpty) {
+          appLogger.d(
+            'searchSectionsByExternalIdUri: guid=$guid section=${section.key}(${section.title}) → ${results.length} results',
+          );
+          return results;
+        }
+      }
+      appLogger.d('searchSectionsByExternalIdUri: guid=$guid → 0 results across ${sections.length} sections');
+      return [];
+    } catch (e) {
+      appLogger.d('searchSectionsByExternalIdUri failed for $guid', error: e);
+      return [];
+    }
+  }
+
+  /// ID-only fallback for items where the GUID-parameter section search returns
+  /// no results (e.g. legacy-agent items). Filters sections by [year] to keep
+  /// the candidate set small, then compares external IDs from `includeGuids=1`
+  /// response. Searches ALL sections including shared ones.
+  Future<MediaItem?> findByYearAndExternalIds(
+    int year,
+    ExternalIds ids,
+    MediaKind kind,
+  ) async {
+    final sectionType = kind == MediaKind.movie ? 'movie' : 'show';
+    final plexType = kind == MediaKind.movie ? 1 : 2;
+    final libs = await _getLibraries();
+    final sections = libs.where((l) => l.type == sectionType).toList();
+    appLogger.t('[YearIdSearch] year=$year kind=$kind sections=${sections.length} ids=$ids');
+
+    for (final section in sections) {
+      try {
+        final response = await _getWithFailover(
+          '/library/sections/${section.key}/all',
+          queryParameters: {'type': plexType, 'year': year, 'includeGuids': 1},
+        );
+        final results = _extractMetadataList(response).map(PlexMappers.mediaItem).toList();
+        appLogger.t('[YearIdSearch] section=${section.key}(${section.title}) year=$year → ${results.length} candidates');
+        for (final item in results) {
+          final itemGuids = item.raw?['Guid'] as List?;
+          final ExternalIds itemIds;
+          if (itemGuids != null && itemGuids.isNotEmpty) {
+            itemIds = ExternalIds.fromGuids(itemGuids);
+          } else {
+            // Legacy-agent: Guid array absent; extract ID from primary guid.
+            itemIds = ExternalIds.fromPrimaryGuid(item.guid);
+          }
+          if (!itemIds.hasAny) continue;
+          if ((ids.imdb != null && ids.imdb == itemIds.imdb) ||
+              (ids.tmdb != null && ids.tmdb == itemIds.tmdb) ||
+              (ids.tvdb != null && ids.tvdb == itemIds.tvdb)) {
+            appLogger.d('[YearIdSearch] MATCH ${item.id} via year+ID in section ${section.key}');
+            return item;
+          }
+        }
+      } catch (e) {
+        appLogger.t('[YearIdSearch] section ${section.key} failed', error: e);
+      }
+    }
+    return null;
+  }
+
+  /// Fetches every item in all [sectionType] libraries and returns a map of
+  /// secondary GUID URI → MediaItem (e.g. 'tvdb://73244' → The Office item).
+  ///
+  /// Called once per enrichment run before the parallel stub loop so that
+  /// new-agent items (whose primary guid is plex://show/uuid and therefore
+  /// invisible to ?guid= filters) can be found via their secondary Guid array.
+  Future<Map<String, MediaItem>> buildGuidIndex(String sectionType) async {
+    final plexType = sectionType == 'movie' ? 1 : 2;
+    final libs = await _getLibraries();
+    final sections = libs.where((l) => l.type == sectionType && !l.isShared).toList();
+    final index = <String, MediaItem>{};
+    for (final section in sections) {
+      try {
+        final path = '/library/sections/${section.key}/all?type=$plexType&includeGuids=1';
+        final response = await _getWithFailover(path);
+        final dtos = _extractMetadataList(response);
+        for (final dto in dtos) {
+          final item = PlexMappers.mediaItem(dto);
+          for (final g in dto.guids ?? []) {
+            final id = (g as Map<String, dynamic>)['id'] as String?;
+            if (id != null) index[id] = item;
+          }
+        }
+        appLogger.t('[GuidIndex] section ${section.key}(${section.title}) → ${dtos.length} items indexed');
+      } catch (e) {
+        appLogger.t('[GuidIndex] section ${section.key} failed', error: e);
+      }
+    }
+    appLogger.d('[GuidIndex] $sectionType index ready — ${index.length} GUID entries');
+    return index;
   }
 
   /// Get recently added media (filtered to video content only)
@@ -1549,7 +1702,37 @@ class PlexClient
       final first = metadata.first;
       if (first is! Map) return const [];
       final guids = first['Guid'];
-      if (guids is List) return guids;
+      if (guids is List && guids.isNotEmpty) return guids;
+
+      // Fallback: some Plex servers don't include the Guid array on the detail
+      // endpoint (e.g. unrefreshed new-agent movies). Try the global library
+      // search by primary GUID — it goes through a different server code path
+      // and often returns the external IDs when the detail endpoint doesn't.
+      final primaryGuid = first['guid'] as String?;
+      if (primaryGuid != null && primaryGuid.isNotEmpty) {
+        appLogger.t('fetchExternalGuids: no Guid array for $ratingKey, trying /library/all?guid=$primaryGuid fallback');
+        try {
+          final fallback = await _getWithFailover('/library/all?guid=$primaryGuid&includeGuids=1');
+          final fb = fallback.data;
+          if (fb is Map) {
+            final fbContainer = fb['MediaContainer'] as Map?;
+            final fbMetadata = fbContainer?['Metadata'];
+            if (fbMetadata is List && fbMetadata.isNotEmpty) {
+              final fbFirst = fbMetadata.first;
+              if (fbFirst is Map) {
+                final fbGuids = fbFirst['Guid'];
+                if (fbGuids is List && fbGuids.isNotEmpty) {
+                  appLogger.d('fetchExternalGuids: fallback returned ${fbGuids.length} Guids for $ratingKey');
+                  return fbGuids;
+                }
+              }
+            }
+          }
+        } catch (e) {
+          appLogger.t('fetchExternalGuids fallback failed for $ratingKey', error: e);
+        }
+      }
+
       return const [];
     } catch (e) {
       appLogger.d('fetchExternalGuids failed for $ratingKey', error: e);

--- a/lib/services/plex_mappers.dart
+++ b/lib/services/plex_mappers.dart
@@ -478,6 +478,8 @@ class PlexMetadataDto {
   final bool? skipChildren;
   @JsonKey(fromJson: flexibleInt)
   final int? flattenSeasons;
+  @JsonKey(name: 'Guid', includeToJson: false)
+  final List<dynamic>? guids;
 
   const PlexMetadataDto({
     required this.ratingKey,
@@ -547,6 +549,7 @@ class PlexMetadataDto {
     this.backgroundSquare,
     this.skipChildren,
     this.flattenSeasons,
+    this.guids,
   });
 
   factory PlexMetadataDto.fromJson(Map<String, dynamic> rawJson) {
@@ -676,6 +679,7 @@ class PlexMetadataDto {
     String? backgroundSquare,
     bool? skipChildren,
     int? flattenSeasons,
+    List<dynamic>? guids,
   }) {
     return PlexMetadataDto(
       ratingKey: ratingKey ?? this.ratingKey,
@@ -745,6 +749,7 @@ class PlexMetadataDto {
       backgroundSquare: backgroundSquare ?? this.backgroundSquare,
       skipChildren: skipChildren ?? this.skipChildren,
       flattenSeasons: flattenSeasons ?? this.flattenSeasons,
+      guids: guids ?? this.guids,
     );
   }
 }
@@ -754,6 +759,7 @@ Map<String, Object?>? _rawMetadata(PlexMetadataDto dto) {
   if (dto.key != null) raw['key'] = dto.key;
   if (dto.skipChildren != null) raw['skipChildren'] = dto.skipChildren;
   if (dto.flattenSeasons != null) raw['flattenSeasons'] = dto.flattenSeasons;
+  if (dto.guids != null) raw['Guid'] = dto.guids;
   return raw.isEmpty ? null : raw;
 }
 

--- a/lib/services/plex_mappers.g.dart
+++ b/lib/services/plex_mappers.g.dart
@@ -147,6 +147,7 @@ PlexMetadataDto _$PlexMetadataDtoFromJson(Map<String, dynamic> json) =>
       backgroundSquare: json['backgroundSquare'] as String?,
       skipChildren: flexibleBoolNullable(json['skipChildren']),
       flattenSeasons: flexibleInt(json['flattenSeasons']),
+      guids: json['Guid'] as List<dynamic>?,
     );
 
 Map<String, dynamic> _$PlexMetadataDtoToJson(PlexMetadataDto instance) =>

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -15,6 +15,8 @@ export 'base_shared_preferences_service.dart'
 import '../models/transcode_quality_preset.dart';
 import '../utils/platform_detector.dart';
 import 'trackers/tracker_constants.dart';
+import 'trackers/tracker_coordinator.dart';
+import 'trackers/watch_state_overlay.dart';
 
 enum ThemeMode { system, light, dark, oled }
 
@@ -144,6 +146,12 @@ class _AutoPipPref extends Pref<bool> {
 
   @override
   Future<void> writeTo(BaseSharedPreferencesService svc, bool value) => svc.writeBool(key, value);
+}
+
+/// Stores the name of the active watch-state authority tracker: 'trakt',
+/// 'simkl', 'mal', 'anilist', or 'none' (disabled).
+class _WatchStateAuthorityTrackerPref extends StringPref {
+  const _WatchStateAuthorityTrackerPref() : super('watch_state_authority_tracker', defaultValue: 'none');
 }
 
 String? _trimEmptyAsNull(String? v) {
@@ -319,6 +327,7 @@ class SettingsService extends BaseSharedPreferencesService {
   static const enableDiscordRPC = BoolPref('enable_discord_rpc');
   static const enableTraktScrobble = BoolPref('enable_trakt_scrobble', defaultValue: true);
   static const enableTraktWatchedSync = BoolPref('enable_trakt_watched_sync', defaultValue: true);
+  static const trackerStateAuthority = _WatchStateAuthorityTrackerPref();
   static const enableMalScrobble = BoolPref('enable_mal_scrobble', defaultValue: true);
   static const enableAnilistScrobble = BoolPref('enable_anilist_scrobble', defaultValue: true);
   static const enableSimklScrobble = BoolPref('enable_simkl_scrobble', defaultValue: true);
@@ -668,89 +677,88 @@ class SettingsService extends BaseSharedPreferencesService {
   /// reset surface — notably excludes user-customized data (intro/credits regex
   /// patterns) and opt-in toggles prior versions didn't reset, so behavior
   /// stays identical for users.
-  static List<Pref<Object?>> _resettablePrefs() => [
-    enableDebugLogging,
-    bufferSize,
-    enableHardwareDecoding,
-    enableHDR,
-    preferredVideoCodec,
-    preferredAudioCodec,
-    viewMode,
-    showHeroSection,
-    seekTimeSmall,
-    seekTimeLarge,
-    sleepTimerDuration,
-    audioSyncOffset,
-    subtitleSyncOffset,
-    subtitleSearchLanguage,
-    volume,
-    maxVolume,
-    subtitleFontSize,
-    subtitleTextColor,
-    subtitleBorderSize,
-    subtitleBorderColor,
-    subtitleBackgroundColor,
-    subtitleBackgroundOpacity,
-    subtitlePosition,
-    rememberTrackSelections,
-    customDownloadPathType,
-    downloadOnWifiOnly,
-    autoCheckUpdatesOnStartup,
-    showPerformanceOverlay,
-    autoHidePerformanceOverlay,
-    enableDiscordRPC,
-    enableTraktScrobble,
-    enableTraktWatchedSync,
-    enableMalScrobble,
-    enableAnilistScrobble,
-    enableSimklScrobble,
-    matchContentFrameRate,
-    tunneledPlayback,
-    dvConversionMode,
-    defaultPlaybackSpeed,
-    defaultBoxFitMode,
-    autoPlayNextEpisode,
-    useExoPlayer,
-    alwaysKeepSidebarOpen,
-    showUnwatchedCount,
-    showEpisodeNumberOnCards,
-    showSeasonPostersOnTabs,
-    hideSpoilers,
-    showNavBarLabels,
-    globalShaderPreset,
-    requireProfileSelectionOnOpen,
-    useExternalPlayer,
-    forceTvMode,
-    ambientLighting,
-    audioPassthrough,
-    audioNormalization,
-    themeMode,
-    keyboardShortcuts,
-    keyboardHotkeys,
-    libraryDensity,
-    episodePosterMode,
-    mediaVersionPreferences,
-    appLocale,
-    customDownloadPath,
-    videoPlayerNavigationEnabled,
-    mpvConfigText,
-    mpvPresets,
-    autoPip,
-    customShaderPresets,
-    selectedExternalPlayer,
-    customExternalPlayers,
-    customRelayUrl,
-    companionRemoteLastHostAddress,
+  static List<String> _resettableKeys() => [
+    enableDebugLogging.key,
+    bufferSize.key,
+    enableHardwareDecoding.key,
+    enableHDR.key,
+    preferredVideoCodec.key,
+    preferredAudioCodec.key,
+    viewMode.key,
+    showHeroSection.key,
+    seekTimeSmall.key,
+    seekTimeLarge.key,
+    sleepTimerDuration.key,
+    audioSyncOffset.key,
+    subtitleSyncOffset.key,
+    subtitleSearchLanguage.key,
+    volume.key,
+    maxVolume.key,
+    subtitleFontSize.key,
+    subtitleTextColor.key,
+    subtitleBorderSize.key,
+    subtitleBorderColor.key,
+    subtitleBackgroundColor.key,
+    subtitleBackgroundOpacity.key,
+    subtitlePosition.key,
+    rememberTrackSelections.key,
+    customDownloadPathType.key,
+    downloadOnWifiOnly.key,
+    autoCheckUpdatesOnStartup.key,
+    showPerformanceOverlay.key,
+    autoHidePerformanceOverlay.key,
+    enableDiscordRPC.key,
+    enableTraktScrobble.key,
+    enableTraktWatchedSync.key,
+    trackerStateAuthority.key,
+    enableMalScrobble.key,
+    enableAnilistScrobble.key,
+    enableSimklScrobble.key,
+    matchContentFrameRate.key,
+    tunneledPlayback.key,
+    dvConversionMode.key,
+    defaultPlaybackSpeed.key,
+    defaultBoxFitMode.key,
+    autoPlayNextEpisode.key,
+    useExoPlayer.key,
+    alwaysKeepSidebarOpen.key,
+    showUnwatchedCount.key,
+    showEpisodeNumberOnCards.key,
+    showSeasonPostersOnTabs.key,
+    hideSpoilers.key,
+    showNavBarLabels.key,
+    globalShaderPreset.key,
+    requireProfileSelectionOnOpen.key,
+    useExternalPlayer.key,
+    forceTvMode.key,
+    ambientLighting.key,
+    audioPassthrough.key,
+    audioNormalization.key,
+    themeMode.key,
+    keyboardShortcuts.key,
+    keyboardHotkeys.key,
+    libraryDensity.key,
+    _legacyUseSeasonPosterKey,
+    episodePosterMode.key,
+    mediaVersionPreferences.key,
+    appLocale.key,
+    customDownloadPath.key,
+    videoPlayerNavigationEnabled.key,
+    _legacyMpvConfigEntriesKey,
+    mpvConfigText.key,
+    mpvPresets.key,
+    autoPip.key,
+    customShaderPresets.key,
+    selectedExternalPlayer.key,
+    customExternalPlayers.key,
+    _bufferSizeMigratedKey,
+    customRelayUrl.key,
+    companionRemoteLastHostAddress.key,
   ];
 
   Future<void> resetAllSettings() async {
-    final resettable = _resettablePrefs();
     await Future.wait([
-      ...resettable.map((p) => prefs.remove(p.key)),
-      // Legacy migration sentinels — removed alongside the keys they guarded.
-      prefs.remove(_legacyUseSeasonPosterKey),
-      prefs.remove(_legacyMpvConfigEntriesKey),
-      prefs.remove(_bufferSizeMigratedKey),
+      ..._resettableKeys().map((k) => prefs.remove(k)),
       ...TrackerService.values.expand(
         (s) => [prefs.remove(trackerFilterModePref(s).key), prefs.remove(trackerFilterIdsPref(s).key)],
       ),
@@ -769,5 +777,7 @@ class SettingsService extends BaseSharedPreferencesService {
     PaintingBinding.instance.imageCache.clear();
     PaintingBinding.instance.imageCache.clearLiveImages();
     await PlexImageCacheManager.instance.emptyCache();
+    await WatchStateOverlay.instance.invalidateCache();
+    TrackerCoordinator.instance.invalidateResolverCache();
   }
 }

--- a/lib/services/trackers/tracker.dart
+++ b/lib/services/trackers/tracker.dart
@@ -1,6 +1,7 @@
 import '../../models/trackers/tracker_context.dart';
 import '../settings_service.dart';
 import 'tracker_constants.dart';
+import 'tracker_watch_state_provider.dart';
 
 /// Abstract tracker contract: the coordinator calls [markWatched] once per
 /// playback when progress crosses the watched threshold. Enabled/auth gating
@@ -31,6 +32,10 @@ abstract class Tracker {
 
   Future<void> markWatched(TrackerContext ctx);
   Future<void> markUnwatched(TrackerContext ctx);
+
+  /// Optional: if this tracker supports pull-based watch state authority,
+  /// return its provider here. Returns [null] by default (push-only trackers).
+  TrackerWatchStateProvider? get watchStateProvider => null;
 }
 
 class TrackerRatingUnavailableException implements Exception {
@@ -56,6 +61,9 @@ abstract class TrackerBase implements Tracker {
   bool get canScrobble => _isEnabled && hasActiveClient;
 
   @override
+  TrackerWatchStateProvider? get watchStateProvider => null;
+
+  @override
   Future<void> initialize() async {
     if (_isInitialized) return;
     _isInitialized = true;
@@ -66,6 +74,9 @@ abstract class TrackerBase implements Tracker {
   Future<void> setEnabled(bool enabled) async {
     _isEnabled = enabled;
   }
+
+  @override
+  Future<void> markUnwatched(TrackerContext ctx) async {}
 
   @override
   bool shouldScrobbleForLibrary(String? libraryGlobalKey) =>

--- a/lib/services/trackers/tracker_lifecycle.dart
+++ b/lib/services/trackers/tracker_lifecycle.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+
+import '../../media/media_item.dart';
+import '../../media/media_server_client.dart';
+import '../multi_server_manager.dart';
+import '../trakt/trakt_scrobble_service.dart';
+import '../trakt/trakt_sync_service.dart';
+import 'tracker_coordinator.dart';
+
+/// Centralises all tracker service lifecycle calls so main.dart
+/// never imports individual tracker implementations.
+///
+/// When adding a new authority-capable tracker:
+///   1. Add its initialisation to [initializeWithServerManager].
+///   2. Add its teardown to [dispose] / [cancelInFlight] as needed.
+/// When adding a new scrobble-only tracker:
+///   1. Register it in [TrackerCoordinator].
+class TrackerLifecycle {
+  TrackerLifecycle._();
+
+  static Future<void> initializeScrobble() =>
+      TraktScrobbleService.instance.initialize();
+
+  /// Initialises all non-Trakt trackers (MAL, AniList, Simkl).
+  /// Passed as [onFirstMount] in main.dart so initialization waits for
+  /// the first widget mount (when a Plex profile is available).
+  static Future<void> initializeCoordinator() =>
+      TrackerCoordinator.instance.initialize();
+
+  /// Initialises all tracker services that require a [MultiServerManager]
+  /// (e.g. for GUID lookups and Plex-layer cache management).
+  static void initializeWithServerManager(MultiServerManager serverManager) {
+    unawaited(TraktSyncService.instance.initialize(serverManager: serverManager));
+  }
+
+  /// Starts scrobbling for a new playback session.
+  static void startPlayback(MediaItem metadata, MediaServerClient client, {bool isLive = false}) {
+    unawaited(TraktScrobbleService.instance.startPlayback(metadata, client, isLive: isLive));
+    unawaited(TrackerCoordinator.instance.startPlayback(metadata, client, isLive: isLive));
+  }
+
+  /// Updates the current playback position for all active scrobblers.
+  static void updatePosition(Duration position) {
+    TraktScrobbleService.instance.updatePosition(position);
+    TrackerCoordinator.instance.updatePosition(position);
+  }
+
+  /// Updates the known duration for all active scrobblers.
+  static void updateDuration(Duration duration) {
+    TraktScrobbleService.instance.updateDuration(duration);
+    TrackerCoordinator.instance.updateDuration(duration);
+  }
+
+  /// Signals that playback resumed after a pause.
+  static void resumePlayback() {
+    unawaited(TraktScrobbleService.instance.resumePlayback());
+  }
+
+  /// Signals that playback was paused.
+  static void pausePlayback() {
+    unawaited(TraktScrobbleService.instance.pausePlayback());
+  }
+
+  /// Stops active playback scrobbling and any in-flight threshold tracking.
+  /// Call this from the video player instead of importing tracker services directly.
+  static Future<void> stopPlayback() async {
+    unawaited(TraktScrobbleService.instance.stopPlayback());
+    await TrackerCoordinator.instance.stopPlayback();
+  }
+
+  /// Cancels all in-flight tracker operations across all tracker families.
+  static void cancelInFlight() {
+    TrackerCoordinator.instance.cancelInFlight();
+    TraktScrobbleService.instance.cancelInFlight();
+  }
+
+  static Future<void> dispose() => TraktSyncService.instance.dispose();
+
+  static void flushQueue() => TraktSyncService.instance.flushQueue();
+}

--- a/lib/services/trackers/tracker_rating_service.dart
+++ b/lib/services/trackers/tracker_rating_service.dart
@@ -1,0 +1,57 @@
+import '../trakt/trakt_scrobble_service.dart';
+import 'anilist/anilist_tracker.dart';
+import 'mal/mal_tracker.dart';
+import 'simkl/simkl_tracker.dart';
+import 'tracker_constants.dart';
+import 'tracker_id_resolver.dart' show TrackerRatingContext;
+
+/// Generic rating dispatcher. UI widgets call into this service instead of
+/// importing concrete tracker classes, so adding (or replacing) a tracker
+/// requires no widget-level changes.
+///
+/// This file is the only allowlisted import of concrete tracker classes from
+/// outside their own subfolder — see CLAUDE.md's "Tracker import hygiene"
+/// section.
+class TrackerRatingService {
+  static final TrackerRatingService instance = TrackerRatingService._();
+  TrackerRatingService._();
+
+  Future<int?> getRating(TrackerService service, TrackerRatingContext ctx) {
+    switch (service) {
+      case TrackerService.trakt:
+        return TraktScrobbleService.instance.getRating(ctx);
+      case TrackerService.mal:
+        return MalTracker.instance.getRating(ctx);
+      case TrackerService.anilist:
+        return AnilistTracker.instance.getRating(ctx);
+      case TrackerService.simkl:
+        return SimklTracker.instance.getRating(ctx);
+    }
+  }
+
+  Future<void> rate(TrackerService service, TrackerRatingContext ctx, int score) {
+    switch (service) {
+      case TrackerService.trakt:
+        return TraktScrobbleService.instance.rate(ctx, score);
+      case TrackerService.mal:
+        return MalTracker.instance.rate(ctx, score);
+      case TrackerService.anilist:
+        return AnilistTracker.instance.rate(ctx, score);
+      case TrackerService.simkl:
+        return SimklTracker.instance.rate(ctx, score);
+    }
+  }
+
+  Future<void> clearRating(TrackerService service, TrackerRatingContext ctx) {
+    switch (service) {
+      case TrackerService.trakt:
+        return TraktScrobbleService.instance.clearRating(ctx);
+      case TrackerService.mal:
+        return MalTracker.instance.clearRating(ctx);
+      case TrackerService.anilist:
+        return AnilistTracker.instance.clearRating(ctx);
+      case TrackerService.simkl:
+        return SimklTracker.instance.clearRating(ctx);
+    }
+  }
+}

--- a/lib/services/trackers/tracker_stub_resolver.dart
+++ b/lib/services/trackers/tracker_stub_resolver.dart
@@ -1,0 +1,39 @@
+import '../plex_client.dart';
+import '../../media/media_item.dart';
+
+/// Optional capability a [Tracker] can implement to resolve its synthetic stub
+/// IDs to real Plex metadata and to manage the stub→Plex bridge map.
+///
+/// Implement this alongside [TrackerWatchStateProvider] when the tracker
+/// produces "Continue Watching" stubs (e.g. Trakt). Scrobble-only trackers
+/// (MAL, AniList, Simkl) do not implement this.
+abstract class TrackerStubResolver {
+  /// True when [stubId] was synthesized by this tracker.
+  bool ownsStub(String stubId) => false;
+
+  /// Resolve a stub episode to the real Plex episode [MediaItem].
+  /// Returns [stub] unchanged when resolution fails.
+  Future<MediaItem> resolveEpisodeStub(MediaItem stub, PlexClient client) async => stub;
+
+  /// Resolve a stub movie to the real Plex movie [MediaItem].
+  /// Returns null when the movie was not found in any Plex library.
+  Future<MediaItem?> resolveMovieStub(MediaItem stub, PlexClient client) async => stub;
+
+  /// Build a navigation-ready show [MediaItem] from a stub episode.
+  /// Returns null when the show cannot be resolved.
+  Future<MediaItem?> resolveStubShowForNavigation(MediaItem stub, PlexClient client) async => null;
+
+  /// Build a navigation-ready movie [MediaItem] from a stub.
+  /// Returns null when the movie cannot be resolved.
+  Future<MediaItem?> resolveStubMovieForNavigation(MediaItem stub, PlexClient client) async => null;
+
+  /// Enrich unresolved stubs by searching Plex servers and populating the bridge
+  /// map. Safe to call fire-and-forget; concurrent callers wait for the in-progress
+  /// run rather than starting a second one.
+  Future<void> enrichStubs(String? preferredServerId, Map<String, PlexClient> clientMap) async {}
+
+  /// Eagerly resolve episode display positions for Continue Watching cards so
+  /// the correct S/E is shown before the user taps anything.
+  Future<void> resolveEpisodeDisplayPositions(
+      Map<String, PlexClient> clients, String? fallbackServerId) async {}
+}

--- a/lib/services/trackers/tracker_sync_notifier.dart
+++ b/lib/services/trackers/tracker_sync_notifier.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+import 'tracker_watch_state_provider.dart';
+import 'watch_state_overlay.dart';
+
+/// Generic tracker sync hub. Screens subscribe here for any tracker
+/// sync/state-change notification without coupling to a specific tracker.
+///
+/// A tracker account provider (e.g. [TraktAccountProvider]) drives this by
+/// calling [activateAuthority] on connect and [deactivateAuthority] on
+/// disconnect. Adding a new tracker requires no screen-level changes.
+class TrackerSyncNotifier extends ChangeNotifier {
+  static final TrackerSyncNotifier instance = TrackerSyncNotifier._();
+  TrackerSyncNotifier._();
+
+  VoidCallback? _triggerPostPlaybackSync;
+  Future<void> Function()? _forceSyncWatchState;
+  Future<void> Function()? _syncIfStale;
+
+  /// Register [provider] as the active watch-state authority and bind the
+  /// tracker's sync-action callbacks. Call this from the tracker account
+  /// provider when the user connects or re-enables watch-state authority.
+  ///
+  /// Activation flow: TrackerAccountProvider → TrackerSyncNotifier.activateAuthority
+  /// → WatchStateOverlay.setActiveProvider → TrackerWatchStateProvider (see CLAUDE.md §Activation flow).
+  ///
+  /// Internally wires [WatchStateOverlay] so no tracker need import it directly.
+  void activateAuthority(
+    TrackerWatchStateProvider provider, {
+    required VoidCallback triggerPostPlaybackSync,
+    required Future<void> Function() forceSyncWatchState,
+    required Future<void> Function() syncIfStale,
+  }) {
+    // Provider must be registered first so any listener that fires during
+    // this synchronous call sees a valid overlay. The callback assignments
+    // below are safe because Dart is single-threaded — no listener can run
+    // between setActiveProvider and the end of this method.
+    WatchStateOverlay.instance.setActiveProvider(provider);
+    _triggerPostPlaybackSync = triggerPostPlaybackSync;
+    _forceSyncWatchState = forceSyncWatchState;
+    _syncIfStale = syncIfStale;
+  }
+
+  /// Clear the active watch-state authority and all action callbacks. Call this
+  /// from the tracker account provider on disconnect or when the user disables
+  /// watch-state authority.
+  void deactivateAuthority() {
+    WatchStateOverlay.instance.setActiveProvider(null);
+    _triggerPostPlaybackSync = null;
+    _forceSyncWatchState = null;
+    _syncIfStale = null;
+  }
+
+  /// Called by the active tracker account provider after each sync or state
+  /// change. Notifies all screen-level listeners.
+  void notifySync() => notifyListeners();
+
+  /// Fire-and-forget sync triggered 2 s after playback ends.
+  void triggerPostPlaybackSync() => _triggerPostPlaybackSync?.call();
+
+  /// Full re-sync, ignoring activity timestamps. Awaitable.
+  Future<void> forceSyncWatchState() => _forceSyncWatchState?.call() ?? Future.value();
+
+  /// Sync only when remote data has changed since last sync. Awaitable.
+  Future<void> syncIfStale() => _syncIfStale?.call() ?? Future.value();
+}

--- a/lib/services/trackers/tracker_ui_helper.dart
+++ b/lib/services/trackers/tracker_ui_helper.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../plex_client.dart';
+import '../../media/media_item.dart';
+import '../../media/media_kind.dart';
+import '../../providers/offline_mode_provider.dart';
+import '../../screens/media_detail_screen.dart';
+import '../../utils/provider_extensions.dart';
+import 'watch_state_overlay.dart';
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Navigation helpers — tracker stub → Plex MediaDetailScreen
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Navigates to the show detail screen for a tracker stub episode.
+/// Resolves via the active [TrackerStubResolver]; no-op when no resolver is active.
+Future<void> navigateToTrackerStubShow(BuildContext context, MediaItem stub,
+    {bool isOffline = false}) async {
+  final resolver = WatchStateOverlay.instance.stubResolver;
+  if (resolver == null) return;
+  final client = context.getPlexClientWithFallback(stub.serverId);
+  final showItem = await resolver.resolveStubShowForNavigation(stub, client);
+  if (!context.mounted) return;
+  if (showItem == null) {
+    ScaffoldMessenger.maybeOf(context)
+        ?.showSnackBar(const SnackBar(content: Text('Could not find this show in your Plex library')));
+    return;
+  }
+  await Navigator.push(
+    context,
+    MaterialPageRoute(builder: (_) => MediaDetailScreen(metadata: showItem, isOffline: isOffline)),
+  );
+}
+
+/// Navigates to the movie detail screen for a tracker stub movie.
+/// Resolves via the active [TrackerStubResolver]; no-op when no resolver is active.
+Future<void> navigateToTrackerMovieDetail(BuildContext context, MediaItem stub,
+    {bool isOffline = false}) async {
+  final resolver = WatchStateOverlay.instance.stubResolver;
+  if (resolver == null) return;
+  final client = context.getPlexClientWithFallback(stub.serverId);
+  final movieItem = await resolver.resolveStubMovieForNavigation(stub, client);
+  if (!context.mounted) return;
+  if (movieItem == null) {
+    ScaffoldMessenger.maybeOf(context)
+        ?.showSnackBar(const SnackBar(content: Text('Could not find this movie in your Plex library')));
+    return;
+  }
+  await Navigator.push(
+    context,
+    MaterialPageRoute(builder: (_) => MediaDetailScreen(metadata: movieItem, isOffline: isOffline)),
+  );
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Resolution helpers — stub → real Plex MediaItem (for playback)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Resolves [item] to its effective Plex [MediaItem] for a user-initiated action
+/// (mark watched, remove from continue watching, etc.). Use this for mutations.
+/// For navigation/playback use [resolveTrackerEpisodeStub] / [resolveTrackerMovieStub] directly.
+///
+/// Returns [item] unchanged when no active resolver owns it.
+/// Returns the resolved item on success.
+/// Returns null and shows an error snackbar when resolution fails; callers must
+/// check [context].mounted before using a null result.
+Future<MediaItem?> resolveTrackerItemForAction(BuildContext context, MediaItem item) async {
+  final resolver = WatchStateOverlay.instance.stubResolver;
+  if (resolver == null || !resolver.ownsStub(item.id)) return item;
+  // Stub resolution requires a live Plex connection — refuse when offline.
+  if (context.read<OfflineModeProvider>().isOffline) {
+    ScaffoldMessenger.maybeOf(context)
+        ?.showSnackBar(const SnackBar(content: Text('Cannot resolve this item while offline')));
+    return null;
+  }
+  final client = context.getPlexClientWithFallback(item.serverId);
+  final MediaItem? resolved = item.kind == MediaKind.movie
+      ? await resolver.resolveMovieStub(item, client)
+      : await resolver.resolveEpisodeStub(item, client);
+  if (!context.mounted) return null;
+  if (resolved == null) {
+    ScaffoldMessenger.maybeOf(context)
+        ?.showSnackBar(const SnackBar(content: Text('Could not find this item in your Plex library')));
+  }
+  return resolved;
+}
+
+/// Resolves a tracker stub episode to the real Plex episode [MediaItem].
+/// Returns [stub] unchanged when no resolver is active, resolution fails, or offline.
+Future<MediaItem> resolveTrackerEpisodeStub(BuildContext context, MediaItem stub) async {
+  if (context.read<OfflineModeProvider>().isOffline) return stub;
+  final resolver = WatchStateOverlay.instance.stubResolver;
+  if (resolver == null || !resolver.ownsStub(stub.id)) return stub;
+  final client = context.getPlexClientWithFallback(stub.serverId);
+  return resolver.resolveEpisodeStub(stub, client);
+}
+
+/// Resolves a tracker stub movie to the real Plex movie [MediaItem].
+/// Returns [stub] when no resolver is active or offline; null when the movie was not found.
+Future<MediaItem?> resolveTrackerMovieStub(BuildContext context, MediaItem stub) async {
+  if (context.read<OfflineModeProvider>().isOffline) return stub;
+  final resolver = WatchStateOverlay.instance.stubResolver;
+  if (resolver == null || !resolver.ownsStub(stub.id)) return stub;
+  final client = context.getPlexClientWithFallback(stub.serverId);
+  return resolver.resolveMovieStub(stub, client);
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Enrichment helpers — populate stub→Plex bridge map in the background
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Searches Plex for tracker stubs not yet in the bridge map and populates it.
+/// Safe to call fire-and-forget; concurrent callers wait for the in-progress run.
+Future<void> enrichTrackerStubs(
+    String? preferredServerId, Map<String, PlexClient> clientMap) async {
+  await WatchStateOverlay.instance.stubResolver?.enrichStubs(preferredServerId, clientMap);
+}
+
+/// Eagerly resolves episode display positions for Continue Watching cards so
+/// the correct S/E label is shown before the user taps anything.
+Future<void> resolveTrackerEpisodeDisplayPositions(
+    Map<String, PlexClient> clients, String? fallbackServerId) async {
+  await WatchStateOverlay.instance.stubResolver
+      ?.resolveEpisodeDisplayPositions(clients, fallbackServerId);
+}

--- a/lib/services/trackers/tracker_watch_state_provider.dart
+++ b/lib/services/trackers/tracker_watch_state_provider.dart
@@ -1,0 +1,121 @@
+import '../../media/media_item.dart';
+import '../plex_client.dart';
+import 'tracker_stub_resolver.dart';
+
+/// Overlay DTO that mirrors watch-state fields so the UI layer needs
+/// zero Trakt-specific code. Values here directly replace the corresponding
+/// fields on [MediaItem] via `copyWith`.
+class WatchStateOverride {
+  /// Replaces [MediaItem.viewCount] — number of times watched.
+  final int? viewCount;
+
+  /// Replaces [MediaItem.viewOffsetMs] — resume position in milliseconds.
+  /// Semantics: null = preserve the item's existing Plex offset (tracker has no
+  /// opinion); 0 = explicit no-progress (tracker confirms unwatched or complete);
+  /// positive = tracker's resume position.
+  final int? viewOffset;
+
+  /// Replaces [MediaItem.viewedLeafCount] — watched episodes in a show/season.
+  final int? viewedLeafCount;
+
+  /// Replaces [MediaItem.leafCount] — total episodes in a show/season.
+  final int? leafCount;
+
+  /// Replaces [MediaItem.lastViewedAt] — unix timestamp (seconds).
+  final int? lastViewedAt;
+
+  const WatchStateOverride({this.viewCount, this.viewOffset, this.viewedLeafCount, this.leafCount, this.lastViewedAt});
+}
+
+/// A lightweight item representing an in-progress piece of content from the
+/// tracker's `/sync/playback` endpoint, used by the "Continue Watching" hub.
+class ContinueWatchingItem {
+  /// The media item enriched with tracker progress.
+  final MediaItem metadata;
+
+  /// Progress percentage (0–100) from the tracker.
+  final double progress;
+
+  /// The next episode after [metadata], pre-fetched from Plex during enrichment.
+  /// Null for movies, if the show has no further episodes, or if enrichment
+  /// has not yet run. Used to immediately populate Continue Watching after the
+  /// user marks the current episode as watched.
+  final MediaItem? nextEpisode;
+
+  const ContinueWatchingItem({
+    required this.metadata,
+    required this.progress,
+    this.nextEpisode,
+  });
+}
+
+/// Optional capability a [Tracker] can implement to provide authoritative
+/// watch state via pull-based sync rather than just push-based scrobbling.
+///
+/// Only one tracker may be active as watch-state authority at a time.
+/// When active, its data replaces the server's native watch fields
+/// before the UI renders them — no fields are added or removed.
+abstract class TrackerWatchStateProvider {
+  /// Human-readable name of the tracker (e.g. 'Trakt'). Shown in UI badges.
+  String get trackerName;
+
+  /// Whether the user has enabled this tracker as the watch state authority.
+  bool get isTrackerStateAuthorityEnabled;
+
+  /// Completes when the initial cache load is finished.
+  Future<void> get cacheReady;
+
+  /// Pull all watch data from the tracker. Called once on app boot (background)
+  /// and on reconnect after going offline. Must NOT block the UI thread.
+  Future<void> syncWatchState();
+
+  /// Synchronous lookup for a single [MediaItem]. Returns [null] if
+  /// no tracker data exists for this item — in which case the original
+  /// server state is shown unchanged.
+  WatchStateOverride? getOverrideFor(MediaItem item);
+
+  /// In-progress items from the tracker's playback-progress endpoint.
+  /// Sorted by most-recently-paused first.
+  List<ContinueWatchingItem> getContinueWatchingItems();
+
+  /// Drop all in-memory and persistent cached state. Called on account switch
+  /// or when the user manually requests a cache clear.
+  Future<void> invalidateCache();
+
+  /// Returns the up-next (season, episode) position for a show by its media ID.
+  /// Null when this tracker does not track positional watch state.
+  ({int season, int episode, int? tvdb, int? tmdb})? getUpNextPosition(String mediaId) => null;
+
+  /// Lazily fetch detailed show progress if not already cached.
+  /// Returns true if new data arrived that warrants a UI refresh.
+  Future<bool> fetchShowProgressIfNeeded(MediaItem show) async => false;
+
+  /// Queue a tracker scrobble for offline playback. Called when the player
+  /// crosses the watch threshold while offline. Implementors persist the action
+  /// so [flushOfflineQueue] can drain it when the network returns.
+  Future<void> queueOfflineScrobble(MediaItem item, {required double progressPercent}) async {}
+
+  /// Drain any queued offline scrobbles to the tracker's API.
+  /// Called when the app detects it is back online.
+  Future<void> flushOfflineQueue() async {}
+
+  /// Optimistically remove [item] from the local playback cache so it
+  /// disappears from Continue Watching immediately, without waiting for the
+  /// tracker's history push to complete. A background sync confirms the state.
+  void evictFromPlayback(MediaItem item) {}
+
+  /// Returns this provider as a [TrackerStubResolver] if it also implements
+  /// that interface, or null otherwise. Override to return [this] when the
+  /// tracker produces synthetic stub IDs for Continue Watching.
+  TrackerStubResolver? get asStubResolver => null;
+
+  /// Items in the tracker's primary curated list when acting as watch-state
+  /// authority (e.g. Trakt's watchlist). Resolved against the user's Plex
+  /// libraries via [clients] (keyed by serverId) — only items present in the
+  /// user's Plex library are returned; unresolved entries are dropped.
+  /// Returns empty for trackers that have no list concept. When non-empty
+  /// the Playlists tab renders these items in place of Plex playlists.
+  Future<List<MediaItem>> getAuthorityListItems(
+    Map<String, PlexClient> clients,
+  ) async => const [];
+}

--- a/lib/services/trackers/watch_state_overlay.dart
+++ b/lib/services/trackers/watch_state_overlay.dart
@@ -1,0 +1,188 @@
+import '../../media/media_item.dart';
+import '../../utils/app_logger.dart';
+import '../plex_client.dart';
+import 'tracker_stub_resolver.dart';
+import 'tracker_watch_state_provider.dart';
+
+/// Central synchronous overlay point: the UI calls [apply] / [applyAll] to
+/// get the authoritative version of a [MediaItem]. All data is pre-loaded in
+/// memory by [TrackerWatchStateProvider.syncWatchState], so these methods
+/// never block.
+///
+/// **Load-bearing invariant — do not weaken without re-reading pr.md
+/// "What is not affected":** when an authority is active and the tracker has
+/// no record for an item, [apply] zeroes the watch-state fields rather than
+/// passing through Plex's own counts. The entire "tracker as source of truth"
+/// guarantee depends on this. A future refactor that decides "fall back to
+/// Plex when tracker has no record" would silently re-introduce a watch-state
+/// leak this overlay was built to prevent.
+///
+/// Usage:
+/// ```dart
+/// final overlay = WatchStateOverlay.instance;
+/// final enriched = overlay.apply(rawItem);
+/// ```
+class WatchStateOverlay {
+  static final WatchStateOverlay instance = WatchStateOverlay._();
+  WatchStateOverlay._();
+
+  TrackerWatchStateProvider? _activeProvider;
+
+  /// Register the active watch-state authority. Pass [null] to disable.
+  void setActiveProvider(TrackerWatchStateProvider? provider) {
+    appLogger.d('WatchStateOverlay: activating provider ${provider?.runtimeType}');
+    _activeProvider = provider;
+  }
+
+  /// Whether any tracker is currently acting as watch state authority.
+  bool get hasActiveAuthority {
+    final p = _activeProvider;
+    return p != null && p.isTrackerStateAuthorityEnabled;
+  }
+
+  /// The display name of the active tracker authority (e.g. 'Trakt'), or null.
+  String? get activeTrackerName => hasActiveAuthority ? _activeProvider!.trackerName : null;
+
+  /// Completes when the active provider's initial cache load is finished.
+  Future<void> get cacheReady async {
+    if (_activeProvider != null) {
+      await _activeProvider!.cacheReady;
+    }
+  }
+
+  MediaItem _applyOverride(MediaItem item, WatchStateOverride override) => item.copyWith(
+    viewCount: override.viewCount ?? item.viewCount,
+    viewOffsetMs: override.viewOffset ?? item.viewOffsetMs,
+    viewedLeafCount: override.viewedLeafCount ?? item.viewedLeafCount,
+    leafCount: override.leafCount ?? item.leafCount,
+    lastViewedAt: override.lastViewedAt ?? item.lastViewedAt,
+  );
+
+  /// Apply the active authority's data to a single [MediaItem].
+  ///
+  /// Returns a new [MediaItem] with overridden watch-state fields, or the
+  /// original item if no override exists or no authority is active.
+  MediaItem apply(MediaItem item) {
+    if (!hasActiveAuthority) {
+      appLogger.t('WatchStateOverlay: no active authority for ${item.title}');
+      return item;
+    }
+    final override = _activeProvider!.getOverrideFor(item);
+    if (override == null) {
+      // Tracker is authority but has no record for this item — treat as unwatched.
+      // Never let Plex's own watch state leak through when a tracker is active.
+      appLogger.t('WatchStateOverlay: no tracker record for ${item.title} (${item.id}) — zeroing watch state');
+      return item.copyWith(viewCount: 0, viewOffsetMs: 0, viewedLeafCount: 0, lastViewedAt: null);
+    }
+
+    final enriched = _applyOverride(item, override);
+    appLogger.t(
+      'WatchStateOverlay: Enriched ${item.title} (${item.id}) with ${_activeProvider!.trackerName} data: '
+      'offset=${enriched.viewOffsetMs}, count=${enriched.viewCount}, '
+      'leaf=${enriched.viewedLeafCount}/${enriched.leafCount}',
+    );
+    return enriched;
+  }
+
+  /// Apply to an entire list. Safe to call on large lists (synchronous, O(n)).
+  List<MediaItem> applyAll(List<MediaItem> items) {
+    appLogger.t('WatchStateOverlay.applyAll: items=${items.length}, authority=$hasActiveAuthority');
+    if (!hasActiveAuthority) return items;
+    appLogger.t('WatchStateOverlay: processing batch of ${items.length} items');
+    return items.map(apply).toList();
+  }
+
+  /// Apply overlay AND filter to only items the tracker has any watch record for.
+  /// Single-pass — calls [getOverrideFor] once per item. Use for library-level
+  /// Continue Watching hubs when the tracker is authority; prevents Plex-only
+  /// in-progress items from leaking through.
+  List<MediaItem> applyAllContinueWatching(List<MediaItem> items) {
+    if (!hasActiveAuthority) return applyAll(items);
+    final result = <MediaItem>[];
+    for (final item in items) {
+      final override = _activeProvider!.getOverrideFor(item);
+      if (override == null) continue;
+      result.add(_applyOverride(item, override));
+    }
+    return result;
+  }
+
+  /// Returns true if the active tracker has in-progress playback for [item]
+  /// (i.e. an override exists with viewOffset > 0). Used to filter movies
+  /// in authority mode — only include movies Trakt actually knows about.
+  bool hasTrackerProgress(MediaItem item) {
+    if (!hasActiveAuthority) return false;
+    final override = _activeProvider!.getOverrideFor(item);
+    return override != null && (override.viewOffset ?? 0) > 0;
+  }
+
+  /// Returns true if the active tracker has ANY watch record for [item]
+  /// (viewed, in-progress, or timestamped). Used to filter "Recently Watched"
+  /// hub items — only show items Trakt knows the user has seen.
+  bool hasTrackerRecord(MediaItem item) {
+    if (!hasActiveAuthority) return false;
+    return _activeProvider!.getOverrideFor(item) != null;
+  }
+
+  /// The "Continue Watching" items from the active tracker's playback data.
+  /// Empty list when no authority is active.
+  List<ContinueWatchingItem> getContinueWatchingItems() {
+    if (!hasActiveAuthority) return const [];
+    return _activeProvider!.getContinueWatchingItems();
+  }
+
+  /// Items in the active tracker's primary curated list (e.g. Trakt watchlist),
+  /// resolved against [clients] (keyed by serverId). Empty when no authority
+  /// is active or the active tracker has no list concept. Consumed by the
+  /// Playlists tab when authority is on — Plex playlists are hidden in that
+  /// mode and these items render in their place.
+  Future<List<MediaItem>> getAuthorityListItems(
+    Map<String, PlexClient> clients,
+  ) {
+    if (!hasActiveAuthority) return Future.value(const []);
+    return _activeProvider!.getAuthorityListItems(clients);
+  }
+
+  /// Returns the up-next (season, episode) position for a show.
+  /// Null when no authority is active or the tracker doesn't support this.
+  ({int season, int episode, int? tvdb, int? tmdb})? getUpNextPosition(String mediaId) {
+    if (!hasActiveAuthority) return null;
+    return _activeProvider!.getUpNextPosition(mediaId);
+  }
+
+  /// Lazily fetch detailed show progress if not already cached.
+  /// Returns true if new data arrived that warrants a UI refresh.
+  Future<bool> fetchShowProgressIfNeeded(MediaItem show) {
+    if (!hasActiveAuthority) return Future.value(false);
+    return _activeProvider!.fetchShowProgressIfNeeded(show);
+  }
+
+  /// Queue a tracker scrobble for offline playback. No-op when no authority is active.
+  Future<void> queueOfflineScrobble(MediaItem item, {required double progressPercent}) {
+    if (!hasActiveAuthority) return Future.value();
+    return _activeProvider!.queueOfflineScrobble(item, progressPercent: progressPercent);
+  }
+
+  /// Drain queued offline scrobbles. Call when the network returns.
+  Future<void> flushOfflineQueue() {
+    if (!hasActiveAuthority) return Future.value();
+    return _activeProvider!.flushOfflineQueue();
+  }
+
+  /// Optimistically evict [item] from the active tracker's playback cache
+  /// so Continue Watching updates immediately, without waiting for the
+  /// tracker API push to finish. A background sync confirms the final state.
+  void evictFromPlayback(MediaItem item) => _activeProvider?.evictFromPlayback(item);
+
+  /// Drop all in-memory and persisted cache for the active tracker authority.
+  /// No-op when no authority is active.
+  Future<void> invalidateCache() => _activeProvider?.invalidateCache() ?? Future.value();
+
+  /// Returns the active tracker's stub resolver, or null when the active
+  /// tracker does not support stub resolution (or no authority is active).
+  TrackerStubResolver? get stubResolver {
+    final p = _activeProvider;
+    if (p == null || !p.isTrackerStateAuthorityEnabled) return null;
+    return p.asStubResolver;
+  }
+}

--- a/lib/services/trakt/trakt_client.dart
+++ b/lib/services/trakt/trakt_client.dart
@@ -64,12 +64,88 @@ class TraktClient {
 
   Future<void> removeRatings(Map<String, dynamic> body) => _request('POST', '/sync/ratings/remove', body: body);
 
-  Future<List<dynamic>> getRatings(String type) async {
-    final res = await _request('GET', '/sync/ratings/$type');
-    return res is List ? res : const [];
+  /// Saves current playback progress as a resume point.
+  /// Per trakt.apib, /scrobble/stop with progress < 80% stores the position
+  /// without marking as watched. Returns immediately for progress < 1% to
+  /// avoid Trakt's 422 response.
+  Future<void> savePlaybackProgress(TraktScrobbleRequest item) {
+    if ((item.progress ?? 0) < 1.0) return Future.value();
+    return scrobbleStop(item);
   }
 
-  /// Refresh the access token. Coalesces concurrent calls so
+  // ---------------------------------------------------------------------------
+  // Pull methods — used by TraktWatchStateProvider for authoritative watch state
+  // ---------------------------------------------------------------------------
+
+  /// `GET /sync/watched/movies` — full history for all watched movies.
+  Future<List<dynamic>> getWatchedMovies() async {
+    final res = await _request('GET', '/sync/watched/movies');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// `GET /sync/watched/shows` — full history including per-season/episode data.
+  /// Does NOT use `?extended=noseasons` so we get the complete episode breakdown.
+  Future<List<dynamic>> getWatchedShows() async {
+    final res = await _request('GET', '/sync/watched/shows');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// `GET apiz.trakt.tv/sync/progress/up_next_nitro` — private endpoint that
+  /// returns shows with a next episode to watch, regardless of whether it has
+  /// been started. Used to supplement /sync/playback/episodes for shows where
+  /// the last episode was completed but the next hasn't been started.
+  Future<List<dynamic>> getUpNextItems() async {
+    final res = await _request('GET', '${TraktConstants.apizBase}/sync/progress/up_next_nitro');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// `GET /sync/playback/movies?extended=full,images` — all in-progress movies, paginated.
+  Future<List<dynamic>> getPlaybackMovies({int limit = 100}) =>
+      _fetchAllPages('/sync/playback/movies?extended=full,images', limit: limit);
+
+  /// `GET /sync/playback/episodes?extended=full,images` — all in-progress episodes, paginated.
+  Future<List<dynamic>> getPlaybackEpisodes({int limit = 100}) =>
+      _fetchAllPages('/sync/playback/episodes?extended=full,images', limit: limit);
+
+  /// `GET /sync/last_activities` — timestamps of the most recent watched/paused
+  /// events. Used to decide whether a full re-sync is necessary.
+  Future<Map<String, dynamic>> getLastActivities() async {
+    final res = await _request('GET', '/sync/last_activities');
+    return res as Map<String, dynamic>? ?? {};
+  }
+
+  /// `GET /shows/{id}/progress/watched` — detailed season/episode breakdown for
+  /// a specific show. Called lazily when a show detail screen is opened.
+  Future<Map<String, dynamic>> getShowWatchedProgress(int traktId) async {
+    final res = await _request('GET', '/shows/$traktId/progress/watched');
+    return res as Map<String, dynamic>? ?? {};
+  }
+
+  /// `GET /sync/watchlist/{type}` — user's watchlist (movies or shows).
+  Future<List<dynamic>> getWatchlist({String type = 'shows'}) async {
+    final res = await _request('GET', '/sync/watchlist/$type');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// `GET /sync/ratings/{type}` — user's ratings with rating value and date.
+  Future<List<dynamic>> getRatings({String type = 'shows'}) async {
+    final res = await _request('GET', '/sync/ratings/$type');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// `GET /sync/favorites/{type}` — user's favorites with optional notes.
+  Future<List<dynamic>> getFavorites({String type = 'shows'}) async {
+    final res = await _request('GET', '/sync/favorites/$type');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// `GET /sync/collection/{type}` — user's collected items with metadata.
+  Future<List<dynamic>> getCollection({String type = 'shows'}) async {
+    final res = await _request('GET', '/sync/collection/$type');
+    return res as List<dynamic>? ?? [];
+  }
+
+  /// Refresh the access token. Coalesces concurrent calls via [_refreshLock] so
   /// duplicate POSTs don't race when multiple in-flight requests hit 401.
   Future<TraktSession> refresh() => _refreshCoalescer.run(_doRefresh);
 
@@ -123,6 +199,50 @@ class TraktClient {
     }
   }
 
+  /// Fetches every page of a paginated Trakt list endpoint and returns the
+  /// merged items. [path] must already contain query params (e.g.
+  /// `?extended=full,images`) — `&page=N&limit=L` are appended per iteration.
+  Future<List<dynamic>> _fetchAllPages(String path, {int limit = 100}) async {
+    if (_session.needsRefresh) {
+      try {
+        await refresh();
+      } catch (_) {}
+    }
+
+    final allItems = <dynamic>[];
+    var page = 1;
+    var totalPages = 1;
+
+    do {
+      final pagePath = '$path&page=$page&limit=$limit';
+      var res = await _send('GET', pagePath);
+
+      if (res.statusCode == 401) {
+        await refresh();
+        res = await _send('GET', pagePath);
+      }
+      if (res.statusCode == 429) {
+        throw TraktRateLimitException(retryAfterSeconds: int.tryParse(res.headers['retry-after'] ?? ''));
+      }
+      if (res.statusCode != 200) {
+        throw TraktApiException(statusCode: res.statusCode, body: res.body);
+      }
+
+      if (res.body.isNotEmpty) {
+        try {
+          final decoded = json.decode(res.body);
+          if (decoded is List) allItems.addAll(decoded);
+        } catch (_) {}
+      }
+
+      totalPages = int.tryParse(res.headers['x-pagination-page-count'] ?? '1') ?? 1;
+      appLogger.d('Trakt paginated $path page=$page/$totalPages total=${allItems.length}');
+      page++;
+    } while (page <= totalPages);
+
+    return allItems;
+  }
+
   /// Send an authenticated request, refreshing on 401 and retrying once.
   Future<dynamic> _request(
     String method,
@@ -162,7 +282,7 @@ class TraktClient {
   }
 
   Future<http.Response> _send(String method, String path, {Map<String, dynamic>? body}) async {
-    final uri = Uri.parse('${TraktConstants.apiBase}$path');
+    final uri = path.startsWith('https://') ? Uri.parse(path) : Uri.parse('${TraktConstants.apiBase}$path');
     final headers = TraktConstants.headers(accessToken: _session.accessToken);
     final encoded = body == null ? null : json.encode(body);
 

--- a/lib/services/trakt/trakt_constants.dart
+++ b/lib/services/trakt/trakt_constants.dart
@@ -14,6 +14,7 @@ class TraktConstants {
   static const String clientSecret = 'acfa17b9d77fabd7e51175b7da6631aea69423530a6d49b3b3c38cd107cbd207';
 
   static const String apiBase = 'https://api.trakt.tv';
+  static const String apizBase = 'https://apiz.trakt.tv';
   static const String apiVersion = '2';
 
   // OAuth endpoints
@@ -48,7 +49,8 @@ enum TraktScrobbleState { start, pause, stop }
 /// Direction of a watched-status sync push.
 enum TraktSyncOp {
   add,
-  remove;
+  remove,
+  progress;
 
   static TraktSyncOp fromName(String name) =>
       values.firstWhere((v) => v.name == name, orElse: () => throw ArgumentError('Unknown TraktSyncOp: $name'));

--- a/lib/services/trakt/trakt_scrobble_service.dart
+++ b/lib/services/trakt/trakt_scrobble_service.dart
@@ -50,11 +50,15 @@ class TraktScrobbleService {
   TraktClient? _client;
   TrackerIdResolver? _resolver;
   TraktScrobbleRequest? _currentBody;
+  void Function(int traktShowId, int season, int episode)? _onPlaybackStopped;
   Duration _currentPosition = Duration.zero;
   Duration _currentDuration = Duration.zero;
   TraktScrobbleState? _lastSentState;
   DateTime? _lastSentAt;
   DateTime? _lastSeekCheckpointAt;
+  // Incremented by cancelInFlight() so any in-flight startPlayback can detect
+  // it has been superseded and self-abort before sending a ghost scrobble.
+  int _startGeneration = 0;
 
   Future<void> initialize() async {
     if (_isInitialized) return;
@@ -66,6 +70,14 @@ class TraktScrobbleService {
   Future<void> setEnabled(bool enabled) async {
     _isEnabled = enabled;
     if (!enabled) cancelInFlight();
+  }
+
+  /// Register a callback fired after each successful scrobble stop for an episode.
+  /// The resolved Trakt show ID, season, and episode number are passed directly
+  /// so the receiver can stamp the local cache without re-deriving IDs.
+  /// Pass null to unregister (e.g. on profile switch / disconnect).
+  void setOnPlaybackStopped(void Function(int traktShowId, int season, int episode)? callback) {
+    _onPlaybackStopped = callback;
   }
 
   /// Switch to a different account. Cancels any in-flight scrobble for the
@@ -88,7 +100,7 @@ class TraktScrobbleService {
     final localIds = TraktIds.fromExternal(ctx.ids.external).toJson();
     if (localIds.isEmpty) throw const TrackerRatingUnavailableException('Trakt');
 
-    final entries = await client.getRatings(_ratingType(ctx));
+    final entries = await client.getRatings(type: _ratingType(ctx));
     for (final entry in entries) {
       if (entry is! Map) continue;
       if (!_ratingEntryMatches(ctx, entry.cast<String, dynamic>(), localIds)) continue;
@@ -112,7 +124,11 @@ class TraktScrobbleService {
 
   /// Drop the current scrobble state without sending a stop. Called on profile
   /// switch and when the service is disabled mid-playback.
+  /// Incrementing [_startGeneration] causes any concurrent [startPlayback]
+  /// still awaiting [_buildBody] to self-abort rather than send a ghost scrobble.
   void cancelInFlight() {
+    appLogger.d('Trakt [scrobble]: cancelInFlight() gen $_startGeneration → ${_startGeneration + 1}, hadBody=${_currentBody != null}, lastState=$_lastSentState');
+    _startGeneration++;
     _currentBody = null;
     _lastSentState = null;
     _lastSentAt = null;
@@ -123,6 +139,13 @@ class TraktScrobbleService {
   }
 
   bool get _canScrobble => _isEnabled && _client != null;
+
+  /// True when the most recent scrobble event sent was a stop.
+  /// Used by TraktSyncService to suppress the final progress push that fires
+  /// immediately after _sendStoppedProgressOnce() during episode navigation.
+  /// Must be checked before any await — cancelInFlight() clears _lastSentState
+  /// before _dispatch fires, so a late check would always return false.
+  bool get wasRecentlyStopped => _lastSentState == TraktScrobbleState.stop;
 
   String _ratingType(TrackerRatingContext ctx) => switch (ctx.kind) {
     MediaKind.movie => 'movies',
@@ -219,7 +242,10 @@ class TraktScrobbleService {
   }
 
   Future<void> startPlayback(MediaItem metadata, MediaServerClient client, {bool isLive = false}) async {
-    if (!_canScrobble) return;
+    if (!_canScrobble) {
+      appLogger.i('Trakt [scrobble]: startPlayback() — skipped (enabled=$_isEnabled, hasClient=${_client != null})');
+      return;
+    }
     if (isLive) return;
 
     final type = metadata.kind;
@@ -227,7 +253,7 @@ class TraktScrobbleService {
 
     final settings = SettingsService.instanceOrNull;
     if (settings != null && !settings.isLibraryAllowedForTracker(TrackerService.trakt, metadata.libraryGlobalKey)) {
-      appLogger.d('Trakt: library filtered out for ${metadata.id}');
+      appLogger.i('Trakt [scrobble]: startPlayback() — library filtered for ${metadata.id}');
       return;
     }
 
@@ -238,12 +264,21 @@ class TraktScrobbleService {
     _lastSeekCheckpointAt = null;
     _resolver = TrackerIdResolver(client, needsFribb: () => false);
 
+    final generation = ++_startGeneration;
+    appLogger.d('Trakt [scrobble]: startPlayback() — resolving IDs for ${metadata.id} at gen=$generation');
     final body = await _buildBody(metadata);
+    // A concurrent stopPlayback() or new startPlayback() increments _startGeneration.
+    // If ours no longer matches, this start was cancelled — abort without sending.
+    if (_startGeneration != generation) {
+      appLogger.d('Trakt [scrobble]: startPlayback() — aborted for ${metadata.id} (gen changed $generation → $_startGeneration)');
+      return;
+    }
     if (body == null) {
-      appLogger.d('Trakt: skipping scrobble — no usable IDs for ${metadata.id}');
+      appLogger.d('Trakt [scrobble]: startPlayback() — no usable IDs for ${metadata.id}, cancelling');
       cancelInFlight();
       return;
     }
+    appLogger.d('Trakt [scrobble]: startPlayback() — sending start for ${metadata.id} at gen=$generation');
     _currentBody = body;
     await _send(TraktScrobbleState.start, progress: _progressPercent());
   }
@@ -273,19 +308,63 @@ class TraktScrobbleService {
   }
 
   Future<void> pausePlayback() async {
-    if (_currentBody == null) return;
+    if (_currentBody == null) {
+      appLogger.d('Trakt [scrobble]: pausePlayback() — skipped (no active body)');
+      return;
+    }
+    // Don't send a pause if the last state was already a stop — the player
+    // fires isPlaying=false as a side-effect of navigation (pause() called in
+    // _navigateToEpisode before pushReplacement). Sending pause after stop
+    // would re-add the episode to Trakt's /sync/playback, undoing the
+    // watched-marking from the stop scrobble.
+    if (_lastSentState == TraktScrobbleState.stop) {
+      appLogger.d('Trakt [scrobble]: pausePlayback() — suppressed (last sent was stop, would undo watched-mark)');
+      return;
+    }
+    appLogger.d('Trakt [scrobble]: pausePlayback() — sending pause @ ${_progressPercent().toStringAsFixed(1)}% (lastState=$_lastSentState)');
     await _send(TraktScrobbleState.pause, progress: _progressPercent());
   }
 
   Future<void> resumePlayback() async {
-    if (_currentBody == null) return;
+    if (_currentBody == null) {
+      appLogger.d('Trakt [scrobble]: resumePlayback() — skipped (no active body)');
+      return;
+    }
+    appLogger.d('Trakt [scrobble]: resumePlayback() — sending start');
     await _send(TraktScrobbleState.start, progress: _progressPercent());
   }
 
   Future<void> stopPlayback() async {
-    if (_currentBody == null) return;
+    final body = _currentBody;
+    if (body == null) {
+      // No active scrobble body yet — startPlayback may still be resolving IDs.
+      // Cancel it so it doesn't send a ghost start after we've moved on.
+      appLogger.d('Trakt [scrobble]: stopPlayback() — no body, cancelling in-flight (gen=$_startGeneration)');
+      cancelInFlight();
+      return;
+    }
+    // Capture generation before the async send so we can detect if a concurrent
+    // startPlayback() incremented it while we were waiting (episode-skip race).
+    final genAtStop = _startGeneration;
+    appLogger.d('Trakt [scrobble]: stopPlayback() — sending stop @ ${_progressPercent().toStringAsFixed(1)}% gen=$genAtStop lastState=$_lastSentState');
     await _send(TraktScrobbleState.stop, progress: _progressPercent());
-    cancelInFlight();
+    // Fire before clearing body.
+    if (body case TraktScrobbleEpisodeRequest(:final showIds, :final season, :final number)) {
+      final traktId = showIds.trakt;
+      if (traktId != null) _onPlaybackStopped?.call(traktId, season, number);
+    }
+    if (_startGeneration == genAtStop) {
+      // Nothing started while we were stopping — full reset.
+      appLogger.d('Trakt [scrobble]: stopPlayback() — gen unchanged ($genAtStop), full reset');
+      cancelInFlight();
+    } else {
+      // A concurrent startPlayback() incremented _startGeneration while we were
+      // sending stop (episode-skip path). We must NOT touch _startGeneration or
+      // _resolver — that would abort the new episode's in-flight start. Only
+      // null the body if startPlayback hasn't already replaced it with ep2's body.
+      appLogger.d('Trakt [scrobble]: stopPlayback() — gen changed ($genAtStop → $_startGeneration), ep2 already started; partial reset only');
+      if (_currentBody == body) _currentBody = null;
+    }
   }
 
   Future<TraktScrobbleRequest?> _buildBody(MediaItem metadata) async {
@@ -343,13 +422,22 @@ class TraktScrobbleService {
   Future<void> _send(TraktScrobbleState state, {required double progress}) async {
     final client = _client;
     final body = _currentBody;
-    if (client == null || body == null) return;
+    if (client == null || body == null) {
+      appLogger.d('Trakt [scrobble]: _send(${state.name}) — skipped (client=${client != null}, body=${body != null})');
+      return;
+    }
 
     final now = DateTime.now();
     if (_lastSentState == state && _lastSentAt != null) {
       final elapsed = now.difference(_lastSentAt!);
-      if (elapsed < _duplicateStateDebounce) return;
-      if (state == TraktScrobbleState.start && elapsed < _startResendThrottle) return;
+      if (elapsed < _duplicateStateDebounce) {
+        appLogger.d('Trakt [scrobble]: _send(${state.name}) — deduped (${elapsed.inMilliseconds}ms < debounce)');
+        return;
+      }
+      if (state == TraktScrobbleState.start && elapsed < _startResendThrottle) {
+        appLogger.d('Trakt [scrobble]: _send(start) — throttled (${elapsed.inSeconds}s < ${_startResendThrottle.inSeconds}s)');
+        return;
+      }
     }
     _lastSentState = state;
     _lastSentAt = now;
@@ -364,10 +452,10 @@ class TraktScrobbleService {
         case TraktScrobbleState.stop:
           await client.scrobbleStop(scrobble);
       }
-      appLogger.d('Trakt: scrobble ${state.name} @ ${progress.toStringAsFixed(1)}%');
+      appLogger.d('Trakt [scrobble]: ✓ ${state.name} @ ${progress.toStringAsFixed(1)}%');
     } catch (e) {
       // Never let scrobble errors block playback.
-      appLogger.d('Trakt: scrobble ${state.name} failed', error: e);
+      appLogger.d('Trakt [scrobble]: ✗ ${state.name} failed', error: e);
     }
   }
 }

--- a/lib/services/trakt/trakt_sync_queue.dart
+++ b/lib/services/trakt/trakt_sync_queue.dart
@@ -19,8 +19,21 @@ class TraktSyncQueueItem {
   final int? season;
   final int? number;
 
+  /// Progress percentage (0–100). Used for TraktSyncOp.progress items.
+  final double? progress;
+
   final String watchedAtIso;
   final int attempts;
+
+  /// When non-null, drain skips this item until the current epoch-second
+  /// exceeds this value. Used for 404 backoff: the item exists in Trakt's DB
+  /// but may be added later, so we retry daily instead of dropping it.
+  final int? retryNotBefore;
+
+  /// When true, this item was queued while external IDs were unavailable
+  /// (e.g. offline — Plex GUID lookup failed). IDs and season/number are
+  /// placeholders. The drain resolves them on the next online flush.
+  final bool needsResolution;
 
   const TraktSyncQueueItem({
     required this.op,
@@ -32,7 +45,10 @@ class TraktSyncQueueItem {
     this.libraryGlobalKey,
     this.season,
     this.number,
+    this.progress,
     this.attempts = 0,
+    this.retryNotBefore,
+    this.needsResolution = false,
   });
 
   TraktSyncQueueItem incrementAttempts() => TraktSyncQueueItem(
@@ -45,7 +61,25 @@ class TraktSyncQueueItem {
     watchedAtIso: watchedAtIso,
     season: season,
     number: number,
+    progress: progress,
     attempts: attempts + 1,
+    retryNotBefore: retryNotBefore,
+    needsResolution: needsResolution,
+  );
+
+  TraktSyncQueueItem withRetryNotBefore(int epochSeconds) => TraktSyncQueueItem(
+    op: op,
+    ratingKey: ratingKey,
+    serverId: serverId,
+    kind: kind,
+    ids: ids,
+    watchedAtIso: watchedAtIso,
+    season: season,
+    number: number,
+    progress: progress,
+    attempts: attempts,
+    retryNotBefore: epochSeconds,
+    needsResolution: needsResolution,
   );
 
   Map<String, dynamic> toJson() => {
@@ -57,8 +91,11 @@ class TraktSyncQueueItem {
     'ids': ids.toJson(),
     if (season != null) 'season': season,
     if (number != null) 'number': number,
+    if (progress != null) 'progress': progress,
     'watchedAtIso': watchedAtIso,
     'attempts': attempts,
+    if (retryNotBefore != null) 'retryNotBefore': retryNotBefore,
+    if (needsResolution) 'needsResolution': true,
   };
 
   factory TraktSyncQueueItem.fromJson(Map<String, dynamic> json) => TraktSyncQueueItem(
@@ -70,8 +107,11 @@ class TraktSyncQueueItem {
     ids: TraktIds.fromJson(json['ids'] as Map<String, dynamic>),
     season: (json['season'] as num?)?.toInt(),
     number: (json['number'] as num?)?.toInt(),
+    progress: (json['progress'] as num?)?.toDouble(),
     watchedAtIso: json['watchedAtIso'] as String,
     attempts: (json['attempts'] as num?)?.toInt() ?? 0,
+    retryNotBefore: (json['retryNotBefore'] as num?)?.toInt(),
+    needsResolution: json['needsResolution'] as bool? ?? false,
   );
 }
 

--- a/lib/services/trakt/trakt_sync_service.dart
+++ b/lib/services/trakt/trakt_sync_service.dart
@@ -5,6 +5,7 @@ import '../../media/media_item.dart';
 import '../../media/media_kind.dart';
 import '../../media/media_server_client.dart';
 import '../../models/trakt/trakt_ids.dart';
+import '../../utils/external_ids.dart';
 import '../../models/trakt/trakt_scrobble_request.dart';
 import '../../utils/app_logger.dart';
 import '../../utils/episode_collection.dart';
@@ -14,6 +15,7 @@ import '../settings_service.dart';
 import '../trackers/tracker_constants.dart';
 import '../trackers/tracker_id_resolver.dart';
 import 'trakt_client.dart';
+import 'trakt_scrobble_service.dart';
 import 'trakt_constants.dart';
 import 'trakt_session.dart';
 import 'trakt_sync_queue.dart';
@@ -56,6 +58,28 @@ class TraktSyncService {
 
   bool _isFlushing = false;
 
+  /// Set when [flushQueue] runs. Used to detect offline-reconnect progress
+  /// pushes (which happen shortly after a flush) so [_onProgressPushed] fires
+  /// only for that case and not for every 10-second online progress push.
+  DateTime? _lastFlushTime;
+
+  /// Called after each successful history-add dispatch. Registered by
+  /// [TraktAccountProvider] to trigger a lightweight playback refresh so the
+  /// next episode surfaces in Continue Watching without waiting for the next sync.
+  void Function()? _onHistoryAdded;
+
+  /// Register (or clear) the post-history-add callback.
+  void setOnHistoryAdded(void Function()? callback) => _onHistoryAdded = callback;
+
+  /// Called after the first successful progress push that follows a [flushQueue]
+  /// run. Registered by [TraktAccountProvider] to refresh the playback cache so
+  /// Continue Watching reflects the offline position without waiting for the
+  /// next full sync.
+  void Function()? _onProgressPushed;
+
+  /// Register (or clear) the post-progress-push callback.
+  void setOnProgressPushed(void Function()? callback) => _onProgressPushed = callback;
+
   Future<void> initialize({required MultiServerManager serverManager}) async {
     if (_isInitialized) return;
     _isInitialized = true;
@@ -97,6 +121,16 @@ class TraktSyncService {
 
   bool get _canPush => _isEnabled && _client != null;
 
+  /// Resolve external IDs for a movie without pushing any sync operation.
+  /// Used by [TraktWatchStateProvider] as a background fetch callback for
+  /// movies whose Plex detail endpoint returns no Guid array.
+  Future<ExternalIds?> resolveMovieIds(String ratingKey, String serverId) async {
+    final resolver = _resolverFor(serverId);
+    if (resolver == null) return null;
+    final resolved = await resolver.resolveForMovie(ratingKey);
+    return resolved?.external;
+  }
+
   TrackerIdResolver? _resolverFor(String serverId) {
     final cached = _resolvers[serverId];
     if (cached != null) return cached;
@@ -115,16 +149,49 @@ class TraktSyncService {
   MediaServerClient? _clientFor(String serverId) => _serverManager?.getClient(serverId);
 
   Future<void> _onWatchStateEvent(WatchStateEvent event) async {
+    appLogger.i('Trakt sync: event received — ${event.changeType.name} for ${event.itemId} (canPush=$_canPush, enabled=$_isEnabled, hasClient=${_client != null})');
     if (!_canPush) return;
-    if (event.changeType != WatchStateChangeType.watched && event.changeType != WatchStateChangeType.unwatched) return;
+
+    final kind = TraktMediaKind.tryFromMediaKindId(event.mediaType);
+    if (kind == null) return;
+
+    if (event.changeType == WatchStateChangeType.progressUpdate) {
+      // Suppress progress save when the scrobble service just sent a stop.
+      // The stop itself captures the final position; a subsequent
+      // savePlaybackProgress() → POST /scrobble/stop would re-add the episode
+      // to Trakt's /sync/playback, undoing the stop's cleanup and making the
+      // skipped episode reappear in Continue Watching.
+      // Checked here (before any await) — cancelInFlight() clears _lastSentState
+      // before _dispatch fires, so a later check would always return false.
+      if (TraktScrobbleService.instance.wasRecentlyStopped) {
+        appLogger.i('Trakt sync: progressUpdate suppressed — scrobble stop just sent (ep skip path)');
+        return;
+      }
+      // Save resume point so the user can continue on another device.
+      final progress = event.progressPercent;
+      appLogger.i('Trakt sync: progressUpdate — pushing resume point for ${event.itemId} at ${((progress ?? 0) * 100).toStringAsFixed(1)}%');
+      if (progress != null && progress > 0.01) {
+        await _push(
+          op: TraktSyncOp.progress,
+          ratingKey: event.itemId,
+          serverId: event.serverId,
+          libraryGlobalKey: event.librarySectionGlobalKey,
+          kind: kind,
+          watchedAtIso: DateTime.now().toUtc().toIso8601String(),
+          progress: (progress * 100.0).clamp(0.0, 100.0),
+        );
+      }
+      return;
+    }
 
     if (!_isLibraryAllowed(event.librarySectionGlobalKey)) {
-      appLogger.d('Trakt sync: library filtered out for ${event.itemId}');
+      appLogger.i('Trakt sync: ${event.changeType.name} for ${event.itemId} dropped — library ${event.librarySectionGlobalKey} not allowed');
       return;
     }
 
     final op = event.changeType == WatchStateChangeType.watched ? TraktSyncOp.add : TraktSyncOp.remove;
     final watchedAtIso = DateTime.now().toUtc().toIso8601String();
+    appLogger.i('Trakt sync: ${event.changeType.name} event — op=${op.name} for ${event.itemId} (${event.mediaType})');
 
     switch (event.mediaType) {
       case 'movie':
@@ -205,6 +272,7 @@ class TraktSyncService {
     required TraktMediaKind kind,
     required String watchedAtIso,
     MediaItem? episodeMeta,
+    double? progress,
   }) async {
     final resolver = _resolverFor(serverId);
     if (resolver == null) {
@@ -224,24 +292,32 @@ class TraktSyncService {
       // MediaServerClient surface (Plex `/library/metadata`, Jellyfin
       // `/Users/{id}/Items/{id}`).
       final mediaClient = _clientFor(serverId);
-      if (mediaClient == null) return;
+      if (mediaClient == null) {
+        appLogger.d('Trakt sync: no media client for $serverId, skipping $ratingKey');
+        return;
+      }
       final metadata = episodeMeta ?? await mediaClient.fetchItem(ratingKey);
-      if (metadata == null) return;
+      if (metadata == null) {
+        appLogger.i('Trakt sync: fetchItem returned null for $ratingKey, skipping');
+        return;
+      }
       season = metadata.parentIndex;
       number = metadata.index;
-      if (season == null || number == null) return;
+      if (season == null || number == null) {
+        appLogger.i('Trakt sync: missing season/number for $ratingKey (s=$season e=$number), skipping');
+        return;
+      }
       resolved = await resolver.resolveShowForEpisode(metadata, includeAnimeProgress: false);
     }
 
     if (resolved == null) {
-      appLogger.d('Trakt sync: no IDs for ${kind.name} $ratingKey, dropping');
+      appLogger.i('Trakt sync: no IDs for ${kind.name} $ratingKey, dropping');
       return;
     }
-
     final ids = TraktIds.fromExternal(resolved.external);
     final body = kind == TraktMediaKind.movie
-        ? TraktScrobbleRequest.movie(ids: ids)
-        : TraktScrobbleRequest.episode(showIds: ids, season: season!, number: number!);
+        ? TraktScrobbleRequest.movie(ids: ids, progress: progress)
+        : TraktScrobbleRequest.episode(showIds: ids, season: season!, number: number!, progress: progress);
 
     final item = TraktSyncQueueItem(
       op: op,
@@ -252,6 +328,7 @@ class TraktSyncService {
       ids: ids,
       season: season,
       number: number,
+      progress: progress,
       watchedAtIso: watchedAtIso,
     );
 
@@ -266,9 +343,17 @@ class TraktSyncService {
     }
     try {
       await _dispatch(client, item, body);
-      appLogger.d('Trakt sync: ${item.op.name} ${item.ratingKey} → ok');
+      appLogger.i('Trakt sync: ${item.op.name} ${item.ratingKey} → ok');
+      if (item.op == TraktSyncOp.add) _onHistoryAdded?.call();
+      if (item.op == TraktSyncOp.progress) {
+        final lastFlush = _lastFlushTime;
+        if (lastFlush != null && DateTime.now().difference(lastFlush).inSeconds < 60) {
+          _lastFlushTime = null; // fire once per flush cycle
+          _onProgressPushed?.call();
+        }
+      }
     } catch (e) {
-      appLogger.d('Trakt sync: ${item.op.name} ${item.ratingKey} failed, queuing', error: e);
+      appLogger.i('Trakt sync: ${item.op.name} ${item.ratingKey} failed, queuing', error: e);
       await _persistOrBuffer(item);
     }
   }
@@ -297,6 +382,7 @@ class TraktSyncService {
     return switch (item.op) {
       TraktSyncOp.add => client.addToHistory(body, watchedAt: item.watchedAtIso),
       TraktSyncOp.remove => client.removeFromHistory(body),
+      TraktSyncOp.progress => client.savePlaybackProgress(body),
     };
   }
 
@@ -307,26 +393,51 @@ class TraktSyncService {
     final client = _client;
     if (client == null) return;
     _isFlushing = true;
+    _lastFlushTime = DateTime.now();
     try {
       await _recoverInMemoryFallback();
 
+      // fetchExternalGuids returns [] (not throws) on network failure, so
+      // offline lookups are cached as null in TrackerIdResolver. Clear before
+      // draining so reconnect pushes — including those triggered by the
+      // notifyProgress event from OfflineWatchSyncService._syncAction() —
+      // make a fresh network call instead of hitting a stale null entry.
+      for (final resolver in _resolvers.values) {
+        resolver.clearCache();
+      }
+
+      final nowEpoch = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       await _queue.drainWith(_activeUserUuid, (item) async {
         if (!_isLibraryAllowed(item.libraryGlobalKey)) {
           appLogger.d('Trakt sync: queued library filtered out for ${item.ratingKey}');
           return null;
         }
-        if (item.attempts >= TraktSyncQueue.maxAttempts) {
+
+        // Legacy items queued with needsResolution=true by an older build are
+        // dropped; the OfflineWatchSyncService._syncAction() → notifyProgress
+        // path now handles these items correctly on reconnect.
+        if (item.needsResolution) return null;
+
+        // 404 backoff: item not in Trakt's DB yet — retry after 24 h.
+        if (item.retryNotBefore != null && nowEpoch < item.retryNotBefore!) {
+          return item; // keep, skip for now
+        }
+        if (item.retryNotBefore == null && item.attempts >= TraktSyncQueue.maxAttempts) {
           appLogger.w('Trakt sync: dropping ${item.op.name} ${item.ratingKey} after ${item.attempts} attempts');
           return null;
         }
         try {
           await _dispatch(client, item, _bodyFor(item));
-          appLogger.d('Trakt sync: drained ${item.op.name} ${item.ratingKey}');
           await Future<void>.delayed(_queueRequestSpacing);
           return null;
         } catch (e) {
-          appLogger.d('Trakt sync: drain failed for ${item.ratingKey}, will retry', error: e);
           await Future<void>.delayed(_queueRequestSpacing);
+          if (e is TraktApiException && e.statusCode == 404) {
+            // Item not found in Trakt's DB — may be added later; retry in 24 h.
+            appLogger.d('Trakt sync: 404 for ${item.ratingKey}, backing off 24 h');
+            return item.withRetryNotBefore(nowEpoch + 86400);
+          }
+          appLogger.d('Trakt sync: drain failed for ${item.ratingKey}, will retry', error: e);
           return item.incrementAttempts();
         }
       });
@@ -353,11 +464,12 @@ class TraktSyncService {
 
   TraktScrobbleRequest _bodyFor(TraktSyncQueueItem item) {
     return switch (item.kind) {
-      TraktMediaKind.movie => TraktScrobbleRequest.movie(ids: item.ids),
+      TraktMediaKind.movie => TraktScrobbleRequest.movie(ids: item.ids, progress: item.progress),
       TraktMediaKind.episode => TraktScrobbleRequest.episode(
         showIds: item.ids,
         season: item.season!,
         number: item.number!,
+        progress: item.progress,
       ),
     };
   }

--- a/lib/services/trakt/trakt_watch_state_provider.dart
+++ b/lib/services/trakt/trakt_watch_state_provider.dart
@@ -1,0 +1,3120 @@
+// ─────────────────────────────────────────────────────────────────────────
+// TraktWatchStateProvider — section map for a 2900+-line file.
+//   _CacheKeys                                    21– 43
+//   _TraktState / _TraktEpisodeState / _TraktCache
+//                  / _ResolvedMovieEntry          44–166
+//   _BoundedMap helper                           182–209
+//   TraktWatchStateProvider singleton + state    211–356
+//   bindSession / lifecycle (initialize, setEnabled,
+//                            invalidateCache, _resetInMemoryState)
+//                                                371–435 + 893–972
+//   Watch-state API (overrides + sync)           Search "TrackerWatchStateProvider impl"
+//   Offline / eviction                           Search "Optimistic eviction"
+//   Cache persistence (loadFromCache /
+//                      _persistToCache)          Search "Cache persistence (ApiCache table)"
+//   Enrichment + stub resolution                 Search "Stub resolution"
+// ─────────────────────────────────────────────────────────────────────────
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import '../../media/media_item.dart';
+import '../../media/media_kind.dart';
+import '../../services/plex_api_cache.dart';
+import '../../services/settings_service.dart';
+import '../../utils/app_logger.dart';
+import '../../utils/external_ids.dart';
+import '../../utils/watch_state_notifier.dart';
+import '../plex_client.dart';
+import '../trackers/tracker_constants.dart';
+import '../trackers/tracker_stub_resolver.dart';
+import '../trackers/tracker_sync_notifier.dart';
+import '../trackers/tracker_watch_state_provider.dart';
+import 'trakt_client.dart';
+import 'trakt_session.dart';
+import 'trakt_sync_service.dart';
+
+/// Persistence keys for the ApiCache table (prefixed with "trakt:" to avoid
+/// collisions with Plex's serverId-prefixed cache keys).
+class _CacheKeys {
+  static const String watchedMovies = 'trakt:watched_movies';
+  static const String watchedShows = 'trakt:watched_shows';
+  static const String playback = 'trakt:playback';
+  static const String lastActivities = 'trakt:last_activities';
+  static const String watchlistShows = 'trakt:watchlist_shows';
+  static const String watchlistMovies = 'trakt:watchlist_movies';
+  static const String ratingsShows = 'trakt:ratings_shows';
+  static const String ratingsMovies = 'trakt:ratings_movies';
+  static const String bridgeMaps = 'trakt:bridge_maps';
+  static const String enrichNotFound = 'trakt:enrich_not_found';
+  static const String upNext = 'trakt:up_next';
+  static const String externalIds = 'trakt:external_ids';
+  static const String resolvedPositions = 'trakt:resolved_positions';
+}
+
+// TTL for empty external-ID markers (items with no Plex external IDs yet).
+// After this duration the marker expires and a background re-fetch is allowed,
+// in case the Plex metadata was refreshed in the interim.
+const int _externalIdsEmptyTtlMs = 24 * 60 * 60 * 1000; // 24 h
+
+/// Internal watch-state record for a movie or show.
+class _TraktState {
+  final int plays;
+  final String? lastWatchedAt;
+  final int traktId;
+
+  const _TraktState({required this.plays, required this.lastWatchedAt, required this.traktId});
+}
+
+/// Per-episode state inside a show.
+class _TraktEpisodeState {
+  final int plays;
+  final String? lastWatchedAt;
+
+  const _TraktEpisodeState({required this.plays, required this.lastWatchedAt});
+}
+
+/// Fully resolved movie entry stored in the single-entry-point cache.
+/// Populated on first successful [TraktWatchStateProvider.getOverrideFor] call;
+/// subsequent calls return this directly without re-running the ID lookup chain.
+class _ResolvedMovieEntry {
+  final int traktId;
+  final int plays;
+  final double? playbackProgress; // 0–100, null = not in progress
+  final String? lastWatchedAt;
+
+  const _ResolvedMovieEntry({
+    required this.traktId,
+    required this.plays,
+    this.playbackProgress,
+    this.lastWatchedAt,
+  });
+}
+
+/// Fully resolved show entry stored in the single-entry-point cache.
+/// Stores only the Trakt show ID so the ID-lookup chain is skipped on
+/// subsequent calls. Progress is always read live from `_cache.showProgress`
+/// so deep-fetch updates (fetchShowProgressIfNeeded) are reflected immediately.
+class _ResolvedShowEntry {
+  final int traktId;
+  const _ResolvedShowEntry({required this.traktId});
+}
+
+/// In-memory cache of Trakt watch data. Stores raw responses for future use
+/// and builds lookup indices keyed by external IDs.
+class _TraktCache {
+  // ---- raw responses ----
+  List<Map<String, dynamic>> watchedMoviesRaw = [];
+  List<Map<String, dynamic>> watchedShowsRaw = [];
+  List<Map<String, dynamic>> playbackRaw = [];
+  Map<String, dynamic>? lastActivities;
+
+  List<Map<String, dynamic>> upNextRaw = [];
+
+  // ---- continue-watching stubs built from playbackRaw + upNextRaw ----
+  List<ContinueWatchingItem> playbackStubs = [];
+
+  // ---- lookup indices for movies ----
+  final Map<String, _TraktState> byImdb = {};
+  final Map<int, _TraktState> byTmdb = {};
+  final Map<int, _TraktState> byTvdb = {};
+
+  // ---- lookup indices for shows (show-level + episode-level) ----
+  // traktShowId -> season#episode -> episode state
+  final Map<int, Map<String, _TraktEpisodeState>> showEpisodes = {};
+
+  // show-level: traktShowId -> watched episode count, total aired
+  final Map<int, (int watched, int aired, String? lastWatchedAt)> showProgress = {};
+
+  // show-level ID maps
+  final Map<String, _TraktState> showByImdb = {};
+  final Map<int, _TraktState> showByTmdb = {};
+  final Map<int, _TraktState> showByTvdb = {};
+
+  // playback (in-progress) — imdb/tmdb/tvdb + traktId keys for fast lookup
+  // value: progress 0-100
+  final Map<String, double> playbackByImdb = {};
+  final Map<int, double> playbackByTmdb = {};
+  final Map<int, double> playbackByTvdb = {};
+  // traktMovieId → progress; used as safety-net when imdb/tmdb cross-match fails
+  final Map<int, double> playbackByTraktId = {};
+  // imdb/tmdb → traktMovieId for playback-only movies (not in watched list).
+  // Used by feedExternalIds to populate the bridge map for in-progress movies.
+  final Map<String, int> playbackTraktIdByImdb = {};
+  final Map<int, int> playbackTraktIdByTmdb = {};
+  // episode-level playback keyed as "traktShowId:s1e2"
+  // value carries both the resume progress and when the pause was saved.
+  final Map<String, ({double progress, String? pausedAt})> episodePlayback = {};
+
+  // ---- single-entry-point resolved cache ----
+  // Populated on first successful getOverrideFor; subsequent calls skip ID chain.
+  // Cleared at the start of each index rebuild so stale entries don't survive sync.
+  final Map<String, _ResolvedMovieEntry> resolvedMovies = {}; // plexRatingKey → entry
+  final Map<String, _ResolvedShowEntry> resolvedShows = {};   // plexRatingKey → entry
+
+  bool get isEmpty => watchedMoviesRaw.isEmpty && watchedShowsRaw.isEmpty && playbackRaw.isEmpty;
+
+  void clear() {
+    watchedMoviesRaw = [];
+    watchedShowsRaw = [];
+    playbackRaw = [];
+    upNextRaw = [];
+    playbackStubs = [];
+    lastActivities = null;
+    byImdb.clear();
+    byTmdb.clear();
+    byTvdb.clear();
+    showEpisodes.clear();
+    showProgress.clear();
+    showByImdb.clear();
+    showByTmdb.clear();
+    showByTvdb.clear();
+    playbackByImdb.clear();
+    playbackByTmdb.clear();
+    playbackByTvdb.clear();
+    playbackByTraktId.clear();
+    playbackTraktIdByImdb.clear();
+    playbackTraktIdByTmdb.clear();
+    episodePlayback.clear();
+    resolvedMovies.clear();
+    resolvedShows.clear();
+  }
+}
+
+/// Trakt's implementation of [TrackerWatchStateProvider].
+///
+/// On [syncWatchState] (called once at boot):
+///   1. Checks `last_activities` timestamps to decide if a refresh is needed.
+///   2. Fetches `/sync/watched/movies`, `/sync/watched/shows`, `/sync/playback`.
+///   3. Persists raw responses to the existing [ApiCache] table.
+///   4. Builds in-memory lookup indices.
+///
+/// [getOverrideFor] is synchronous — it looks up from the pre-built indices.
+/// Insertion-ordered map with a hard capacity ceiling. On insert past
+/// capacity, evicts the oldest entry. Cheaper than full LRU and good enough
+/// for the bridge maps — access patterns are dominated by recent activity,
+/// so insertion-order eviction approximates LRU adequately.
+class _BoundedMap<K, V> extends MapBase<K, V> {
+  final int capacity;
+  final LinkedHashMap<K, V> _store = LinkedHashMap<K, V>();
+
+  _BoundedMap(this.capacity);
+
+  @override
+  V? operator [](Object? key) => _store[key];
+
+  @override
+  void operator []=(K key, V value) {
+    _store[key] = value;
+    if (_store.length > capacity) {
+      _store.remove(_store.keys.first);
+    }
+  }
+
+  @override
+  void clear() => _store.clear();
+
+  @override
+  Iterable<K> get keys => _store.keys;
+
+  @override
+  V? remove(Object? key) => _store.remove(key);
+}
+
+class TraktWatchStateProvider implements TrackerWatchStateProvider, TrackerStubResolver {
+  // ApiCache uses a dummy serverId prefix. We scope it by the active Plex
+  // profile UUID so two profiles with different Trakt accounts on the same
+  // device do not share cached watch history. Cold-start before bindSession
+  // sets the unscoped 'trakt' value; first bindSession with a profile UUID
+  // upgrades it to 'trakt:<uuid>' before any read or write. Pre-fix builds
+  // wrote under the unscoped 'trakt:*' rows — these are intentionally left
+  // in place (no migration); they are orphaned and will be cleaned by the
+  // user's next manual cache reset.
+  String _cacheServerId = 'trakt';
+  String? _boundUserUuid;
+
+  TraktClient? _client;
+  final _TraktCache _cache = _TraktCache();
+  bool _syncInProgress = false;
+  bool _stubRebuildPending = false;
+
+  // Forward bridge maps: Trakt ID → Plex metadata.
+  // Lifecycle: populated lazily by getOverrideFor() and by enrichStubs();
+  //            cleared on invalidateCache(); persisted via _persistBridgeMaps().
+  // Capacity ceiling guards against unbounded growth on shared-device long-
+  // uptime sessions where invalidateCache() may never fire. 10k entries per
+  // map covers any realistic Trakt history with margin.
+  final _BoundedMap<int, String> _traktShowIdToPlexKey = _BoundedMap(_bridgeMapCapacity);
+  final _BoundedMap<int, String> _traktShowIdToThumb = _BoundedMap(_bridgeMapCapacity); // show poster
+  final _BoundedMap<int, String> _traktShowIdToArt = _BoundedMap(_bridgeMapCapacity); // show background art (for hero)
+  final _BoundedMap<int, String> _traktShowIdToServerId = _BoundedMap(_bridgeMapCapacity);
+  // Movie forward maps (traktMovieId → Plex data).
+  // Lifecycle: populated by enrichStubs() and lazily by _overrideForMovie();
+  //            cleared on invalidateCache(); persisted via _persistBridgeMaps().
+  // isMovieEnrichNotFound() / markMovieEnrichNotFound() guard against repeated
+  // searches for movies the user doesn't have in their Plex library (24 h TTL).
+  final _BoundedMap<int, String> _traktMovieIdToThumb = _BoundedMap(_bridgeMapCapacity);
+  final _BoundedMap<int, String> _traktMovieIdToPlexKey = _BoundedMap(_bridgeMapCapacity);
+  final _BoundedMap<int, String> _traktMovieIdToServerId = _BoundedMap(_bridgeMapCapacity);
+
+  static const int _bridgeMapCapacity = 10000;
+
+  // stub id → resolved Plex season/episode + episode thumb, populated when ID
+  // matching succeeds. Used to show correct S/E and fallback thumb on cards.
+  final Map<String, ({int season, int episode, String? thumb})> _resolvedEpisodePosition = {};
+
+  // Trakt IDs that were fully searched and not found in any Plex library,
+  // mapped to the epoch-second timestamp when they were marked. Entries expire
+  // after 24 h so the item is re-attempted (the show may have been added to Plex).
+  final Map<int, int> _enrichNotFoundShowTs = {};
+  final Map<int, int> _enrichNotFoundMovieTs = {};
+
+  static const _enrichNotFoundTtlSeconds = 86400; // 24 h
+
+  int get _nowEpoch => DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+  // Reverse bridge maps: Plex ratingKey → Trakt ID.
+  // Lifecycle: populated by _overrideForEpisode/_overrideForMovie/_overrideForShow
+  //            and by enrichStubs(); cleared on invalidateCache(); persisted via _persistBridgeMaps().
+  // Lets _overrideForEpisode resolve the Trakt show ID via grandparentRatingKey.
+  final _BoundedMap<String, int> _plexKeyToTraktShowId = _BoundedMap(_bridgeMapCapacity);
+
+  // Fast lookup: Trakt show ID → _TraktState (plays, lastWatchedAt).
+  // Built in _buildShowIndices() from /sync/watched/shows.
+  final Map<int, _TraktState> _showByTraktId = {};
+
+  // Fast lookup: Trakt movie ID → _TraktState. Built in _buildMovieIndices().
+  final Map<int, _TraktState> _movieByTraktId = {};
+
+  // Reverse bridge map for movies: Plex ratingKey → Trakt movie ID.
+  // Populated on first successful _overrideForMovie match, same pattern as _plexKeyToTraktShowId.
+  final _BoundedMap<String, int> _plexMovieKeyToTraktMovieId = _BoundedMap(_bridgeMapCapacity);
+
+  // Watchlist raw items (Trakt JSON shape from /sync/watchlist/{type}).
+  // Populated by _syncWatchlist during sync and by loadFromCache on cold boot.
+  // Cleared in _resetInMemoryState; on-disk copy wiped in invalidateCache.
+  // Used only for surfacing a single "Trakt Watchlist" entry to the
+  // playlists tab when authority is on; items are resolved lazily to real
+  // Plex MediaItems at detail-screen open time.
+  List<Map<String, dynamic>> _watchlistShowsRaw = const [];
+  List<Map<String, dynamic>> _watchlistMoviesRaw = const [];
+
+  // Shows for which /shows/{id}/progress/watched has been fetched (lazy, once per session).
+  final Set<int> _deepFetchedShows = {};
+
+  // Shows confirmed not in Trakt this session (no IDs matched). Avoids re-running
+  // the full _lookupShow chain on every getOverrideFor() call for the same show.
+  // Cleared on every _buildShowIndices() (i.e. each sync cycle).
+  final Set<String> _grandparentIdsNotFound = {};
+
+  // Stale-pause decision cache. Incremented by _buildShowIndices() and
+  // _buildPlaybackIndices() whenever the inputs to stale-pause detection change.
+  // Allows _buildContinueWatchingStubs() calls that follow a no-input-change
+  // event (e.g. resolveEpisodeDisplayPositions) to skip the detection loop.
+  int _rawDataVersion = 0;
+  int _stalePauseCacheVersion = -1;
+  // showId → alreadyWatched: per-sync-cycle stale-pause decision cache for
+  // _buildContinueWatchingStubs(). Cleared when _rawDataVersion changes.
+  final Map<int, bool> _stalePauseCache = {};
+
+  // Reverse map: '{traktShowId}:s{plexSeason}e{plexEp}' → 's{traktSeason}e{traktEp}'.
+  // Built from _resolvedEpisodePosition so _overrideForEpisode can find Trakt
+  // episode data for shows whose Plex S/E numbering differs from Trakt's (e.g. anime).
+  // Cleared on invalidateCache(); rebuilt from _resolvedEpisodePosition on loadFromCache().
+  final Map<String, String> _plexSeToTraktSeKey = {};
+
+  // External IDs fed from the scrobble path for movies whose Plex metadata
+  // doesn't include a Guid array (e.g. un-refreshed new-agent movies).
+  // Keyed by Plex ratingKey; cleared on invalidateCache().
+  final Map<String, ExternalIds> _fetchedExternalIds = {};
+
+  // Tracks in-flight background ID fetches to avoid duplicate requests.
+  final Set<String> _pendingIdFetches = {};
+
+  // Optimistic-eviction guard. Keyed by Trakt ID.
+  // • Movies: epKey is null — suppresses the movie stub until Trakt confirms removal.
+  // • Shows: epKey is 's{season}e{episode}' of the evicted episode — only suppresses
+  //   that specific episode stub. A stub for a different episode (e.g. the next ep after
+  //   a successful history push) passes through immediately so it can be shown.
+  // Pruned in _buildContinueWatchingStubs(); TTL prevents permanent suppression.
+  // 5 minutes: the post-playback CW re-sync fires within ~2 s; this window
+  // is intentionally wider to survive slow networks or a delayed foreground event.
+  static const _pendingEvictionTtlSeconds = 300;
+  final Map<int, ({String? epKey, int evictedAt})> _pendingEvictions = {};
+
+  // Session-scoped cache for PlexClient.getAllLeaves() results, keyed by
+  // Plex show ratingKey. Capped at 50 entries (FIFO eviction) so anime shows
+  // with 400+ episodes don't blow up the heap. Cleared on invalidateCache().
+  // Owned here so tracker lifecycle controls its lifetime, not PlexClient.
+  final Map<String, List<MediaItem>> _allLeavesCache = {};
+  static const _leavesCacheMaxEntries = 50;
+
+  // Per-server GUID index built by _doEnrichStubs(). Cached for 5 min so
+  // repeated enrichment runs within a sync window don't re-fetch every library
+  // section on every server. Keyed by "show_{serverId}" / "movie_{serverId}".
+  // Cleared on invalidateCache() and when the TTL expires.
+  final Map<String, Map<String, MediaItem>> _guidIndexCache = {};
+  int? _guidIndexBuiltAt;
+  static const _guidIndexTtlSeconds = 300;
+
+  // Timer that fires a lightweight playback+up_next refresh ~1.5 s after a
+  // successful Trakt history-add. Debounced so bulk season marks coalesce.
+  Timer? _postMarkRefreshTimer;
+
+  // Stub ID → next episode MediaItem, populated by resolveEpisodeDisplayPositions().
+  final Map<String, MediaItem> _nextEpisodeByStubId = {};
+
+  // Immediately-shown next episodes after eviction, cleared when _refreshPlaybackAndUpNext fires.
+  final List<ContinueWatchingItem> _pendingNextEpisodes = [];
+
+  // Callback registered by TraktAccountProvider to resolve external IDs via
+  // the Plex client without creating a circular import.
+  Future<ExternalIds?> Function(String plexKey, String serverId)? _externalIdsFetcher;
+
+  /// Called whenever a new entry is added to the bridge map (i.e. a show was
+  /// matched in Plex for the first time). Registered by [TraktAccountProvider]
+  /// so the UI can refresh Continue Watching thumbnails without waiting for the
+  /// next full sync cycle.
+  VoidCallback? _onBridgeMapUpdated;
+
+  /// Register (or clear) the bridge-map-updated callback.
+  void setOnBridgeMapUpdated(VoidCallback? callback) {
+    _onBridgeMapUpdated = callback;
+  }
+
+  VoidCallback? _onCachesInvalidated;
+
+  /// Register (or clear) the callback invoked at the end of [invalidateCache].
+  /// Use this to clear related caches in other layers (e.g. PlexClient._allLeavesCache).
+  void setOnCachesInvalidated(VoidCallback? callback) {
+    _onCachesInvalidated = callback;
+  }
+
+  /// Completes when [loadFromCache] has finished (successfully or not).
+  /// Consumers can await this before calling [getOverrideFor].
+  Completer<void> _cacheReadyCompleter = Completer<void>();
+
+  @override
+  Future<void> get cacheReady => _cacheReadyCompleter.future;
+
+  TraktWatchStateProvider._();
+
+  static final TraktWatchStateProvider instance = TraktWatchStateProvider._();
+
+  // -------------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------------
+
+  /// Bind a live [TraktSession]. Called by [TraktAccountProvider] when the
+  /// active profile's session changes.
+  ///
+  /// Contract: callers that want to (re)activate the overlay must await this
+  /// future before doing so. The in-memory caches and `_client` reflect the
+  /// new profile only after this completes; activating the overlay too early
+  /// would cause it to serve the prior profile's data until the next
+  /// syncWatchState() finishes. See [TraktAccountProvider._setSessionAndRebind]
+  /// for the correct ordering.
+  ///
+  /// On full disconnect (`session == null`) the on-disk cache for the prior
+  /// profile is wiped. On profile switch (both connected, identity changed),
+  /// in-memory state is reset but the prior profile's persisted cache stays
+  /// on disk so a future switch back is fast.
+  Future<void> bindSession(
+    TraktSession? session, {
+    required String userUuid,
+    required void Function() onSessionInvalidated,
+  }) async {
+    final newScope = session != null && userUuid.isNotEmpty ? 'trakt:$userUuid' : 'trakt';
+    final identityChanged = newScope != _cacheServerId || userUuid != _boundUserUuid;
+    _client?.dispose();
+    _client = session != null ? TraktClient(session, onSessionInvalidated: onSessionInvalidated) : null;
+    _cacheServerId = newScope;
+    _boundUserUuid = userUuid;
+    if (session == null) {
+      await invalidateCache();
+    } else if (identityChanged) {
+      _resetInMemoryState();
+    }
+  }
+
+  /// Load the "enabled" setting from SharedPreferences.
+  Future<void> initialize() async {
+    // No-op for now as we read directly from SettingsService,
+    // but kept for future boots-up logic.
+  }
+
+  /// Toggle the authority on/off and persist the preference.
+  Future<void> setEnabled(bool enabled) async {
+    final settings = await SettingsService.getInstance();
+    await settings.write(SettingsService.trackerStateAuthority, enabled ? TrackerService.trakt.name : 'none');
+    if (!enabled) await invalidateCache();
+  }
+
+  @override
+  String get trackerName => 'Trakt';
+
+  @override
+  TrackerStubResolver? get asStubResolver => this;
+
+  @override
+  Future<List<MediaItem>> getAuthorityListItems(
+    Map<String, PlexClient> clients,
+  ) async {
+    if (!isTrackerStateAuthorityEnabled) return const [];
+    if (_watchlistShowsRaw.isEmpty && _watchlistMoviesRaw.isEmpty) return const [];
+    // Fire enrichment so unmatched watchlist items get a chance to resolve on
+    // subsequent opens (no-op if already in flight; coalesced internally).
+    unawaited(enrichStubs(null, clients));
+    final out = <MediaItem>[];
+    await _appendResolvedWatchlistItems(
+      raws: _watchlistShowsRaw,
+      idMap: _traktShowIdToPlexKey,
+      serverMap: _traktShowIdToServerId,
+      typeKey: 'show',
+      clients: clients,
+      out: out,
+    );
+    await _appendResolvedWatchlistItems(
+      raws: _watchlistMoviesRaw,
+      idMap: _traktMovieIdToPlexKey,
+      serverMap: _traktMovieIdToServerId,
+      typeKey: 'movie',
+      clients: clients,
+      out: out,
+    );
+    return out;
+  }
+
+  /// Walk a watchlist raw list, look up each entry's Plex ratingKey via the
+  /// bridge map, and append the fetched [MediaItem]. Drops entries without a
+  /// bridge-map hit (enrichment will pick them up on a subsequent open).
+  Future<void> _appendResolvedWatchlistItems({
+    required List<Map<String, dynamic>> raws,
+    required _BoundedMap<int, String> idMap,
+    required _BoundedMap<int, String> serverMap,
+    required String typeKey,
+    required Map<String, PlexClient> clients,
+    required List<MediaItem> out,
+  }) async {
+    for (final entry in raws) {
+      final inner = entry[typeKey];
+      if (inner is! Map) continue;
+      final ids = inner['ids'];
+      if (ids is! Map) continue;
+      final traktId = (ids['trakt'] as num?)?.toInt();
+      if (traktId == null) continue;
+      final plexKey = idMap[traktId];
+      if (plexKey == null) continue;
+      final serverId = serverMap[traktId];
+      final client = serverId != null ? clients[serverId] : null;
+      if (client == null) continue;
+      try {
+        final item = await client.fetchItem(plexKey);
+        if (item != null) out.add(item);
+      } catch (e) {
+        appLogger.d('TraktWatchState: watchlist item fetch failed for $plexKey', error: e);
+      }
+    }
+  }
+
+  @override
+  bool get isTrackerStateAuthorityEnabled {
+    final settings = SettingsService.instanceOrNull;
+    return settings?.read(SettingsService.trackerStateAuthority) == TrackerService.trakt.name && _client != null;
+  }
+
+  // -------------------------------------------------------------------------
+  // TrackerWatchStateProvider impl
+  // -------------------------------------------------------------------------
+
+  @override
+  Future<void> syncWatchState({bool force = false}) async {
+    if (_syncInProgress) {
+      appLogger.d('TraktWatchState: sync already in progress, skipping');
+      return;
+    }
+    final client = _client;
+    if (client == null) return;
+    _syncInProgress = true;
+    appLogger.d('TraktWatchState: checking for updates (force=$force)...');
+    try {
+      await _doSync(client, force: force);
+    } catch (e, st) {
+      appLogger.e('TraktWatchState: sync failed', error: e, stackTrace: st);
+    } finally {
+      _syncInProgress = false;
+    }
+  }
+
+  @override
+  WatchStateOverride? getOverrideFor(MediaItem item) {
+    if (!isTrackerStateAuthorityEnabled) return null;
+
+    final ids = _idsFromItem(item);
+    final type = item.kind;
+    WatchStateOverride? override;
+
+    if (type == MediaKind.movie) override = _overrideForMovie(item, ids);
+    if (type == MediaKind.episode) override = _overrideForEpisode(item, ids);
+    if (type == MediaKind.show || type == MediaKind.season) override = _overrideForShow(item, ids);
+
+    if (override != null) {
+      appLogger.t(
+        'TraktWatchState: found override for ${item.title} (${item.id}) '
+        '[ids: $ids, plays: ${override.viewCount}, offset: ${override.viewOffset}]',
+      );
+    } else {
+      appLogger.t('TraktWatchState: no Trakt record for ${item.title} (${item.id})');
+    }
+    return override;
+  }
+
+  /// Returns the Plex show ratingKey for a given Trakt show ID, if known.
+  String? getPlexShowKey(int traktShowId) => _traktShowIdToPlexKey[traktShowId];
+
+  /// Returns the cached Plex show thumb for a given Trakt show ID, if known.
+  String? getPlexShowThumb(int traktShowId) => _traktShowIdToThumb[traktShowId];
+
+  /// Returns the cached Plex show background art for a given Trakt show ID, if known.
+  String? getPlexShowArt(int traktShowId) => _traktShowIdToArt[traktShowId];
+
+  /// Returns the cached Plex serverId for a given Trakt show ID, if known.
+  String? getPlexShowServerId(int traktShowId) => _traktShowIdToServerId[traktShowId];
+
+  /// Returns the cached Plex movie thumbnail for a given Trakt movie ID, if known.
+  String? getPlexMovieThumb(int traktMovieId) => _traktMovieIdToThumb[traktMovieId];
+
+  /// Returns the cached Plex movie ratingKey for a given Trakt movie ID, if known.
+  String? getPlexMovieKey(int traktMovieId) => _traktMovieIdToPlexKey[traktMovieId];
+
+  /// Returns the cached Plex serverId for a given Trakt movie ID, if known.
+  String? getPlexMovieServerId(int traktMovieId) => _traktMovieIdToServerId[traktMovieId];
+
+  /// Records the resolved Plex season/episode for a stub after a successful ID
+  /// match in [resolveTraktEpisodeStub]. Rebuilds Continue Watching stubs so
+  /// the card shows the correct S/E number instead of Trakt's numbering.
+  void recordResolvedEpisodePosition(String stubId, int season, int episode, {String? thumb}) {
+    final prev = _resolvedEpisodePosition[stubId];
+    if (prev?.season == season && prev?.episode == episode && prev?.thumb == thumb) return;
+    _resolvedEpisodePosition[stubId] = (season: season, episode: episode, thumb: thumb);
+    _updatePlexSeRemapping(stubId, season, episode);
+  }
+
+  /// Updates `_plexSeToTraktSeKey` with a Plex→Trakt S/E translation derived
+  /// from [stubId]. Does nothing for stub IDs that don't encode a show+S/E pair.
+  void _updatePlexSeRemapping(String stubId, int plexSeason, int plexEpisode) {
+    final m = RegExp(r'trakt_(?:upnext|episode_pb)_(\d+)_s(\d+)e(\d+)').firstMatch(stubId);
+    if (m == null) return;
+    final showId = m.group(1)!;
+    final traktSeason = m.group(2)!;
+    final traktEp = m.group(3)!;
+    _plexSeToTraktSeKey['$showId:s${plexSeason}e$plexEpisode'] = 's${traktSeason}e$traktEp';
+  }
+
+  /// Returns true if this Trakt show was searched and not found in Plex recently
+  /// (within the 24 h TTL). Expired entries are treated as "not yet searched".
+  bool isShowEnrichNotFound(int traktShowId) {
+    final ts = _enrichNotFoundShowTs[traktShowId];
+    return ts != null && (_nowEpoch - ts) < _enrichNotFoundTtlSeconds;
+  }
+
+  /// Returns true if this Trakt movie was searched and not found in Plex recently.
+  bool isMovieEnrichNotFound(int traktMovieId) {
+    final ts = _enrichNotFoundMovieTs[traktMovieId];
+    return ts != null && (_nowEpoch - ts) < _enrichNotFoundTtlSeconds;
+  }
+
+  /// Marks a show as searched-but-not-found. Expires after 24 h so it is
+  /// re-attempted in case the user adds the show to their Plex library later.
+  /// Call [flushEnrichNotFound] after a batch of marks to persist to disk.
+  void markShowEnrichNotFound(int traktShowId) {
+    _enrichNotFoundShowTs[traktShowId] = _nowEpoch;
+  }
+
+  /// Marks a movie as searched-but-not-found (24 h TTL).
+  /// Call [flushEnrichNotFound] after a batch of marks to persist to disk.
+  void markMovieEnrichNotFound(int traktMovieId) {
+    _enrichNotFoundMovieTs[traktMovieId] = _nowEpoch;
+  }
+
+  /// Persists the current not-found sets to disk. Call once after a batch of
+  /// [markShowEnrichNotFound]/[markMovieEnrichNotFound] calls.
+  Future<void> flushEnrichNotFound() => _persistEnrichNotFound();
+
+  /// Returns the in-progress episode (season, episode) for a Plex show, if known.
+  ///
+  /// Priority: /sync/playback/episodes (genuinely paused) → up_next_nitro (next
+  /// unstarted). A playback entry is skipped when its episode is already marked
+  /// watched in /sync/watched/shows — that means the pause point is stale (e.g.
+  /// watched to completion on another device without Plex scrobbling).
+  @override
+  ({int season, int episode, int? tvdb, int? tmdb})? getUpNextPosition(String plexShowRatingKey) {
+    final traktId = _plexKeyToTraktShowId[plexShowRatingKey];
+    if (traktId == null) {
+      appLogger.d('TraktWatchState: getUpNextPosition — no traktId for plexKey=$plexShowRatingKey');
+      return null;
+    }
+
+    // Fast path: the CW stub for this show already has the resolved Plex S/E position
+    // (parentIndex/index are translated from Trakt's numbering in _buildContinueWatchingStubs).
+    // Using it avoids returning a stale re-watch entry from episodePlayback — e.g. a show
+    // where the user is mid-re-watch of S1E1 while the real up-next is S2E1.
+    final cwItem = getContinueWatchingItems()
+        .where((item) => item.metadata.grandparentId == plexShowRatingKey)
+        .firstOrNull;
+    if (cwItem != null) {
+      final cwMeta = cwItem.metadata;
+      final s = cwMeta.parentIndex ?? 0;
+      final e = cwMeta.index ?? 0;
+      if (s > 0 && e > 0) {
+        final tvdb = cwMeta.raw?['episodeTvdb'] as int?;
+        final tmdb = cwMeta.raw?['episodeTmdb'] as int?;
+        appLogger.d(
+          'TraktWatchState: getUpNextPosition — CW fast path traktId=$traktId: '
+          's${s}e$e tvdb=$tvdb tmdb=$tmdb (stub=${cwMeta.id})',
+        );
+        return (season: s, episode: e, tvdb: tvdb, tmdb: tmdb);
+      }
+    }
+
+    final showLastWatchedAt = DateTime.tryParse(_cache.showProgress[traktId]?.$3 ?? '');
+
+    for (final key in _cache.episodePlayback.keys) {
+      if (!key.startsWith('$traktId:')) continue;
+      final m = RegExp(r':s(\d+)e(\d+)$').firstMatch(key);
+      if (m == null) continue;
+      final season = int.parse(m.group(1)!);
+      final ep = int.parse(m.group(2)!);
+      final epState = _cache.showEpisodes[traktId]?['s${season}e$ep'];
+      final pausedAt = DateTime.tryParse(_cache.episodePlayback[key]?.pausedAt ?? '');
+
+      // Show-level stale check: if any episode in the show was completed more
+      // recently than this pause, the user has moved past it.
+      if (pausedAt != null && showLastWatchedAt != null && showLastWatchedAt.isAfter(pausedAt)) {
+        appLogger.d(
+          'TraktWatchState: getUpNextPosition — stale pause at s${season}e$ep '
+          'for traktId=$traktId (showLastWatched=$showLastWatchedAt, paused=$pausedAt) — falling back to up_next_nitro',
+        );
+        break;
+      }
+
+      // Episode-level stale check: this specific episode was completed after
+      // its pause (plays > 0 and watched date is not older than the pause).
+      if ((epState?.plays ?? 0) > 0) {
+        final watchedAt = DateTime.tryParse(epState?.lastWatchedAt ?? '');
+        if (pausedAt == null || watchedAt == null || !pausedAt.isAfter(watchedAt)) {
+          appLogger.d(
+            'TraktWatchState: getUpNextPosition — stale pause at s${season}e$ep '
+            'for traktId=$traktId (plays=${epState?.plays}, watched=$watchedAt, paused=$pausedAt) — falling back to up_next_nitro',
+          );
+          break;
+        }
+      }
+
+      // Look up episode IDs from playbackRaw for ID-based resolution.
+      int? tvdb, tmdb;
+      for (final item in _cache.playbackRaw) {
+        final show = item['show'] as Map<String, dynamic>?;
+        final episode = item['episode'] as Map<String, dynamic>?;
+        if (show == null || episode == null) continue;
+        final sid = ((show['ids'] as Map?)?['trakt'] as num?)?.toInt() ?? 0;
+        final eSeason = (episode['season'] as num?)?.toInt() ?? 0;
+        final eNumber = (episode['number'] as num?)?.toInt() ?? 0;
+        if (sid == traktId && eSeason == season && eNumber == ep) {
+          final ids = episode['ids'] as Map<String, dynamic>?;
+          tvdb = (ids?['tvdb'] as num?)?.toInt();
+          tmdb = (ids?['tmdb'] as num?)?.toInt();
+          break;
+        }
+      }
+
+      // Translate Trakt S/E → resolved Plex S/E so Strategy 1 in
+      // _applyTrackerUpNextToOnDeck can match against _episodes (Plex numbering).
+      final pbStub = 'trakt_episode_pb_${traktId}_s${season}e$ep';
+      final unStub = 'trakt_upnext_${traktId}_s${season}e$ep';
+      final res = _resolvedEpisodePosition[pbStub] ?? _resolvedEpisodePosition[unStub];
+      final outSeason = res?.season ?? season;
+      final outEp = res?.episode ?? ep;
+      appLogger.d(
+        'TraktWatchState: getUpNextPosition — traktId=$traktId '
+        'playback=s${season}e$ep → plex=s${outSeason}e$outEp '
+        '(resolved=${res != null}) tvdb=$tvdb tmdb=$tmdb',
+      );
+      return (season: outSeason, episode: outEp, tvdb: tvdb, tmdb: tmdb);
+    }
+
+    // Fall back to up_next_nitro for the next unstarted episode.
+    for (final item in _cache.upNextRaw) {
+      final showId =
+          (item['show_id'] as num?)?.toInt() ??
+          ((item['show'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt() ??
+          0;
+      if (showId != traktId) continue;
+      final nextEp = (item['progress'] as Map<String, dynamic>?)?['next_episode'] as Map<String, dynamic>?;
+      if (nextEp == null) return null;
+      final season = (nextEp['season'] as num?)?.toInt() ?? 0;
+      final ep = (nextEp['number'] as num?)?.toInt() ?? 0;
+      if (season <= 0 || ep <= 0) return null;
+      final nextEpIds = nextEp['ids'] as Map<String, dynamic>?;
+      final tvdb = (nextEpIds?['tvdb'] as num?)?.toInt();
+      final tmdb = (nextEpIds?['tmdb'] as num?)?.toInt();
+      // Translate Trakt S/E → resolved Plex S/E (same as episodePlayback path above).
+      final unStub = 'trakt_upnext_${traktId}_s${season}e$ep';
+      final pbStub = 'trakt_episode_pb_${traktId}_s${season}e$ep';
+      final res = _resolvedEpisodePosition[unStub] ?? _resolvedEpisodePosition[pbStub];
+      final outSeason = res?.season ?? season;
+      final outEp = res?.episode ?? ep;
+      appLogger.d(
+        'TraktWatchState: getUpNextPosition — traktId=$traktId '
+        'upnext=s${season}e$ep → plex=s${outSeason}e$outEp '
+        '(resolved=${res != null}) tvdb=$tvdb tmdb=$tmdb',
+      );
+      return (season: outSeason, episode: outEp, tvdb: tvdb, tmdb: tmdb);
+    }
+
+    return null;
+  }
+
+  /// Update the Plex bridge map from an externally resolved show.
+  /// Rebuilds stubs so thumbnails + navigation keys are injected immediately.
+  void updateBridgeMap({
+    required int traktShowId,
+    required String plexKey,
+    String? thumb,
+    String? art,
+    String? serverId,
+  }) {
+    final isNew = !_traktShowIdToPlexKey.containsKey(traktShowId);
+    final artWasNull = !_traktShowIdToArt.containsKey(traktShowId);
+    _traktShowIdToPlexKey[traktShowId] = plexKey;
+    _plexKeyToTraktShowId[plexKey] = traktShowId;
+    if (serverId != null) _traktShowIdToServerId[traktShowId] = serverId;
+    if (thumb != null) _traktShowIdToThumb[traktShowId] = thumb;
+    if (art != null) _traktShowIdToArt[traktShowId] = art;
+    _enrichNotFoundShowTs.remove(traktShowId); // matched — clear any not-found mark
+    unawaited(_persistBridgeMaps());
+    if (isNew || (art != null && artWasNull)) {
+      _scheduleBuildContinueWatchingStubs();
+      _onBridgeMapUpdated?.call();
+    }
+  }
+
+  /// Update the movie bridge map from an externally resolved Plex movie item.
+  /// Rebuilds stubs so the thumbnail and navigation key are injected immediately.
+  void updateMovieBridgeMap({required int traktMovieId, String? plexKey, String? thumb, String? serverId}) {
+    final isNew = !_traktMovieIdToPlexKey.containsKey(traktMovieId);
+    final hadThumb = _traktMovieIdToThumb.containsKey(traktMovieId);
+    if (plexKey != null) _traktMovieIdToPlexKey[traktMovieId] = plexKey;
+    if (thumb != null) _traktMovieIdToThumb[traktMovieId] = thumb;
+    if (serverId != null) _traktMovieIdToServerId[traktMovieId] = serverId;
+    _enrichNotFoundMovieTs.remove(traktMovieId); // matched — clear any not-found mark
+    unawaited(_persistBridgeMaps());
+    if (isNew || (!hadThumb && thumb != null)) {
+      _scheduleBuildContinueWatchingStubs();
+      _onBridgeMapUpdated?.call();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Offline scrobble
+  // -------------------------------------------------------------------------
+
+  /// Queue a tracker scrobble for offline playback. Emits a [WatchStateNotifier]
+  /// watched event so [TraktSyncService] handles the push + retry-on-failure.
+  @override
+  Future<void> queueOfflineScrobble(MediaItem item, {required double progressPercent}) async {
+    appLogger.d('TraktWatchState: queueOfflineScrobble for ${item.title} (${progressPercent.toStringAsFixed(1)}%)');
+    WatchStateNotifier().notifyWatched(item: item, isNowWatched: true);
+  }
+
+  /// Drain the Trakt sync queue. Delegates to [TraktSyncService] which owns
+  /// the queue and retry logic. After draining, re-syncs the in-memory cache
+  /// so any deferred offline items that were just pushed to Trakt are reflected
+  /// in the UI without waiting for the next scheduled sync.
+  @override
+  Future<void> flushOfflineQueue() async {
+    await TraktSyncService.instance.flushQueue();
+    await syncWatchState(force: true);
+    TrackerSyncNotifier.instance.notifySync();
+  }
+
+  /// Lazily fetches `/shows/{id}/progress/watched` for the given show metadata.
+  ///
+  /// Called when the user opens a show's detail screen. Provides accurate
+  /// per-episode `completed` booleans and `aired` counts (not available from
+  /// the boot-time `/sync/watched/shows` call). Only runs once per show per session.
+  /// Returns true if new data was fetched and the caller should re-apply overlays.
+  @override
+  Future<bool> fetchShowProgressIfNeeded(MediaItem show) async {
+    if (!isTrackerStateAuthorityEnabled) return false;
+    if (_client == null) return false;
+
+    // Resolve traktId via bridge map or ID/title lookup.
+    int? traktId = _plexKeyToTraktShowId[show.id];
+    if (traktId == null) {
+      final ids = _idsFromItem(show);
+      final state = _lookupShow(ids);
+      traktId = state?.traktId;
+    }
+    if (traktId == null || traktId == 0) return false;
+    if (_deepFetchedShows.contains(traktId)) return false;
+    _deepFetchedShows.add(traktId);
+
+    try {
+      final data = await _client!.getShowWatchedProgress(traktId);
+      _applyShowWatchedProgress(traktId, data);
+      return true;
+    } catch (e) {
+      _deepFetchedShows.remove(traktId); // allow retry on next open
+      appLogger.d('TraktWatchState: deep progress fetch failed for traktId=$traktId', error: e);
+      return false;
+    }
+  }
+
+  void _applyShowWatchedProgress(int traktId, Map<String, dynamic> data) {
+    final completed = (data['completed'] as num?)?.toInt() ?? 0;
+    final aired = (data['aired'] as num?)?.toInt() ?? 0;
+    final lastWatchedAt = data['last_watched_at'] as String?;
+
+    // Update show-level progress with accurate aired count.
+    _cache.showProgress[traktId] = (completed, aired, lastWatchedAt);
+
+    // Update per-episode state from the richer response.
+    final seasons = data['seasons'] as List?;
+    if (seasons != null) {
+      final epMap = _cache.showEpisodes[traktId] ?? {};
+      for (final season in seasons) {
+        final seasonNum = (season['number'] as num?)?.toInt() ?? 0;
+        final episodes = season['episodes'] as List?;
+        if (episodes == null) continue;
+        for (final ep in episodes) {
+          final epNum = (ep['number'] as num?)?.toInt() ?? 0;
+          final isCompleted = ep['completed'] as bool? ?? false;
+          final epWatchedAt = ep['last_watched_at'] as String?;
+          final key = 's${seasonNum}e$epNum';
+          // Use completion status from this richer endpoint to set plays=1 when
+          // the episode is completed but /sync/watched/shows had plays=0 (e.g.
+          // watched via Plex VIP scrobble which updates progress but not play count).
+          final existing = epMap[key];
+          final existingPlays = existing?.plays ?? 0;
+          epMap[key] = _TraktEpisodeState(
+            plays: isCompleted && existingPlays == 0 ? 1 : existingPlays,
+            lastWatchedAt: epWatchedAt ?? existing?.lastWatchedAt,
+          );
+        }
+      }
+      _cache.showEpisodes[traktId] = epMap;
+    }
+  }
+
+  Future<void> _persistEnrichNotFound() async {
+    try {
+      await PlexApiCache.instance.put(_cacheServerId, _CacheKeys.enrichNotFound, {
+        'showTs': _enrichNotFoundShowTs.map((k, v) => MapEntry(k.toString(), v)),
+        'movieTs': _enrichNotFoundMovieTs.map((k, v) => MapEntry(k.toString(), v)),
+      });
+    } catch (e) {
+      appLogger.d('TraktWatchState: enrich-not-found persist failed (non-fatal)', error: e);
+    }
+  }
+
+  Future<void> _persistBridgeMaps() async {
+    try {
+      final cache = PlexApiCache.instance;
+      await cache.put(_cacheServerId, _CacheKeys.bridgeMaps, {
+        'plexKey': _traktShowIdToPlexKey.map((k, v) => MapEntry(k.toString(), v)),
+        'thumb': _traktShowIdToThumb.map((k, v) => MapEntry(k.toString(), v)),
+        'art': _traktShowIdToArt.map((k, v) => MapEntry(k.toString(), v)),
+        'serverId': _traktShowIdToServerId.map((k, v) => MapEntry(k.toString(), v)),
+        'movieThumb': _traktMovieIdToThumb.map((k, v) => MapEntry(k.toString(), v)),
+        'movieKey': _traktMovieIdToPlexKey.map((k, v) => MapEntry(k.toString(), v)),
+        'movieServerId': _traktMovieIdToServerId.map((k, v) => MapEntry(k.toString(), v)),
+      });
+    } catch (e) {
+      appLogger.d('TraktWatchState: bridge map persist failed (non-fatal)', error: e);
+    }
+  }
+
+  @override
+  List<ContinueWatchingItem> getContinueWatchingItems() {
+    if (!isTrackerStateAuthorityEnabled) return const [];
+    final expiryCutoff = _nowEpoch - _pendingEvictionTtlSeconds;
+    final fromStubs = _cache.playbackStubs.where((stub) {
+      final id = stub.metadata.id;
+      if (id.startsWith('trakt_movie_pb_')) {
+        final traktId = int.tryParse(id.substring('trakt_movie_pb_'.length));
+        if (traktId == null) return false;
+        if (!_traktMovieIdToPlexKey.containsKey(traktId)) return false;
+        final record = _pendingEvictions[traktId];
+        if (record != null && record.evictedAt > expiryCutoff) return false;
+        return true;
+      }
+      if (id.startsWith('trakt_episode_pb_') || id.startsWith('trakt_upnext_')) {
+        final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_').firstMatch(id);
+        final showId = m != null ? int.tryParse(m.group(1)!) : null;
+        if (showId == null) return false;
+        if (!_traktShowIdToPlexKey.containsKey(showId)) return false;
+        final record = _pendingEvictions[showId];
+        if (record != null && record.evictedAt > expiryCutoff) {
+          // Only suppress the exact evicted episode — a different ep key means
+          // Trakt already advanced to the next episode, so let it through.
+          final m2 = RegExp(r'_s(\d+)e(\d+)$').firstMatch(id);
+          final stubEpKey = m2 != null ? 's${m2.group(1)}e${m2.group(2)}' : null;
+          if (record.epKey == stubEpKey) return false;
+        }
+        return true;
+      }
+      return false;
+    }).toList();
+    if (_pendingNextEpisodes.isEmpty) return fromStubs;
+    return ([...fromStubs, ..._pendingNextEpisodes]
+      ..sort((a, b) => (b.metadata.lastViewedAt ?? 0).compareTo(a.metadata.lastViewedAt ?? 0)));
+  }
+
+  /// All playback stubs, unfiltered — used by enrichment to find stubs that
+  /// need Plex GUID matching regardless of current bridge-map state.
+  List<ContinueWatchingItem> getAllPlaybackStubs() => List.unmodifiable(_cache.playbackStubs);
+
+  /// Fire the bridge-map-updated callback to refresh any listening UI (e.g.
+  /// after marking stubs as not-found so Continue Watching re-renders).
+  void notifyBridgeMapChanged() => _onBridgeMapUpdated?.call();
+
+  /// Feed external IDs resolved outside this provider (e.g. from the scrobble
+  /// path) for a Plex item whose metadata doesn't include a Guid array.
+  /// Also immediately populates the movie bridge map when a Trakt state match
+  /// is found, so [getContinueWatchingItems] can surface the stub without
+  /// waiting for a separate [getOverrideFor] call.
+  void feedExternalIds(String plexKey, ExternalIds ids, {String? thumbPath, String? serverId}) {
+    if (!ids.hasAny) return;
+    _fetchedExternalIds[plexKey] = ids;
+
+    // Immediately wire up the bridge map so getContinueWatchingItems() can
+    // surface in-progress movie stubs without a separate getOverrideFor call.
+    // Check both the watched-movies state (fully watched) and the playback
+    // reverse maps (in-progress only, not yet fully watched).
+    final state = _lookupMovie(ids);
+    final traktId = state?.traktId
+        ?? (ids.imdb != null ? _cache.playbackTraktIdByImdb[ids.imdb] : null)
+        ?? (ids.tmdb != null ? _cache.playbackTraktIdByTmdb[ids.tmdb] : null);
+    if (traktId != null) {
+      _plexMovieKeyToTraktMovieId[plexKey] = traktId;
+      if (!_traktMovieIdToPlexKey.containsKey(traktId)) {
+        _traktMovieIdToPlexKey[traktId] = plexKey;
+        if (thumbPath != null) _traktMovieIdToThumb[traktId] = thumbPath;
+        if (serverId != null) _traktMovieIdToServerId[traktId] = serverId;
+        _onBridgeMapUpdated?.call();
+      }
+    }
+  }
+
+  /// Register a callback used to fetch external IDs for movies whose Plex
+  /// metadata endpoint doesn't return a Guid array.  Set to null to disable.
+  void setExternalIdsFetcher(Future<ExternalIds?> Function(String plexKey, String serverId)? fetcher) {
+    _externalIdsFetcher = fetcher;
+  }
+
+  void _triggerBackgroundIdFetch(MediaItem item) {
+    final key = item.id;
+    final serverId = item.serverId;
+    if (serverId == null || serverId.isEmpty) return;
+    // Skip if already fetched (regardless of whether a Trakt match was found).
+    if (_fetchedExternalIds.containsKey(key)) return;
+    if (_pendingIdFetches.contains(key)) return;
+    final fetcher = _externalIdsFetcher;
+    if (fetcher == null) return;
+    _pendingIdFetches.add(key);
+    unawaited(
+      fetcher(key, serverId).then((ids) {
+        _pendingIdFetches.remove(key);
+        if (ids != null && ids.hasAny) {
+          feedExternalIds(key, ids, thumbPath: item.thumbPath, serverId: serverId);
+          TrackerSyncNotifier.instance.notifySync();
+        } else {
+          // Mark as resolved-but-empty so we don't re-fetch on next render.
+          _fetchedExternalIds[key] = const ExternalIds();
+        }
+        // Save once when the last concurrent fetch drains the pending set,
+        // so a single write captures the complete map instead of 23 racing writes.
+        if (_pendingIdFetches.isEmpty) unawaited(_saveExternalIds());
+      }).catchError((Object _) {
+        _pendingIdFetches.remove(key);
+        if (_pendingIdFetches.isEmpty) unawaited(_saveExternalIds());
+      }),
+    );
+  }
+
+  /// Clear every in-memory cache and lookup map. Does not touch the on-disk
+  /// cache (see [invalidateCache] for that). Used by [bindSession] on profile
+  /// switch so the new profile starts with empty memory but the prior
+  /// profile's persisted cache stays on disk for a future switch-back.
+  void _resetInMemoryState() {
+    _cache.clear();
+    if (_cacheReadyCompleter.isCompleted) {
+      _cacheReadyCompleter = Completer<void>();
+    }
+    _traktShowIdToPlexKey.clear();
+    _traktShowIdToThumb.clear();
+    _traktShowIdToArt.clear();
+    _traktShowIdToServerId.clear();
+    _traktMovieIdToThumb.clear();
+    _traktMovieIdToPlexKey.clear();
+    _traktMovieIdToServerId.clear();
+    _plexKeyToTraktShowId.clear();
+    _showByTraktId.clear();
+    _movieByTraktId.clear();
+    _plexMovieKeyToTraktMovieId.clear();
+    _deepFetchedShows.clear();
+    _enrichNotFoundShowTs.clear();
+    _enrichNotFoundMovieTs.clear();
+    _fetchedExternalIds.clear();
+    _pendingIdFetches.clear();
+    _pendingEvictions.clear();
+    _nextEpisodeByStubId.clear();
+    _resolvedEpisodePosition.clear();
+    _plexSeToTraktSeKey.clear();
+    _pendingNextEpisodes.clear();
+    _allLeavesCache.clear();
+    _guidIndexCache.clear();
+    _guidIndexBuiltAt = null;
+    _watchlistShowsRaw = const [];
+    _watchlistMoviesRaw = const [];
+    _postMarkRefreshTimer?.cancel();
+    _postMarkRefreshTimer = null;
+    // Keep _onBridgeMapUpdated and _externalIdsFetcher — these callbacks should
+    // persist through cache clears.
+  }
+
+  @override
+  Future<void> invalidateCache() async {
+    _resetInMemoryState();
+    final cache = PlexApiCache.instance;
+    await Future.wait([
+      cache.delete(_cacheServerId, _CacheKeys.watchedMovies),
+      cache.delete(_cacheServerId, _CacheKeys.watchedShows),
+      cache.delete(_cacheServerId, _CacheKeys.playback),
+      cache.delete(_cacheServerId, _CacheKeys.upNext),
+      cache.delete(_cacheServerId, _CacheKeys.lastActivities),
+      cache.delete(_cacheServerId, _CacheKeys.bridgeMaps),
+      cache.delete(_cacheServerId, _CacheKeys.enrichNotFound),
+      cache.delete(_cacheServerId, _CacheKeys.externalIds),
+      cache.delete(_cacheServerId, _CacheKeys.resolvedPositions),
+      cache.delete(_cacheServerId, _CacheKeys.watchlistShows),
+      cache.delete(_cacheServerId, _CacheKeys.watchlistMovies),
+    ]);
+    appLogger.d('TraktWatchState: cache invalidated (memory and persistent)');
+    _onCachesInvalidated?.call();
+  }
+
+  // -------------------------------------------------------------------------
+  // Optimistic eviction
+  // -------------------------------------------------------------------------
+
+  /// Immediately removes [item] from the in-memory playback cache so
+  /// Continue Watching updates without waiting for the Trakt history push.
+  /// A background [syncWatchState] confirms the final state.
+  @override
+  void evictFromPlayback(MediaItem item) {
+    final kind = item.kind;
+    appLogger.d('TraktWatchState: evictFromPlayback called — kind=${kind.name} id=${item.id} title="${item.title}"');
+    if (kind == MediaKind.movie) {
+      final traktId = _plexMovieKeyToTraktMovieId[item.id];
+      if (traktId == null) {
+        appLogger.w('TraktWatchState: evict failed — movie key ${item.id} not in bridge map');
+        return;
+      }
+      _pendingEvictions[traktId] = (epKey: null, evictedAt: _nowEpoch);
+      final before = _cache.playbackRaw.length;
+      _cache.playbackRaw = _cache.playbackRaw.where((e) {
+        final id = ((e['movie'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt();
+        return id != traktId;
+      }).toList();
+      appLogger.d('TraktWatchState: evicted movie traktId=$traktId (playback $before→${_cache.playbackRaw.length})');
+    } else {
+      // Show, season, or episode: key off the show's Plex rating key.
+      final showPlexKey = switch (kind) {
+        MediaKind.episode => item.grandparentId ?? item.id,
+        MediaKind.season => item.parentId ?? item.id,
+        _ => item.id,
+      };
+      final traktShowId = _plexKeyToTraktShowId[showPlexKey];
+      if (traktShowId == null) {
+        appLogger.w('TraktWatchState: evict failed — show plexKey=$showPlexKey not in bridge map');
+        return;
+      }
+      _pendingEvictions[traktShowId] = (epKey: 's${item.parentIndex ?? 0}e${item.index ?? 0}', evictedAt: _nowEpoch);
+
+      // Capture pre-fetched next episode before evicting the stub from cache.
+      ContinueWatchingItem? evictedStub;
+      for (final stub in _cache.playbackStubs) {
+        final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_').firstMatch(stub.metadata.id);
+        final sid = m != null ? int.tryParse(m.group(1)!) : null;
+        if (sid == traktShowId) { evictedStub = stub; break; }
+      }
+
+      final beforePb = _cache.playbackRaw.length;
+      final beforeUn = _cache.upNextRaw.length;
+      _cache.playbackRaw = _cache.playbackRaw.where((e) {
+        final id = ((e['show'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt();
+        return id != traktShowId;
+      }).toList();
+      _cache.upNextRaw = _cache.upNextRaw.where((e) {
+        final id =
+            (e['show_id'] as num?)?.toInt() ??
+            ((e['show'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt();
+        return id != traktShowId;
+      }).toList();
+      appLogger.d(
+        'TraktWatchState: evicted show traktId=$traktShowId '
+        '(playback $beforePb→${_cache.playbackRaw.length}, upNext $beforeUn→${_cache.upNextRaw.length})',
+      );
+
+      final nextEp = evictedStub?.nextEpisode;
+      if (nextEp != null) {
+        final nextWithTimestamp = nextEp.copyWith(lastViewedAt: _nowEpoch);
+        _pendingNextEpisodes.add(ContinueWatchingItem(metadata: nextWithTimestamp, progress: 0.0));
+        appLogger.d(
+          'TraktWatchState: pre-fetched next ep ready — '
+          'S${nextEp.parentIndex}E${nextEp.index} "${nextEp.title}" (${nextEp.id})',
+        );
+      } else {
+        appLogger.d('TraktWatchState: no pre-fetched next ep for show $traktShowId — waiting for Trakt refresh');
+      }
+    }
+    _buildContinueWatchingStubs();
+    appLogger.d('TraktWatchState: eviction complete — ${_cache.playbackStubs.length} stubs remain');
+  }
+
+  void touchPlaybackEntryByIds(int traktShowId, int season, int episode) {
+    final nowStr = DateTime.now().toUtc().toIso8601String();
+    bool updated = false;
+    for (var i = 0; i < _cache.playbackRaw.length; i++) {
+      final entry = _cache.playbackRaw[i];
+      if (entry['type'] != 'episode') continue;
+      final entryShowId = ((entry['show'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt();
+      if (entryShowId != traktShowId) continue;
+      final ep = entry['episode'] as Map<String, dynamic>?;
+      if ((ep?['season'] as num?)?.toInt() != season) continue;
+      if ((ep?['number'] as num?)?.toInt() != episode) continue;
+      _cache.playbackRaw[i] = {...entry, 'paused_at': nowStr};
+      updated = true;
+      appLogger.t('TraktWatchState: touched paused_at for s${season}e$episode traktShowId=$traktShowId');
+      break;
+    }
+    if (updated) {
+      _buildPlaybackIndices();
+      _buildContinueWatchingStubs();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Playback + up_next lightweight refresh (used by both _doSync and post-mark)
+  // -------------------------------------------------------------------------
+
+  /// Fetch `/sync/playback` and `/sync/up_next_nitro`, update the in-memory cache,
+  /// and rebuild stubs. Called by the `_doSync` playback-only path and by
+  /// [schedulePlaybackRefresh] after a successful Trakt history push.
+  Future<void> _refreshPlaybackAndUpNext(TraktClient client) async {
+    _pendingNextEpisodes.clear(); // real Trakt data takes over from here
+    List<dynamic> moviesRaw = [], episodesRaw = [], upNextItemsRaw = [];
+    await Future.wait([
+      client.getPlaybackMovies().then((v) => moviesRaw = v),
+      client.getPlaybackEpisodes().then((v) => episodesRaw = v),
+      client.getUpNextItems().then((v) => upNextItemsRaw = v),
+    ]);
+    _cache.playbackRaw = [...moviesRaw, ...episodesRaw].whereType<Map<String, dynamic>>().toList();
+    _cache.upNextRaw = upNextItemsRaw.whereType<Map<String, dynamic>>().toList();
+    _logPlaybackResponse(_cache.playbackRaw);
+    _buildPlaybackIndices();
+    _buildContinueWatchingStubs();
+    _onBridgeMapUpdated?.call();
+    unawaited(_persistToCache(null));
+  }
+
+  /// Schedule a debounced playback+up_next refresh ~1.5 s from now.
+  /// Called after each successful Trakt history-add so the next episode appears
+  /// in Continue Watching without waiting for the next app-launch sync.
+  /// Debounced so bulk season marks coalesce into a single fetch.
+  void schedulePlaybackRefresh() {
+    _postMarkRefreshTimer?.cancel();
+    _postMarkRefreshTimer = Timer(const Duration(milliseconds: 1500), () {
+      final client = _client;
+      if (client == null) return;
+      unawaited(
+        _refreshPlaybackAndUpNext(client)
+            .then((_) => TrackerSyncNotifier.instance.notifySync())
+            .catchError((Object e) {
+          appLogger.d('TraktWatchState: post-mark refresh failed (non-fatal)', error: e);
+        }),
+      );
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Sync logic
+  // -------------------------------------------------------------------------
+
+  Future<void> _doSync(TraktClient client, {bool force = false}) async {
+    // 1. Fetch last_activities to determine whether data is stale.
+    Map<String, dynamic>? newActivities;
+    try {
+      newActivities = await client.getLastActivities();
+    } catch (e) {
+      appLogger.d('TraktWatchState: getLastActivities failed', error: e);
+    }
+
+    final needsRefresh = force || _needsRefresh(newActivities);
+
+    // Trakt unreachable (getLastActivities threw) — preserve existing cache rather
+    // than risk overwriting good data with empty results from a failed full sync.
+    // cacheReady is completed so UI can proceed with whatever is already loaded.
+    if (newActivities == null && !_cache.isEmpty) {
+      appLogger.w('TraktWatchState: Trakt unreachable — keeping cached watch data');
+      if (!_cacheReadyCompleter.isCompleted) _cacheReadyCompleter.complete();
+      return;
+    }
+
+    if (!needsRefresh && !_cache.isEmpty) {
+      // Lightweight refresh: only re-fetches /sync/playback and /sync/up_next to
+      // update in-progress items without re-fetching the full watched history.
+      // Full rebuild (below) clears resolved-show/movie caches so getOverrideFor()
+      // picks up renames and GUID changes — triggered when last_activities shows new
+      // data or force=true (e.g. after a manual mark-watched or app foreground).
+      appLogger.d('TraktWatchState: watched data up-to-date, refreshing playback only');
+      try {
+        await _refreshPlaybackAndUpNext(client);
+      } catch (e) {
+        appLogger.w('TraktWatchState: playback refresh failed (non-fatal)', error: e);
+      }
+      if (!_cacheReadyCompleter.isCompleted) _cacheReadyCompleter.complete();
+      return;
+    }
+
+    appLogger.d('TraktWatchState: starting full sync (force=$force)');
+
+    // 2. Fetch all raw data in parallel.
+    List<dynamic> moviesRaw = [];
+    List<dynamic> showsRaw = [];
+    List<dynamic> playbackMoviesRaw = [];
+    List<dynamic> playbackEpisodesRaw = [];
+    List<dynamic> upNextItemsRaw = [];
+
+    await Future.wait([
+      client.getWatchedMovies().then((v) => moviesRaw = v).catchError((Object e) {
+        appLogger.w('TraktWatchState: getWatchedMovies failed', error: e);
+        return <dynamic>[];
+      }),
+      client.getWatchedShows().then((v) => showsRaw = v).catchError((Object e) {
+        appLogger.w('TraktWatchState: getWatchedShows failed', error: e);
+        return <dynamic>[];
+      }),
+      client.getPlaybackMovies().then((v) => playbackMoviesRaw = v).catchError((Object e) {
+        appLogger.w('TraktWatchState: getPlaybackMovies failed', error: e);
+        return <dynamic>[];
+      }),
+      client.getPlaybackEpisodes().then((v) => playbackEpisodesRaw = v).catchError((Object e) {
+        appLogger.w('TraktWatchState: getPlaybackEpisodes failed', error: e);
+        return <dynamic>[];
+      }),
+      client.getUpNextItems().then((v) => upNextItemsRaw = v).catchError((Object e) {
+        appLogger.w('TraktWatchState: getUpNextItems failed', error: e);
+        return <dynamic>[];
+      }),
+    ]);
+
+    // 3. Cast and store raw responses.
+    _cache.watchedMoviesRaw = moviesRaw.whereType<Map<String, dynamic>>().toList();
+    _cache.watchedShowsRaw = showsRaw.whereType<Map<String, dynamic>>().toList();
+    _cache.playbackRaw = [...playbackMoviesRaw, ...playbackEpisodesRaw].whereType<Map<String, dynamic>>().toList();
+    _cache.upNextRaw = upNextItemsRaw.whereType<Map<String, dynamic>>().toList();
+    if (newActivities != null) _cache.lastActivities = newActivities;
+
+    // 4. Build lookup indices and continue-watching stubs.
+    _buildMovieIndices();
+    _buildShowIndices();
+    _buildPlaybackIndices();
+    _logPlaybackResponse(_cache.playbackRaw);
+    _buildContinueWatchingStubs();
+
+    // 5. Persist to ApiCache.
+    await _persistToCache(newActivities);
+
+    appLogger.d(
+      'TraktWatchState: sync complete — '
+      '${_cache.watchedMoviesRaw.length} movies, '
+      '${_cache.watchedShowsRaw.length} shows, '
+      '${_cache.playbackRaw.length} playback items, '
+      '${_cache.upNextRaw.length} up-next items, '
+      '${_cache.playbackStubs.length} continue-watching stubs',
+    );
+
+    // 6. Unblock consumers awaiting cacheReady.
+    if (!_cacheReadyCompleter.isCompleted) _cacheReadyCompleter.complete();
+
+    // 7. Non-blocking background fetches for watchlist and ratings.
+    //    Watchlist also populates in-memory state so the playlists tab can
+    //    surface it when authority is on (see _syncWatchlist).
+    unawaited(_syncWatchlist(client));
+    unawaited(_fetchAndCacheList(client.getRatings, _CacheKeys.ratingsShows));
+    unawaited(_fetchAndCacheList(() => client.getRatings(type: 'movies'), _CacheKeys.ratingsMovies));
+  }
+
+  /// Generic helper: fetch a list endpoint and persist it to ApiCache.
+  Future<void> _fetchAndCacheList(Future<List<dynamic>> Function() fetch, String cacheKey) async {
+    try {
+      final raw = await fetch();
+      final typed = raw.whereType<Map<String, dynamic>>().toList();
+      await _saveList(PlexApiCache.instance, cacheKey, typed);
+    } catch (e) {
+      appLogger.w('TraktWatchState: cache fetch failed for $cacheKey (non-fatal)', error: e);
+    }
+  }
+
+  /// Fetch shows + movies watchlist, store in memory, and persist. Fires a
+  /// sync notify if either list arrived so the playlists tab can rebuild.
+  Future<void> _syncWatchlist(TraktClient client) async {
+    var updated = false;
+    try {
+      final shows = (await client.getWatchlist()).whereType<Map<String, dynamic>>().toList();
+      _watchlistShowsRaw = shows;
+      await _saveList(PlexApiCache.instance, _CacheKeys.watchlistShows, shows);
+      updated = true;
+    } catch (e) {
+      appLogger.w('TraktWatchState: watchlist (shows) sync failed (non-fatal)', error: e);
+    }
+    try {
+      final movies = (await client.getWatchlist(type: 'movies')).whereType<Map<String, dynamic>>().toList();
+      _watchlistMoviesRaw = movies;
+      await _saveList(PlexApiCache.instance, _CacheKeys.watchlistMovies, movies);
+      updated = true;
+    } catch (e) {
+      appLogger.w('TraktWatchState: watchlist (movies) sync failed (non-fatal)', error: e);
+    }
+    if (updated) TrackerSyncNotifier.instance.notifySync();
+  }
+
+  bool _needsRefresh(Map<String, dynamic>? newActivities) {
+    if (newActivities == null) return true;
+    final stored = _cache.lastActivities;
+    if (stored == null) return true;
+
+    // Compare the top-level 'all' timestamp.
+    final storedAll = stored['all'] as String?;
+    final newAll = newActivities['all'] as String?;
+    if (storedAll == null || newAll == null) return true;
+    return storedAll != newAll;
+  }
+
+  // Build-method call order: _buildMovieIndices → _buildShowIndices → _buildPlaybackIndices → _buildContinueWatchingStubs.
+  // Each method in this chain depends on output from its predecessors; changing
+  // the order or skipping a method will produce incorrect CW stubs.
+  void _buildMovieIndices() {
+    _cache.byImdb.clear();
+    _cache.byTmdb.clear();
+    _cache.byTvdb.clear();
+    _cache.resolvedMovies.clear(); // invalidate resolved cache on every rebuild
+    _movieByTraktId.clear();
+
+    for (final item in _cache.watchedMoviesRaw) {
+      final movie = item['movie'] as Map<String, dynamic>?;
+      if (movie == null) continue;
+      final ids = movie['ids'] as Map<String, dynamic>?;
+      if (ids == null) continue;
+
+      final traktId = (ids['trakt'] as num?)?.toInt() ?? 0;
+      final plays = (item['plays'] as num?)?.toInt() ?? 0;
+      final lastWatched = item['last_watched_at'] as String?;
+      final state = _TraktState(plays: plays, lastWatchedAt: lastWatched, traktId: traktId);
+
+      final imdb = ids['imdb'] as String?;
+      final tmdb = (ids['tmdb'] as num?)?.toInt();
+      if (imdb != null && imdb.isNotEmpty) _cache.byImdb[imdb] = state;
+      if (tmdb != null) _cache.byTmdb[tmdb] = state;
+      if (traktId > 0) _movieByTraktId[traktId] = state;
+    }
+  }
+
+  // Called after _buildMovieIndices. Populates showEpisodes, showProgress, and
+  // per-show ID lookup maps (_cache.showBy*). Must run before _buildPlaybackIndices.
+  void _buildShowIndices() {
+    // Two version increments per full sync (_buildShowIndices + _buildPlaybackIndices)
+    // are intentional: each invalidates the stale-pause cache independently so that
+    // partial refreshes (playback-only via _refreshPlaybackAndUpNext) also trigger
+    // a cache miss. Do not consolidate into a single increment without updating
+    // _refreshPlaybackAndUpNext to increment itself.
+    _rawDataVersion++;
+    _cache.showByImdb.clear();
+    _cache.showByTmdb.clear();
+    _cache.showByTvdb.clear();
+    _cache.showEpisodes.clear();
+    _cache.showProgress.clear();
+    _cache.resolvedShows.clear(); // invalidate resolved cache on every rebuild
+    _grandparentIdsNotFound.clear();
+
+    for (final item in _cache.watchedShowsRaw) {
+      final show = item['show'] as Map<String, dynamic>?;
+      if (show == null) continue;
+      final ids = show['ids'] as Map<String, dynamic>?;
+      if (ids == null) continue;
+
+      final traktId = (ids['trakt'] as num?)?.toInt() ?? 0;
+      final plays = (item['plays'] as num?)?.toInt() ?? 0;
+      final lastWatched = item['last_watched_at'] as String?;
+      final state = _TraktState(plays: plays, lastWatchedAt: lastWatched, traktId: traktId);
+
+      final imdb = ids['imdb'] as String?;
+      final tmdb = (ids['tmdb'] as num?)?.toInt();
+      final tvdb = (ids['tvdb'] as num?)?.toInt();
+      if (imdb != null && imdb.isNotEmpty) _cache.showByImdb[imdb] = state;
+      if (tmdb != null) _cache.showByTmdb[tmdb] = state;
+      if (tvdb != null) _cache.showByTvdb[tvdb] = state;
+
+      if (traktId > 0) _showByTraktId[traktId] = state;
+
+      // Build per-episode map: "s{season}e{episode}" -> state.
+      final seasons = item['seasons'] as List?;
+      if (seasons != null && traktId > 0) {
+        final epMap = <String, _TraktEpisodeState>{};
+        int watchedCount = 0;
+        for (final season in seasons) {
+          final seasonNum = (season['number'] as num?)?.toInt() ?? 0;
+          final episodes = season['episodes'] as List?;
+          if (episodes == null) continue;
+          for (final ep in episodes) {
+            final epNum = (ep['number'] as num?)?.toInt() ?? 0;
+            final epPlays = (ep['plays'] as num?)?.toInt() ?? 0;
+            final epLastWatched = ep['last_watched_at'] as String?;
+            final key = 's${seasonNum}e$epNum';
+            epMap[key] = _TraktEpisodeState(plays: epPlays, lastWatchedAt: epLastWatched);
+            if (epPlays > 0) watchedCount++;
+          }
+        }
+        _cache.showEpisodes[traktId] = epMap;
+        // Store (watched, 0, lastWatched) — aired count not available from
+        // /sync/watched/shows; 0 is a sentinel meaning "use Plex's leafCount".
+        _cache.showProgress[traktId] = (watchedCount, 0, lastWatched);
+      }
+    }
+  }
+
+  // Called after _buildShowIndices. Populates episodePlayback and playback reverse
+  // indices from _cache.playbackRaw. Must run before _buildContinueWatchingStubs.
+  void _buildPlaybackIndices() {
+    _rawDataVersion++; // see _buildShowIndices for why both methods increment
+    _cache.playbackByImdb.clear();
+    _cache.playbackByTmdb.clear();
+    _cache.playbackByTvdb.clear();
+    _cache.playbackByTraktId.clear();
+    _cache.episodePlayback.clear();
+
+    for (final item in _cache.playbackRaw) {
+      final progress = (item['progress'] as num?)?.toDouble() ?? 0.0;
+      final itemType = item['type'] as String?;
+
+      if (itemType == 'movie') {
+        final movie = item['movie'] as Map<String, dynamic>?;
+        final ids = movie?['ids'] as Map<String, dynamic>?;
+        if (ids == null) continue;
+        final imdb = ids['imdb'] as String?;
+        final tmdb = (ids['tmdb'] as num?)?.toInt();
+        final tvdb = (ids['tvdb'] as num?)?.toInt();
+        final traktId = (ids['trakt'] as num?)?.toInt();
+        if (imdb != null && imdb.isNotEmpty) _cache.playbackByImdb[imdb] = progress;
+        if (tmdb != null) _cache.playbackByTmdb[tmdb] = progress;
+        if (tvdb != null) _cache.playbackByTvdb[tvdb] = progress;
+        // traktId-keyed fallback: used when imdb/tmdb cross-match fails
+        if (traktId != null && traktId > 0) {
+          _cache.playbackByTraktId[traktId] = progress;
+          // Reverse maps for feedExternalIds bridge-map population.
+          if (imdb != null && imdb.isNotEmpty) _cache.playbackTraktIdByImdb[imdb] = traktId;
+          if (tmdb != null) _cache.playbackTraktIdByTmdb[tmdb] = traktId;
+        }
+      } else if (itemType == 'episode') {
+        final show = item['show'] as Map<String, dynamic>?;
+        final episode = item['episode'] as Map<String, dynamic>?;
+        if (show == null || episode == null) continue;
+        final showIds = show['ids'] as Map<String, dynamic>?;
+        if (showIds == null) continue;
+        final showTraktId = (showIds['trakt'] as num?)?.toInt() ?? 0;
+        final season = (episode['season'] as num?)?.toInt() ?? 0;
+        final number = (episode['number'] as num?)?.toInt() ?? 0;
+        if (showTraktId > 0) {
+          _cache.episodePlayback['$showTraktId:s${season}e$number'] = (
+            progress: progress,
+            pausedAt: item['paused_at'] as String?,
+          );
+        }
+      }
+    }
+  }
+
+  /// Schedules a [_buildContinueWatchingStubs] call via microtask.
+  /// Multiple calls within the same synchronous block coalesce into one rebuild,
+  /// preventing O(N) redundant iterations when enriching N shows/episodes at once.
+  void _scheduleBuildContinueWatchingStubs() {
+    if (_stubRebuildPending) return;
+    _stubRebuildPending = true;
+    scheduleMicrotask(() {
+      _stubRebuildPending = false;
+      _buildContinueWatchingStubs();
+    });
+  }
+
+  void _buildContinueWatchingStubs() {
+    final stubs = <ContinueWatchingItem>[];
+    final seenMovieIds = <int>{};
+
+    // 1. Movie stubs from /sync/playback/movies.
+    for (final item in _cache.playbackRaw.where((i) => i['type'] == 'movie')) {
+      final traktId = ((item['movie'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt() ?? 0;
+      if (traktId > 0 && seenMovieIds.add(traktId)) {
+        final stub = _stubFromMoviePlayback(item);
+        if (stub != null) stubs.add(stub);
+      }
+    }
+
+    // 2. Build override map: showId → paused-episode stub from /sync/playback/episodes.
+    //    These replace the up_next stub for shows actively mid-watch (correct ep + progress bar).
+    //    When Trakt returns multiple episode entries for the same show (e.g. current ep +
+    //    a previously-paused ep), prefer the one with the latest paused_at timestamp so a
+    //    stale entry from a prior session never displaces the most-recently-paused episode.
+    final Map<int, ({ContinueWatchingItem stub, String pausedAt})> pausedCandidates = {};
+    for (final item in _cache.playbackRaw.where((i) => i['type'] == 'episode')) {
+      final showId = ((item['show'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt() ?? 0;
+      if (showId <= 0) continue;
+      final stub = _stubFromEpisodePlayback(item);
+      if (stub == null) continue;
+      final pausedAt = item['paused_at'] as String? ?? '';
+      final existing = pausedCandidates[showId];
+      if (existing == null || pausedAt.compareTo(existing.pausedAt) > 0) {
+        pausedCandidates[showId] = (stub: stub, pausedAt: pausedAt);
+      }
+    }
+    final pausedByShowId = pausedCandidates.map((k, v) => MapEntry(k, v.stub));
+
+    // 3. Episode stubs: up_next_nitro as base (all shows), override with paused stub if available.
+    //    Only override when the paused episode is NOT already completed in /sync/watched/shows —
+    //    a completed episode with a lingering pause point is stale (watched on another device).
+    final seenShowIds = <int>{};
+    for (final item in _cache.upNextRaw) {
+      final showId =
+          (item['show_id'] as num?)?.toInt() ??
+          ((item['show'] as Map<String, dynamic>?)?['ids']?['trakt'] as num?)?.toInt() ??
+          0;
+      if (showId == 0 || !seenShowIds.add(showId)) continue;
+
+      ContinueWatchingItem? stub;
+      final pausedStub = pausedByShowId[showId];
+      if (pausedStub != null) {
+        // Invalidate stale-pause cache when raw data changed since last build.
+        if (_stalePauseCacheVersion != _rawDataVersion) {
+          _stalePauseCache.clear();
+          _stalePauseCacheVersion = _rawDataVersion;
+        }
+
+        final bool alreadyWatched;
+        if (_stalePauseCache.containsKey(showId)) {
+          alreadyWatched = _stalePauseCache[showId]!;
+        } else {
+          final season = pausedStub.metadata.parentIndex;
+          final ep = pausedStub.metadata.index;
+          _TraktEpisodeState? epState;
+          if (season != null && ep != null) {
+            epState = _cache.showEpisodes[showId]?['s${season}e$ep'];
+          }
+          final pbKey = season != null && ep != null ? '$showId:s${season}e$ep' : null;
+          final pausedAt = DateTime.tryParse(_cache.episodePlayback[pbKey]?.pausedAt ?? '');
+          final showLastWatchedAt = DateTime.tryParse(_cache.showProgress[showId]?.$3 ?? '');
+
+          // Check 1 — show-level: any episode watched more recently than the pause.
+          bool computed =
+              pausedAt != null && showLastWatchedAt != null && showLastWatchedAt.isAfter(pausedAt);
+
+          // Check 2 — episode-level: this specific episode was completed after its pause.
+          if (!computed && (epState?.plays ?? 0) > 0) {
+            final watchedAt = DateTime.tryParse(epState?.lastWatchedAt ?? '');
+            computed = pausedAt == null || watchedAt == null || !pausedAt.isAfter(watchedAt);
+          }
+
+          // Check 3 — race condition: /sync/watched/shows may lag behind up_next_nitro
+          // after a recent scrobble. If up_next_nitro's next episode is strictly ahead of
+          // the paused episode, the pause is stale even if plays is still 0.
+          if (!computed) {
+            final nextEp = (item['progress'] as Map<String, dynamic>?)?['next_episode'] as Map<String, dynamic>?;
+            final upNextSeason = (nextEp?['season'] as num?)?.toInt() ?? 0;
+            final upNextEp = (nextEp?['number'] as num?)?.toInt() ?? 0;
+            final pausedSeason = season ?? 0;
+            final pausedEp = ep ?? 0;
+            final upNextIsAhead =
+                upNextSeason > pausedSeason || (upNextSeason == pausedSeason && upNextEp > pausedEp);
+            if (upNextIsAhead) computed = true;
+          }
+          _stalePauseCache[showId] = computed;
+          alreadyWatched = computed;
+        }
+
+        if (alreadyWatched) {
+          stub = _stubFromUpNextItem(item);
+        } else {
+          // The /sync/playback endpoint doesn't include Trakt's Plex VIP integration IDs,
+          // so the paused stub may lack the plex:// GUID. Inject it from the up_next_nitro
+          // item which always carries the full show.ids.plex object.
+          final upNextShowIds = (item['show'] as Map<String, dynamic>?)?['ids'] as Map<String, dynamic>?;
+          final upNextPlexGuid = (upNextShowIds?['plex'] as Map<String, dynamic>?)?['guid'] as String?;
+          stub = (upNextPlexGuid != null && upNextPlexGuid.isNotEmpty)
+              ? _injectPlexGuid(pausedStub, upNextPlexGuid)
+              : pausedStub;
+        }
+      } else {
+        stub = _stubFromUpNextItem(item);
+      }
+      if (stub != null) stubs.add(stub);
+    }
+
+    // Edge case: show is in /sync/playback/episodes but NOT in up_next_nitro — still add it.
+    for (final entry in pausedByShowId.entries) {
+      if (!seenShowIds.contains(entry.key)) stubs.add(entry.value);
+    }
+
+    stubs.sort((a, b) => (b.metadata.lastViewedAt ?? 0).compareTo(a.metadata.lastViewedAt ?? 0));
+    _cache.playbackStubs = stubs;
+
+    // Prune _pendingEvictions after each rebuild.
+    // Movies: guard cleared when the movie is gone from new stubs.
+    // Shows: guard cleared when either (a) the show is gone, or (b) the new stub
+    //   is for a different episode — meaning Trakt advanced to the next ep.
+    //   This allows the next episode to appear immediately after a history push.
+    if (_pendingEvictions.isNotEmpty) {
+      final Map<int, String?> stubShowEpKeys = {}; // showId → stub ep key
+      final Set<int> stubMovieIds = {};
+      for (final stub in stubs) {
+        final id = stub.metadata.id;
+        if (id.startsWith('trakt_movie_pb_')) {
+          final traktId = int.tryParse(id.substring('trakt_movie_pb_'.length));
+          if (traktId != null) stubMovieIds.add(traktId);
+        } else if (id.startsWith('trakt_episode_pb_') || id.startsWith('trakt_upnext_')) {
+          final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_s(\d+)e(\d+)').firstMatch(id);
+          if (m != null) {
+            final showId = int.tryParse(m.group(1)!);
+            if (showId != null) stubShowEpKeys[showId] = 's${m.group(2)}e${m.group(3)}';
+          }
+        }
+      }
+      final expiryCutoff = _nowEpoch - _pendingEvictionTtlSeconds;
+      _pendingEvictions.removeWhere((traktId, record) {
+        if (record.evictedAt <= expiryCutoff) {
+          appLogger.w('TraktWatchState: pendingEviction $traktId expired TTL without confirmation');
+          return true;
+        }
+        if (record.epKey == null) {
+          // Movie guard: clear when the movie is gone from new stubs.
+          final confirmed = !stubMovieIds.contains(traktId);
+          if (confirmed) appLogger.d('TraktWatchState: pendingEviction movie $traktId confirmed gone');
+          return confirmed;
+        } else {
+          // Show guard: clear when show is gone OR new stub is a different episode.
+          final newEpKey = stubShowEpKeys[traktId];
+          final gone = newEpKey == null;
+          final advanced = newEpKey != null && newEpKey != record.epKey;
+          if (gone) appLogger.d('TraktWatchState: pendingEviction show $traktId confirmed gone');
+          if (advanced) appLogger.d('TraktWatchState: pendingEviction show $traktId advanced to $newEpKey (was ${record.epKey})');
+          return gone || advanced;
+        }
+      });
+    }
+  }
+
+  ContinueWatchingItem _injectPlexGuid(ContinueWatchingItem stub, String plexGuid) {
+    final plexUri = 'plex://show/$plexGuid';
+    final existingRaw = stub.metadata.raw ?? {};
+    final existingGuids = List<Map<String, dynamic>>.from(existingRaw['Guid'] as List? ?? []);
+    if (existingGuids.any((g) => g['id'] == plexUri)) return stub;
+    final newGuids = [{'id': plexUri}, ...existingGuids];
+    return ContinueWatchingItem(
+      metadata: stub.metadata.copyWith(raw: {...existingRaw, 'Guid': newGuids}),
+      progress: stub.progress,
+      nextEpisode: stub.nextEpisode,
+    );
+  }
+
+  ContinueWatchingItem? _stubFromMoviePlayback(Map<String, dynamic> item) {
+    final movie = item['movie'] as Map<String, dynamic>?;
+    if (movie == null) return null;
+    final ids = movie['ids'] as Map<String, dynamic>?;
+    if (ids == null) return null;
+
+    final traktId = (ids['trakt'] as num?)?.toInt() ?? 0;
+    if (traktId == 0) return null;
+
+    final progress = (item['progress'] as num?)?.toDouble() ?? 0.0;
+    final pausedAt = item['paused_at'] as String?;
+
+    final imdb = ids['imdb'] as String?;
+    final tmdb = (ids['tmdb'] as num?)?.toInt();
+
+    final externalGuids = <Map<String, String>>[
+      if (imdb != null && imdb.isNotEmpty) {'id': 'imdb://$imdb'},
+      if (tmdb != null) {'id': 'tmdb://$tmdb'},
+    ];
+
+    final plexKey = _traktMovieIdToPlexKey[traktId];
+    final plexThumb = _traktMovieIdToThumb[traktId];
+    final plexServerId = _traktMovieIdToServerId[traktId];
+
+    final images = movie['images'] as Map<String, dynamic>?;
+    final traktPoster = _extractTraktImage(images, 'poster');
+    final traktFanart = _extractTraktImage(images, 'fanart');
+
+    final runtimeMin = (movie['runtime'] as num?)?.toInt();
+    final duration = runtimeMin != null ? runtimeMin * 60 * 1000 : null;
+    final viewOffset = (duration != null && progress > 0) ? (progress / 100.0 * duration).toInt() : 1;
+
+    final metadata = MediaItem.plex(
+      id: 'trakt_movie_pb_$traktId',
+      kind: MediaKind.movie,
+      title: movie['title'] as String?,
+      year: (movie['year'] as num?)?.toInt(),
+      thumbPath: plexThumb ?? traktPoster,
+      artPath: traktFanart,
+      serverId: plexServerId,
+      grandparentId: plexKey,
+      viewOffsetMs: viewOffset,
+      durationMs: duration,
+      lastViewedAt: _isoToUnix(pausedAt),
+      raw: externalGuids.isEmpty ? null : {'Guid': externalGuids},
+    );
+
+    return ContinueWatchingItem(metadata: metadata, progress: progress);
+  }
+
+  ContinueWatchingItem? _stubFromEpisodePlayback(Map<String, dynamic> item) {
+    final show = item['show'] as Map<String, dynamic>?;
+    final episode = item['episode'] as Map<String, dynamic>?;
+    if (show == null || episode == null) return null;
+
+    final showIds = show['ids'] as Map<String, dynamic>?;
+    if (showIds == null) return null;
+
+    final showTraktId = (showIds['trakt'] as num?)?.toInt() ?? 0;
+    if (showTraktId == 0) return null;
+
+    final season = (episode['season'] as num?)?.toInt() ?? 0;
+    final epNumber = (episode['number'] as num?)?.toInt() ?? 0;
+    final progress = (item['progress'] as num?)?.toDouble() ?? 0.0;
+    final pausedAt = item['paused_at'] as String?;
+
+    final plexGuid = (showIds['plex'] as Map<String, dynamic>?)?['guid'] as String?;
+    final imdb = showIds['imdb'] as String?;
+    final tmdb = (showIds['tmdb'] as num?)?.toInt();
+    final tvdb = (showIds['tvdb'] as num?)?.toInt();
+    final externalGuids = <Map<String, String>>[
+      if (plexGuid != null && plexGuid.isNotEmpty) {'id': 'plex://show/$plexGuid'},
+      if (imdb != null && imdb.isNotEmpty) {'id': 'imdb://$imdb'},
+      if (tmdb != null) {'id': 'tmdb://$tmdb'},
+      if (tvdb != null) {'id': 'tvdb://$tvdb'},
+    ];
+
+    final plexShowKey = _traktShowIdToPlexKey[showTraktId];
+    final plexServerId = _traktShowIdToServerId[showTraktId];
+    final plexThumb = _traktShowIdToThumb[showTraktId];
+    final plexArt = _traktShowIdToArt[showTraktId];
+
+    final showImages = show['images'] as Map<String, dynamic>?;
+    final traktPoster = _extractTraktImage(showImages, 'poster');
+    final traktFanart = _extractTraktImage(showImages, 'fanart');
+    final epImages = episode['images'] as Map<String, dynamic>?;
+    final traktEpThumb = _extractTraktImage(epImages, 'screenshot');
+
+    final episodeIds = episode['ids'] as Map<String, dynamic>?;
+    final episodeTvdb = (episodeIds?['tvdb'] as num?)?.toInt();
+    final episodeTmdb = (episodeIds?['tmdb'] as num?)?.toInt();
+
+    final runtimeMin = (episode['runtime'] as num?)?.toInt() ?? (show['runtime'] as num?)?.toInt();
+    final duration = runtimeMin != null ? runtimeMin * 60 * 1000 : null;
+    final viewOffset = (duration != null && progress > 0) ? (progress / 100.0 * duration).toInt() : 1;
+
+    final stubId = 'trakt_episode_pb_${showTraktId}_s${season}e$epNumber';
+    final resolved = _resolvedEpisodePosition[stubId];
+
+    final metadata = MediaItem.plex(
+      id: stubId,
+      kind: MediaKind.episode,
+      title: episode['title'] as String?,
+      summary: episode['overview'] as String?,
+      grandparentTitle: show['title'] as String?,
+      grandparentId: plexShowKey,
+      grandparentThumbPath: plexThumb ?? traktPoster,
+      grandparentArtPath: plexArt ?? traktFanart,
+      thumbPath: traktEpThumb ?? resolved?.thumb,
+      serverId: plexServerId,
+      year: (show['year'] as num?)?.toInt(),
+      parentIndex: resolved?.season ?? season,
+      index: resolved?.episode ?? epNumber,
+      viewOffsetMs: viewOffset,
+      durationMs: duration,
+      lastViewedAt: _isoToUnix(pausedAt),
+      raw: {
+        if (externalGuids.isNotEmpty) 'Guid': externalGuids,
+        'episodeTvdb': ?episodeTvdb,
+        'episodeTmdb': ?episodeTmdb,
+      },
+    );
+
+    return ContinueWatchingItem(metadata: metadata, progress: progress, nextEpisode: _nextEpisodeByStubId[stubId]);
+  }
+
+  ContinueWatchingItem? _stubFromUpNextItem(Map<String, dynamic> item) {
+    final show = item['show'] as Map<String, dynamic>?;
+    final progress = item['progress'] as Map<String, dynamic>?;
+    if (show == null || progress == null) return null;
+
+    final nextEp = progress['next_episode'] as Map<String, dynamic>?;
+    if (nextEp == null) return null;
+
+    final showIds = show['ids'] as Map<String, dynamic>?;
+    if (showIds == null) return null;
+
+    final showTraktId = (item['show_id'] as num?)?.toInt() ?? (showIds['trakt'] as num?)?.toInt() ?? 0;
+    if (showTraktId == 0) return null;
+
+    final season = (nextEp['season'] as num?)?.toInt() ?? 0;
+    final epNumber = (nextEp['number'] as num?)?.toInt() ?? 0;
+    final lastWatchedAt = progress['last_watched_at'] as String?;
+
+    final plexGuid = (showIds['plex'] as Map<String, dynamic>?)?['guid'] as String?;
+    final imdb = showIds['imdb'] as String?;
+    final tmdb = (showIds['tmdb'] as num?)?.toInt();
+    final tvdb = (showIds['tvdb'] as num?)?.toInt();
+    final externalGuids = <Map<String, String>>[
+      if (plexGuid != null && plexGuid.isNotEmpty) {'id': 'plex://show/$plexGuid'},
+      if (imdb != null && imdb.isNotEmpty) {'id': 'imdb://$imdb'},
+      if (tmdb != null) {'id': 'tmdb://$tmdb'},
+      if (tvdb != null) {'id': 'tvdb://$tvdb'},
+    ];
+
+    final plexShowKey = _traktShowIdToPlexKey[showTraktId];
+    final plexServerId = _traktShowIdToServerId[showTraktId];
+    final plexThumb = _traktShowIdToThumb[showTraktId];
+    final plexArt = _traktShowIdToArt[showTraktId];
+
+    final showImages = show['images'] as Map<String, dynamic>?;
+    final traktPoster = _extractTraktImage(showImages, 'poster');
+    final traktFanart = _extractTraktImage(showImages, 'fanart');
+    final epImages = nextEp['images'] as Map<String, dynamic>?;
+    final traktEpThumb = _extractTraktImage(epImages, 'screenshot');
+
+    final nextEpIds = nextEp['ids'] as Map<String, dynamic>?;
+    final nextEpTvdb = (nextEpIds?['tvdb'] as num?)?.toInt();
+    final nextEpTmdb = (nextEpIds?['tmdb'] as num?)?.toInt();
+
+    final stubId = 'trakt_upnext_${showTraktId}_s${season}e$epNumber';
+    final resolved = _resolvedEpisodePosition[stubId];
+
+    final metadata = MediaItem.plex(
+      id: stubId,
+      kind: MediaKind.episode,
+      title: nextEp['title'] as String?,
+      summary: nextEp['overview'] as String?,
+      grandparentTitle: show['title'] as String?,
+      grandparentId: plexShowKey,
+      grandparentThumbPath: plexThumb ?? traktPoster,
+      grandparentArtPath: plexArt ?? traktFanart,
+      thumbPath: traktEpThumb ?? resolved?.thumb,
+      serverId: plexServerId,
+      year: (show['year'] as num?)?.toInt(),
+      parentIndex: resolved?.season ?? season,
+      index: resolved?.episode ?? epNumber,
+      lastViewedAt: _isoToUnix(lastWatchedAt),
+      raw: {
+        if (externalGuids.isNotEmpty) 'Guid': externalGuids,
+        'episodeTvdb': ?nextEpTvdb,
+        'episodeTmdb': ?nextEpTmdb,
+      },
+    );
+
+    return ContinueWatchingItem(metadata: metadata, progress: 0.0, nextEpisode: _nextEpisodeByStubId[stubId]);
+  }
+
+  // -------------------------------------------------------------------------
+  // Override builders
+  // -------------------------------------------------------------------------
+
+  WatchStateOverride? _overrideForMovie(MediaItem item, ExternalIds ids) {
+    // 1. Resolved-cache fast path — populated on first successful match.
+    final resolved = _cache.resolvedMovies[item.id];
+    if (resolved != null) {
+      final viewOffset = _progressToOffset(resolved.playbackProgress, item.durationMs) ?? 0;
+      appLogger.t('[TraktOverride] movie=${item.title} — resolved cache hit (traktId=${resolved.traktId})');
+      return WatchStateOverride(
+        viewCount: resolved.plays,
+        viewOffset: viewOffset,
+        lastViewedAt: _isoToUnix(resolved.lastWatchedAt),
+      );
+    }
+
+    // 2. Bridge-map fast path — traktId known from a prior session.
+    final cachedTraktId = _plexMovieKeyToTraktMovieId[item.id];
+    _TraktState? state;
+    double? playback;
+    if (cachedTraktId != null) {
+      state = _movieByTraktId[cachedTraktId];
+      playback = _cache.playbackByTraktId[cachedTraktId];
+      appLogger.t('[TraktOverride] movie=${item.title} — bridge map hit (traktId=$cachedTraktId)');
+    } else {
+      // 3. Full external-ID lookup.
+      state = _lookupMovie(ids);
+      playback = _lookupMoviePlayback(ids);
+      // 4. traktId-keyed playback fallback: when imdb/tmdb cross-match misses but
+      //    state was found (giving us the traktId), look up playback by traktId.
+      if (playback == null && state != null) {
+        playback = _cache.playbackByTraktId[state.traktId];
+      }
+    }
+
+    appLogger.t('[TraktOverride] movie=${item.title} state.plays=${state?.plays} playback=$playback ids=$ids');
+
+    // 5. No title fallback — external IDs must match.
+    if (state == null && playback == null) return null;
+
+    final traktViewOffset = _progressToOffset(playback, item.durationMs);
+    // Trakt is the sole authority: active playback → resume; in watched list → done (0); not in Trakt → null (early return above).
+    final viewOffset = traktViewOffset ?? (state != null ? 0 : null);
+    final lastViewed = _isoToUnix(state?.lastWatchedAt);
+
+    // 6. Populate bridge map + resolved cache for subsequent calls.
+    if (state != null) {
+      _plexMovieKeyToTraktMovieId[item.id] = state.traktId;
+      _cache.resolvedMovies[item.id] = _ResolvedMovieEntry(
+        traktId: state.traktId,
+        plays: state.plays,
+        playbackProgress: playback,
+        lastWatchedAt: state.lastWatchedAt,
+      );
+      // Also populate the reverse map so getContinueWatchingItems() shows this
+      // movie without waiting for a full enrichment pass.
+      final isNewBridgeEntry = !_traktMovieIdToPlexKey.containsKey(state.traktId);
+      if (isNewBridgeEntry) {
+        _traktMovieIdToPlexKey[state.traktId] = item.id;
+        if (item.thumbPath != null) _traktMovieIdToThumb[state.traktId] = item.thumbPath!;
+        if (item.serverId != null) _traktMovieIdToServerId[state.traktId] = item.serverId!;
+        _onBridgeMapUpdated?.call();
+      }
+    } else if (playback != null) {
+      // In-progress only (not yet in /sync/watched/movies).
+      // Populate both bridge maps using the playback reverse-index so the
+      // Continue Watching stub becomes visible without waiting for feedExternalIds.
+      final traktId = (ids.imdb != null ? _cache.playbackTraktIdByImdb[ids.imdb] : null)
+          ?? (ids.tmdb != null ? _cache.playbackTraktIdByTmdb[ids.tmdb] : null);
+      if (traktId != null) {
+        _plexMovieKeyToTraktMovieId[item.id] = traktId;
+        if (!_traktMovieIdToPlexKey.containsKey(traktId)) {
+          _traktMovieIdToPlexKey[traktId] = item.id;
+          if (item.thumbPath != null) _traktMovieIdToThumb[traktId] = item.thumbPath!;
+          if (item.serverId != null) _traktMovieIdToServerId[traktId] = item.serverId!;
+          _onBridgeMapUpdated?.call();
+        }
+      }
+    }
+
+    return WatchStateOverride(
+      viewCount: state?.plays ?? 0,
+      viewOffset: viewOffset,
+      lastViewedAt: lastViewed,
+    );
+  }
+
+  WatchStateOverride? _overrideForEpisode(MediaItem item, ExternalIds episodeIds) {
+    final season = item.parentIndex;
+    final number = item.index;
+    if (season == null || number == null) return null;
+
+    // Fast-exit for shows already confirmed not in Trakt this sync cycle.
+    // Skip the fast-exit when the bridge map now has an entry for this grandparentId —
+    // the negative cache is stale (CW enrichment ran after the initial failed lookup).
+    if (item.grandparentId != null && _grandparentIdsNotFound.contains(item.grandparentId)) {
+      if (_plexKeyToTraktShowId.containsKey(item.grandparentId)) {
+        _grandparentIdsNotFound.remove(item.grandparentId!);
+        // Fall through: bridge map will resolve the traktId below.
+      } else {
+        appLogger.t(
+          'TraktWatchState: _overrideForEpisode ${item.title} (${item.id}) — '
+          'grandparentId=${item.grandparentId} in negative cache → null',
+        );
+        return null;
+      }
+    }
+
+    // Identify the show via the episode's own IDs (Plex includes show-level
+    // imdb/tmdb/tvdb on episodes via includeGuids=1).
+    var showState = _lookupShow(episodeIds);
+
+    // Bridge map fallback — works once the show has been matched via getOverrideFor(show)
+    // or via CW enrichment. Also supports shows that are in /sync/playback but have no
+    // entries yet in /sync/watched/shows (_showByTraktId may be null for such shows).
+    int? bridgeMapTraktId;
+    if (item.grandparentId != null) {
+      bridgeMapTraktId = _plexKeyToTraktShowId[item.grandparentId];
+    }
+    if (showState == null && bridgeMapTraktId != null) {
+      showState = _showByTraktId[bridgeMapTraktId];
+    }
+
+    // No title fallback — external IDs or bridge map must match.
+    if (showState == null && bridgeMapTraktId == null) {
+      if (item.grandparentId != null) _grandparentIdsNotFound.add(item.grandparentId!);
+      appLogger.d(
+        'TraktWatchState: show match failed for episode ${item.title} (IDs: $episodeIds, GP: ${item.grandparentId})',
+      );
+      return null;
+    }
+
+    // Use traktId from full show state when available; fall back to bridge map when the
+    // show is in /sync/playback but not yet in /sync/watched/shows (showState == null).
+    final traktShowId = showState?.traktId ?? bridgeMapTraktId!;
+
+    // Register show → Plex data mapping using the show's ratingKey when available.
+    final showPlexKey = item.grandparentId ?? item.id;
+    final isNewEp = !_traktShowIdToPlexKey.containsKey(traktShowId);
+    _traktShowIdToPlexKey[traktShowId] = showPlexKey;
+    _plexKeyToTraktShowId[showPlexKey] = traktShowId;
+    if (item.serverId != null) _traktShowIdToServerId[traktShowId] = item.serverId!;
+    final epThumb = item.grandparentThumbPath ?? item.thumbPath;
+    if (epThumb != null) _traktShowIdToThumb[traktShowId] = epThumb;
+    final epArt = item.grandparentArtPath ?? item.artPath;
+    if (epArt != null) _traktShowIdToArt[traktShowId] = epArt;
+    if (isNewEp) _scheduleBuildContinueWatchingStubs();
+    final epKey = 's${season}e$number';
+    var epState = _cache.showEpisodes[traktShowId]?[epKey];
+    var effectiveEpKey = epKey;
+    // S/E remapping for shows whose Plex numbering differs from Trakt's (e.g. anime).
+    // Falls back to the direct key when no remapping is available.
+    if (epState == null) {
+      final remappedKey = _plexSeToTraktSeKey['$traktShowId:$epKey'];
+      if (remappedKey != null) {
+        effectiveEpKey = remappedKey;
+        epState = _cache.showEpisodes[traktShowId]?[remappedKey];
+      }
+    }
+
+    // Playback progress for this specific episode.
+    final pbKey = '$traktShowId:$effectiveEpKey';
+    final playbackPct = _cache.episodePlayback[pbKey]?.progress;
+    final viewOffset = _progressToOffset(playbackPct, item.durationMs);
+
+    final plays = epState?.plays ?? 0;
+    // Watched episodes (plays >= 1) are always shown with offset=0 — no progress bar.
+    // Trakt may still hold a playback entry (e.g. the user re-started the episode);
+    // we ignore it because showing a bar on a watched episode is confusing.
+    // Unwatched episodes (plays=0): use Trakt's playback offset if present, otherwise
+    // preserve Plex's own in-progress offset (null → caller keeps Plex value).
+    final resolvedViewOffset = plays > 0 ? 0 : viewOffset;
+
+    appLogger.t(
+      'TraktWatchState: _overrideForEpisode ${item.title} (${item.id}) — '
+      'traktShowId=$traktShowId epKey=$effectiveEpKey '
+      'plays=$plays playbackPct=$playbackPct durationMs=${item.durationMs} '
+      'viewOffset=$viewOffset resolvedViewOffset=$resolvedViewOffset',
+    );
+
+    // If Trakt has no per-episode record and no active playback, preserve Plex's
+    // watched state (viewCount) entirely. Returning an override with viewCount=0
+    // would clear Plex checkmarks for episodes watched locally but not scrobbled.
+    if (epState == null && resolvedViewOffset == null) return null;
+
+    return WatchStateOverride(
+      // Only set viewCount when Trakt has positive play data; null preserves Plex's viewCount
+      // for episodes that exist in the show but weren't scrobbled to Trakt.
+      viewCount: plays > 0 ? plays : null,
+      viewOffset: resolvedViewOffset,
+      lastViewedAt: _isoToUnix(epState?.lastWatchedAt),
+    );
+  }
+
+  WatchStateOverride? _overrideForShow(MediaItem item, ExternalIds ids) {
+    // 1. Resolved-cache fast path — only stores traktId so progress is always
+    //    read live from _cache.showProgress (safe against fetchShowProgressIfNeeded updates).
+    final resolved = _cache.resolvedShows[item.id];
+    if (resolved != null) {
+      final progress = _cache.showProgress[resolved.traktId];
+      final storedAired = progress?.$2 ?? 0;
+      final leafCount = storedAired > 0 ? storedAired : item.leafCount;
+      final lastViewed = _isoToUnix(_showByTraktId[resolved.traktId]?.lastWatchedAt);
+      appLogger.t('[TraktOverride] show=${item.title} — resolved cache hit (traktId=${resolved.traktId})');
+      return WatchStateOverride(
+        viewedLeafCount: progress?.$1 ?? 0,
+        leafCount: leafCount,
+        lastViewedAt: lastViewed,
+      );
+    }
+
+    // 2. Bridge map fast path.
+    var showState = _showByTraktId[_plexKeyToTraktShowId[item.id]];
+
+    // 3. External-ID lookup — no title fallback.
+    showState ??= _lookupShow(ids);
+
+    if (showState == null) return null;
+
+    final isNewShow = !_traktShowIdToPlexKey.containsKey(showState.traktId);
+    _traktShowIdToPlexKey[showState.traktId] = item.id;
+    _plexKeyToTraktShowId[item.id] = showState.traktId;
+    if (item.serverId != null) _traktShowIdToServerId[showState.traktId] = item.serverId!;
+    if (item.thumbPath != null) _traktShowIdToThumb[showState.traktId] = item.thumbPath!;
+    if (item.artPath != null) _traktShowIdToArt[showState.traktId] = item.artPath!;
+    if (isNewShow) _scheduleBuildContinueWatchingStubs();
+
+    final progress = _cache.showProgress[showState.traktId];
+    final lastViewed = _isoToUnix(showState.lastWatchedAt);
+
+    // Use Plex's leafCount when the stored aired count is 0 (sentinel —
+    // /sync/watched/shows doesn't return total aired count).
+    final storedAired = progress?.$2 ?? 0;
+    final leafCount = storedAired > 0 ? storedAired : item.leafCount;
+
+    // 4. Populate resolved cache — traktId only; progress is read live above.
+    _cache.resolvedShows[item.id] = _ResolvedShowEntry(traktId: showState.traktId);
+
+    return WatchStateOverride(viewedLeafCount: progress?.$1 ?? 0, leafCount: leafCount, lastViewedAt: lastViewed);
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  ExternalIds _idsFromItem(MediaItem item) {
+    final guids = item.raw?['Guid'] as List?;
+    if (guids != null && guids.isNotEmpty) {
+      return ExternalIds.fromGuids(guids);
+    }
+    // Check IDs fed from the scrobble path (for movies whose Plex detail
+    // endpoint doesn't return a Guid array even with includeGuids=1).
+    final fed = _fetchedExternalIds[item.id];
+    if (fed != null && fed.hasAny) return fed;
+    // No IDs available synchronously — trigger a one-shot background fetch so
+    // the overlay can match on the next render cycle.
+    _triggerBackgroundIdFetch(item);
+    return _idsFromGuid(item.guid);
+  }
+
+  /// Parse external IDs from a Plex guid string.
+  /// Handles both modern (`imdb://tt123`) and legacy agent format
+  /// (`com.plexapp.agents.imdb://tt123/0/0`).
+  ExternalIds _idsFromGuid(String? guid) {
+    if (guid == null || guid.isEmpty) return const ExternalIds();
+    return ExternalIds.fromPrimaryGuid(guid);
+  }
+
+  _TraktState? _lookupMovie(ExternalIds ids) {
+    if (ids.imdb != null) {
+      final s = _cache.byImdb[ids.imdb];
+      if (s != null) return s;
+    }
+    if (ids.tmdb != null) {
+      final s = _cache.byTmdb[ids.tmdb];
+      if (s != null) return s;
+    }
+    if (ids.tvdb != null) {
+      final s = _cache.byTvdb[ids.tvdb];
+      if (s != null) return s;
+    }
+    return null;
+  }
+
+  double? _lookupMoviePlayback(ExternalIds ids) {
+    if (ids.imdb != null) {
+      final p = _cache.playbackByImdb[ids.imdb];
+      if (p != null) return p;
+    }
+    if (ids.tmdb != null) {
+      final p = _cache.playbackByTmdb[ids.tmdb];
+      if (p != null) return p;
+    }
+    if (ids.tvdb != null) {
+      final p = _cache.playbackByTvdb[ids.tvdb];
+      if (p != null) return p;
+    }
+    return null;
+  }
+
+  _TraktState? _lookupShow(ExternalIds ids) {
+    if (ids.imdb != null) {
+      final s = _cache.showByImdb[ids.imdb];
+      if (s != null) return s;
+    }
+    if (ids.tmdb != null) {
+      final s = _cache.showByTmdb[ids.tmdb];
+      if (s != null) return s;
+    }
+    if (ids.tvdb != null) {
+      final s = _cache.showByTvdb[ids.tvdb];
+      if (s != null) return s;
+    }
+    return null;
+  }
+
+  /// Convert a Trakt `progress` (0-100) to a [MediaItem.viewOffset] in ms.
+  int? _progressToOffset(double? progress, int? durationMs) {
+    if (progress == null || durationMs == null || durationMs == 0) return null;
+    if (progress <= 0) return null;
+    return (progress / 100.0 * durationMs).toInt();
+  }
+
+  /// Convert an ISO-8601 timestamp to a unix timestamp in seconds.
+  int? _isoToUnix(String? iso) {
+    if (iso == null || iso.isEmpty) return null;
+    try {
+      return DateTime.parse(iso).millisecondsSinceEpoch ~/ 1000;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _logPlaybackResponse(List<Map<String, dynamic>> items) {
+    if (items.isEmpty) {
+      appLogger.d('TraktWatchState: /sync/playback returned 0 items');
+      return;
+    }
+    appLogger.d('TraktWatchState: /sync/playback returned ${items.length} items');
+    // for (var i = 0; i < items.length; i++) {
+    //   appLogger.d('TraktWatchState: playback[$i] ${jsonEncode(items[i])}');
+    // }
+  }
+
+  /// Extracts the first URL of [type] from a Trakt `images` object and prepends
+  /// `https://` if the URL is not already absolute (Trakt omits the scheme).
+  String? _extractTraktImage(Map<String, dynamic>? images, String type) {
+    if (images == null) return null;
+    final arr = images[type] as List<dynamic>?;
+    if (arr == null || arr.isEmpty) return null;
+    final url = arr.first as String?;
+    if (url == null || url.isEmpty) return null;
+    return url.startsWith('https://') ? url : 'https://$url';
+  }
+
+  // -------------------------------------------------------------------------
+  // Cache persistence (ApiCache table)
+  // -------------------------------------------------------------------------
+
+  Future<void> _persistToCache(Map<String, dynamic>? lastActivities) async {
+    final cache = PlexApiCache.instance;
+    await Future.wait([
+      _saveList(cache, _CacheKeys.watchedMovies, _cache.watchedMoviesRaw),
+      _saveList(cache, _CacheKeys.watchedShows, _cache.watchedShowsRaw),
+      _saveList(cache, _CacheKeys.playback, _cache.playbackRaw),
+      _saveList(cache, _CacheKeys.upNext, _cache.upNextRaw),
+      if (lastActivities != null) cache.put(_cacheServerId, _CacheKeys.lastActivities, lastActivities),
+    ]);
+  }
+
+  Future<void> _saveList(PlexApiCache cache, String key, List<Map<String, dynamic>> items) {
+    return cache.put(_cacheServerId, key, {'items': items});
+  }
+
+  Future<void> _saveExternalIds() async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final items = {
+      for (final e in _fetchedExternalIds.entries)
+        e.key: {
+          'imdb': e.value.imdb,
+          'tmdb': e.value.tmdb,
+          'tvdb': e.value.tvdb,
+          if (!e.value.hasAny) 'ts': now,
+        }
+    };
+    if (items.isNotEmpty) {
+      await PlexApiCache.instance.put(_cacheServerId, _CacheKeys.externalIds, {'items': items});
+    }
+  }
+
+  Future<void> _saveResolvedPositions() async {
+    final items = {
+      for (final e in _resolvedEpisodePosition.entries)
+        e.key: {
+          'season': e.value.season,
+          'episode': e.value.episode,
+          if (e.value.thumb != null) 'thumb': e.value.thumb,
+        },
+    };
+    if (items.isNotEmpty) {
+      await PlexApiCache.instance.put(_cacheServerId, _CacheKeys.resolvedPositions, {'items': items});
+    }
+  }
+
+  /// Load data from ApiCache on startup (avoids a full API sync on cold boot
+  /// if nothing changed since last run).
+  Future<void> loadFromCache() async {
+    try {
+      final cache = PlexApiCache.instance;
+      final lastAct = await cache.get(_cacheServerId, _CacheKeys.lastActivities);
+      if (lastAct != null) _cache.lastActivities = lastAct;
+
+      final movies = await cache.get(_cacheServerId, _CacheKeys.watchedMovies);
+      if (movies != null) {
+        _cache.watchedMoviesRaw = (movies['items'] as List? ?? []).whereType<Map<String, dynamic>>().toList();
+      }
+
+      final shows = await cache.get(_cacheServerId, _CacheKeys.watchedShows);
+      if (shows != null) {
+        _cache.watchedShowsRaw = (shows['items'] as List? ?? []).whereType<Map<String, dynamic>>().toList();
+      }
+
+      final pb = await cache.get(_cacheServerId, _CacheKeys.playback);
+      if (pb != null) {
+        _cache.playbackRaw = (pb['items'] as List? ?? []).whereType<Map<String, dynamic>>().toList();
+      }
+
+      final un = await cache.get(_cacheServerId, _CacheKeys.upNext);
+      if (un != null) {
+        _cache.upNextRaw = (un['items'] as List? ?? []).whereType<Map<String, dynamic>>().toList();
+      }
+
+      // Restore watchlist raw items so the "Trakt Watchlist" playlist shows
+      // immediately on cold boot without waiting for a network sync.
+      final wlShows = await cache.get(_cacheServerId, _CacheKeys.watchlistShows);
+      if (wlShows != null) {
+        _watchlistShowsRaw = (wlShows['items'] as List? ?? []).whereType<Map<String, dynamic>>().toList();
+      }
+      final wlMovies = await cache.get(_cacheServerId, _CacheKeys.watchlistMovies);
+      if (wlMovies != null) {
+        _watchlistMoviesRaw = (wlMovies['items'] as List? ?? []).whereType<Map<String, dynamic>>().toList();
+      }
+
+      // Restore bridge maps so stubs have images immediately on second launch.
+      final bridgeCached = await cache.get(_cacheServerId, _CacheKeys.bridgeMaps);
+      if (bridgeCached != null) {
+        final plexKeyMap = bridgeCached['plexKey'];
+        final thumbMap = bridgeCached['thumb'];
+        final artMap = bridgeCached['art'];
+        final serverIdMap = bridgeCached['serverId'];
+        final movieThumbMap = bridgeCached['movieThumb'];
+        if (plexKeyMap is Map) {
+          for (final e in plexKeyMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) {
+              _traktShowIdToPlexKey[id] = e.value as String;
+              _plexKeyToTraktShowId[e.value as String] = id;
+            }
+          }
+        }
+        if (thumbMap is Map) {
+          for (final e in thumbMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) _traktShowIdToThumb[id] = e.value as String;
+          }
+        }
+        if (artMap is Map) {
+          for (final e in artMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) _traktShowIdToArt[id] = e.value as String;
+          }
+        }
+        if (serverIdMap is Map) {
+          for (final e in serverIdMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) _traktShowIdToServerId[id] = e.value as String;
+          }
+        }
+        if (movieThumbMap is Map) {
+          for (final e in movieThumbMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) _traktMovieIdToThumb[id] = e.value as String;
+          }
+        }
+        final movieKeyMap = bridgeCached['movieKey'];
+        final movieServerIdMap = bridgeCached['movieServerId'];
+        if (movieKeyMap is Map) {
+          for (final e in movieKeyMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) _traktMovieIdToPlexKey[id] = e.value as String;
+          }
+        }
+        if (movieServerIdMap is Map) {
+          for (final e in movieServerIdMap.entries) {
+            final id = int.tryParse(e.key?.toString() ?? '');
+            if (id != null && e.value is String) _traktMovieIdToServerId[id] = e.value as String;
+          }
+        }
+      }
+
+      // Restore external IDs resolved in prior sessions so background fetches
+      // don't repeat for the same items on every cold start.
+      final extIdsCached = await cache.get(_cacheServerId, _CacheKeys.externalIds);
+      if (extIdsCached != null) {
+        final items = extIdsCached['items'];
+        if (items is Map) {
+          final now = DateTime.now().millisecondsSinceEpoch;
+          for (final e in items.entries) {
+            if (e.key is! String) continue;
+            final m = e.value;
+            if (m is! Map) continue;
+            final ids = ExternalIds(
+              imdb: m['imdb'] as String?,
+              tmdb: (m['tmdb'] as num?)?.toInt(),
+              tvdb: (m['tvdb'] as num?)?.toInt(),
+            );
+            if (ids.hasAny) {
+              // Successful resolution — restore without expiry.
+              _fetchedExternalIds[e.key as String] = ids;
+            } else {
+              // Empty marker — only restore if within the 24 h TTL.
+              final ts = (m['ts'] as num?)?.toInt();
+              if (ts != null && now - ts < _externalIdsEmptyTtlMs) {
+                _fetchedExternalIds[e.key as String] = const ExternalIds();
+              }
+            }
+          }
+        }
+      }
+
+      // DO NOT PERSIST _enrichNotFoundShowTs / _enrichNotFoundMovieTs to disk.
+      // Prior incident: persisting them caused unmatched stubs to be permanently
+      // filtered by getContinueWatchingItems() before _doEnrichTraktStubs could
+      // re-try the GUID search, because the not-found marker survived across
+      // sessions. These are session-local guards only — every app launch starts
+      // with empty maps so all unmatched stubs are re-tried.
+
+      // Restore resolved Plex S/E positions from prior sessions so CW stubs show
+      // the correct episode numbers immediately on first render (without waiting for
+      // resolveEpisodeDisplayPositions to re-fetch allLeaves from Plex).
+      final resolvedPosCached = await cache.get(_cacheServerId, _CacheKeys.resolvedPositions);
+      if (resolvedPosCached != null) {
+        final posItems = resolvedPosCached['items'];
+        if (posItems is Map) {
+          for (final e in posItems.entries) {
+            if (e.key is! String) continue;
+            final m = e.value;
+            if (m is! Map) continue;
+            _resolvedEpisodePosition[e.key as String] = (
+              season: (m['season'] as num?)?.toInt() ?? 0,
+              episode: (m['episode'] as num?)?.toInt() ?? 0,
+              thumb: m['thumb'] as String?,
+            );
+          }
+        }
+      }
+      // Rebuild Plex→Trakt S/E remapping from the restored positions so
+      // _overrideForEpisode can resolve anime episodes immediately on first load.
+      for (final e in _resolvedEpisodePosition.entries) {
+        _updatePlexSeRemapping(e.key, e.value.season, e.value.episode);
+      }
+
+      if (!_cache.isEmpty) {
+        _buildMovieIndices();
+        _buildShowIndices();
+        _buildPlaybackIndices();
+        _buildContinueWatchingStubs();
+        appLogger.d(
+          'TraktWatchState: loaded from cache — '
+          '${_cache.watchedMoviesRaw.length} movies, '
+          '${_cache.watchedShowsRaw.length} shows, '
+          '${_cache.upNextRaw.length} up-next, '
+          '${_cache.playbackStubs.length} continue-watching stubs',
+        );
+      }
+    } catch (e) {
+      appLogger.d('TraktWatchState: cache load failed (non-fatal)', error: e);
+    } finally {
+      if (!_cacheReadyCompleter.isCompleted) {
+        _cacheReadyCompleter.complete();
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // TrackerStubResolver impl
+  // -------------------------------------------------------------------------
+
+  Future<void>? _enrichingFuture;
+  Future<void>? _resolvePositionsFuture;
+  // Epoch-second of the last successful resolveEpisodeDisplayPositions run.
+  // Guards against redundant HTTP calls when a screen re-enters the foreground
+  // immediately after a sync already resolved positions.
+  int? _resolvedPositionsAt;
+
+  @override
+  bool ownsStub(String stubId) =>
+      stubId.startsWith('trakt_episode_pb_') ||
+      stubId.startsWith('trakt_upnext_') ||
+      stubId.startsWith('trakt_movie_pb_');
+
+  @override
+  Future<MediaItem> resolveEpisodeStub(MediaItem stub, PlexClient client) async {
+    final RegExp pattern;
+    if (stub.id.startsWith('trakt_episode_pb_')) {
+      pattern = RegExp(r'trakt_episode_pb_(\d+)_s(\d+)e(\d+)');
+    } else if (stub.id.startsWith('trakt_upnext_')) {
+      pattern = RegExp(r'trakt_upnext_(\d+)_s(\d+)e(\d+)');
+    } else {
+      return stub;
+    }
+
+    final m = pattern.firstMatch(stub.id);
+    if (m == null) return stub;
+
+    final traktShowId = int.parse(m.group(1)!);
+    final season = int.parse(m.group(2)!);
+    final epNumber = int.parse(m.group(3)!);
+
+    final showPlexKey = await _resolveShowKey(client, traktShowId, stub);
+    if (showPlexKey == null) return stub;
+
+    final label = stub.grandparentTitle ?? '';
+    try {
+      final episodeTvdb = stub.raw?['episodeTvdb'] as int?;
+      final episodeTmdb = stub.raw?['episodeTmdb'] as int?;
+
+      if (episodeTvdb != null || episodeTmdb != null) {
+        final leaves = await client.getAllLeaves(showPlexKey);
+        for (final ep in leaves) {
+          final guids = (ep.raw?['Guid'] as List? ?? [])
+              .map((g) => (g as Map?)?['id'] as String?)
+              .whereType<String>();
+          if (episodeTvdb != null && guids.contains('tvdb://$episodeTvdb')) {
+            recordResolvedEpisodePosition(
+                stub.id, ep.parentIndex ?? season, ep.index ?? epNumber, thumb: ep.thumbPath);
+            return _overlayApply(ep);
+          }
+          if (episodeTmdb != null && guids.contains('tmdb://$episodeTmdb')) {
+            recordResolvedEpisodePosition(
+                stub.id, ep.parentIndex ?? season, ep.index ?? epNumber, thumb: ep.thumbPath);
+            return _overlayApply(ep);
+          }
+        }
+        appLogger.d('[EpisodeMatch] "$label" S${season}E$epNumber — ID lookup found no Guid match');
+        return stub;
+      }
+
+      final seasons = await client.fetchChildren(showPlexKey);
+      final matched = seasons.where((s) => s.index == season).toList();
+      if (matched.isEmpty) return stub;
+      final episodes = await client.fetchChildren(matched.first.id);
+      final episode = episodes.where((e) => e.index == epNumber).toList();
+      if (episode.isEmpty) return stub;
+      return _overlayApply(episode.first);
+    } catch (_) {
+      return stub;
+    }
+  }
+
+  @override
+  Future<MediaItem?> resolveMovieStub(MediaItem stub, PlexClient client) async {
+    if (!stub.id.startsWith('trakt_movie_pb_')) return stub;
+
+    final m = RegExp(r'trakt_movie_pb_(\d+)').firstMatch(stub.id);
+    if (m == null) return null;
+    final traktMovieId = int.parse(m.group(1)!);
+
+    var plexKey = stub.grandparentId ?? getPlexMovieKey(traktMovieId);
+
+    if (plexKey == null) {
+      final rawGuids = (stub.raw?['Guid'] as List? ?? [])
+          .map((g) => (g as Map?)?['id'] as String?)
+          .whereType<String>()
+          .where((g) => g.startsWith('imdb://') || g.startsWith('tmdb://'))
+          .toList();
+      for (final guid in rawGuids) {
+        try {
+          final results = await client.searchSectionsByExternalIdUri(guid, 'movie');
+          final hit = results.where((r) => r.kind == MediaKind.movie).firstOrNull;
+          if (hit != null) {
+            updateMovieBridgeMap(traktMovieId: traktMovieId, plexKey: hit.id, thumb: hit.thumbPath, serverId: hit.serverId);
+            plexKey = hit.id;
+            break;
+          }
+        } catch (e) {
+          appLogger.w('[MovieNav] section GUID search failed for $guid', error: e);
+        }
+      }
+
+      if (plexKey == null) {
+        for (final guid in rawGuids) {
+          try {
+            final results = await client.searchByExternalIdUri(guid);
+            final hit = results.where((r) => r.kind == MediaKind.movie).firstOrNull;
+            if (hit != null) {
+              updateMovieBridgeMap(traktMovieId: traktMovieId, plexKey: hit.id, thumb: hit.thumbPath, serverId: hit.serverId);
+              plexKey = hit.id;
+              break;
+            }
+          } catch (e) {
+            appLogger.w('[MovieNav] global GUID search failed for $guid', error: e);
+          }
+        }
+      }
+    }
+
+    if (plexKey == null) {
+      appLogger.w('[MovieNav] resolveMovieStub: no Plex key found for traktMovieId=$traktMovieId');
+      return null;
+    }
+
+    try {
+      final result = await client.fetchItem(plexKey);
+      if (result == null) return null;
+      final guidList = stub.raw?['Guid'] as List?;
+      final withGuids = (guidList?.isNotEmpty == true)
+          ? result.copyWith(raw: {...?result.raw, 'Guid': guidList!})
+          : result;
+      return _overlayApply(withGuids);
+    } catch (e) {
+      appLogger.w('[MovieNav] fetchItem failed for plexKey=$plexKey', error: e);
+      return null;
+    }
+  }
+
+  @override
+  Future<MediaItem?> resolveStubShowForNavigation(MediaItem stub, PlexClient client) async {
+    final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_').firstMatch(stub.id);
+    if (m == null) return null;
+    final traktShowId = int.parse(m.group(1)!);
+
+    final showKey = await _resolveShowKey(client, traktShowId, stub);
+    if (showKey == null) return null;
+
+    return MediaItem.plex(
+      id: showKey,
+      kind: MediaKind.show,
+      title: stub.grandparentTitle ?? stub.displayTitle,
+      thumbPath: stub.grandparentThumbPath ?? getPlexShowThumb(traktShowId),
+      serverId: stub.serverId ?? getPlexShowServerId(traktShowId),
+      serverName: stub.serverName,
+    );
+  }
+
+  @override
+  Future<MediaItem?> resolveStubMovieForNavigation(MediaItem stub, PlexClient client) async {
+    final m = RegExp(r'trakt_movie_pb_(\d+)').firstMatch(stub.id);
+    if (m == null) return null;
+    final traktMovieId = int.parse(m.group(1)!);
+
+    var plexKey = stub.grandparentId ?? getPlexMovieKey(traktMovieId);
+
+    if (plexKey == null) {
+      final stubIds = ExternalIds.fromGuids(stub.raw?['Guid'] as List? ?? []);
+      final movieTitle = stub.title;
+      if (movieTitle != null && movieTitle.isNotEmpty && stubIds.hasAny) {
+        try {
+          final candidates = await client.searchItems(movieTitle, limit: 10);
+          for (final c in candidates) {
+            if (c.kind != MediaKind.movie) continue;
+            final ids = await client.fetchExternalIds(c.id);
+            if ((stubIds.imdb != null && stubIds.imdb == ids.imdb) ||
+                (stubIds.tmdb != null && stubIds.tmdb == ids.tmdb)) {
+              updateMovieBridgeMap(
+                  traktMovieId: traktMovieId, plexKey: c.id, thumb: c.thumbPath, serverId: c.serverId);
+              plexKey = c.id;
+              break;
+            }
+          }
+        } catch (_) {}
+      }
+    }
+
+    if (plexKey == null) return null;
+
+    final serverId = stub.serverId ?? getPlexMovieServerId(traktMovieId);
+    return MediaItem.plex(
+      id: plexKey,
+      kind: MediaKind.movie,
+      title: stub.title,
+      thumbPath: stub.thumbPath ?? getPlexMovieThumb(traktMovieId),
+      artPath: stub.artPath,
+      year: stub.year,
+      serverId: serverId,
+      serverName: stub.serverName,
+    );
+  }
+
+  @override
+  Future<void> enrichStubs(String? preferredServerId, Map<String, PlexClient> clientMap) async {
+    if (_enrichingFuture != null) {
+      await _enrichingFuture;
+      return;
+    }
+    final completer = Completer<void>();
+    _enrichingFuture = completer.future;
+    try {
+      await _doEnrichStubs(preferredServerId, clientMap);
+      completer.complete();
+    } catch (e) {
+      completer.completeError(e);
+    } finally {
+      _enrichingFuture = null;
+    }
+  }
+
+  static const _resolvedPositionsTtlSeconds = 60;
+
+  @override
+  Future<void> resolveEpisodeDisplayPositions(
+      Map<String, PlexClient> clients, String? fallbackServerId) async {
+    // Coalesce concurrent callers onto the same in-flight operation.
+    if (_resolvePositionsFuture != null) {
+      await _resolvePositionsFuture;
+      return;
+    }
+    // Skip if data is already fresh (e.g. screen re-enters foreground right
+    // after a sync already resolved positions — no need to re-issue HTTP calls).
+    final lastRan = _resolvedPositionsAt;
+    if (lastRan != null && (_nowEpoch - lastRan) < _resolvedPositionsTtlSeconds) return;
+
+    final completer = Completer<void>();
+    _resolvePositionsFuture = completer.future;
+    try {
+      await _doResolveEpisodeDisplayPositions(clients, fallbackServerId);
+      _resolvedPositionsAt = _nowEpoch;
+      completer.complete();
+    } catch (e, st) {
+      completer.completeError(e, st);
+      rethrow;
+    } finally {
+      _resolvePositionsFuture = null;
+    }
+  }
+
+  Future<List<MediaItem>> _getCachedLeaves(PlexClient client, String ratingKey) async {
+    if (_allLeavesCache.containsKey(ratingKey)) return _allLeavesCache[ratingKey]!;
+    final leaves = await client.getAllLeaves(ratingKey);
+    if (_allLeavesCache.length >= _leavesCacheMaxEntries) {
+      _allLeavesCache.remove(_allLeavesCache.keys.first); // FIFO eviction
+    }
+    _allLeavesCache[ratingKey] = leaves;
+    return leaves;
+  }
+
+  Future<void> _doResolveEpisodeDisplayPositions(
+      Map<String, PlexClient> clients, String? fallbackServerId) async {
+    for (final item in getContinueWatchingItems()) {
+      final meta = item.metadata;
+      if (meta.grandparentId == null) continue;
+      final episodeTvdb = meta.raw?['episodeTvdb'] as int?;
+      final episodeTmdb = meta.raw?['episodeTmdb'] as int?;
+      if (episodeTvdb == null && episodeTmdb == null) continue;
+      final serverId = meta.serverId ?? fallbackServerId;
+      final client = serverId != null ? clients[serverId] : null;
+      if (client == null) continue;
+      final cacheKey = meta.grandparentId!;
+      final leaves = await _getCachedLeaves(client, cacheKey);
+      final sorted = leaves.toList()
+        ..sort((a, b) {
+          final sc = (a.parentIndex ?? 0).compareTo(b.parentIndex ?? 0);
+          return sc != 0 ? sc : (a.index ?? 0).compareTo(b.index ?? 0);
+        });
+      final matchIdx = sorted.indexWhere((ep) {
+        final guids = (ep.raw?['Guid'] as List? ?? [])
+            .map((g) => (g as Map?)?['id'] as String?)
+            .whereType<String>();
+        return (episodeTvdb != null && guids.contains('tvdb://$episodeTvdb')) ||
+            (episodeTmdb != null && guids.contains('tmdb://$episodeTmdb'));
+      });
+      if (matchIdx < 0) continue;
+      final ep = sorted[matchIdx];
+      recordResolvedEpisodePosition(
+          meta.id, ep.parentIndex ?? 0, ep.index ?? 0, thumb: ep.thumbPath);
+      if (matchIdx + 1 < sorted.length) {
+        final nextEp = sorted[matchIdx + 1];
+        _nextEpisodeByStubId[meta.id] = nextEp;
+        appLogger.d(
+          'TraktWatchState: pre-fetched next ep for ${meta.title} → '
+          'S${nextEp.parentIndex}E${nextEp.index} "${nextEp.title}" (${nextEp.id})',
+        );
+      }
+      // Build full show S/E remapping for all episodes via sequential inference.
+      // Covers the entire allLeaves list so _overrideForEpisode can resolve any
+      // episode in the show, not just the current CW stub.
+      final stubM =
+          RegExp(r'trakt_(?:upnext|episode_pb)_(\d+)_s(\d+)e(\d+)').firstMatch(meta.id);
+      if (stubM != null) {
+        final traktShowIdInt = int.tryParse(stubM.group(1)!);
+        final traktSeason = int.tryParse(stubM.group(2)!);
+        final traktEpBase = int.tryParse(stubM.group(3)!);
+        if (traktShowIdInt != null && traktSeason != null && traktEpBase != null) {
+          for (int i = 0; matchIdx + i < sorted.length; i++) {
+            final plexEp = sorted[matchIdx + i];
+            final plexS = plexEp.parentIndex ?? 0;
+            final plexE = plexEp.index ?? 0;
+            final traktE = traktEpBase + i;
+            if (plexS != traktSeason || plexE != traktE) {
+              _plexSeToTraktSeKey['$traktShowIdInt:s${plexS}e$plexE'] = 's${traktSeason}e$traktE';
+            }
+          }
+          for (int i = 1; matchIdx - i >= 0; i++) {
+            final plexEp = sorted[matchIdx - i];
+            final plexS = plexEp.parentIndex ?? 0;
+            final plexE = plexEp.index ?? 0;
+            final traktE = traktEpBase - i;
+            if (traktE <= 0) break;
+            if (plexS != traktSeason || plexE != traktE) {
+              _plexSeToTraktSeKey['$traktShowIdInt:s${plexS}e$plexE'] = 's${traktSeason}e$traktE';
+            }
+          }
+        }
+      }
+    }
+    // Re-build stubs so the newly captured next-episode references are embedded.
+    _buildContinueWatchingStubs();
+    // Persist resolved positions so subsequent cold starts skip the allLeaves fetches.
+    unawaited(_saveResolvedPositions());
+  }
+
+  // ---- private stub-resolution helpers (migrated from trakt_ui_helper.dart) ----
+
+  /// Apply the active overlay to [item]. Thin wrapper so override methods don't
+  /// import WatchStateOverlay directly.
+  MediaItem _overlayApply(MediaItem item) {
+    // Import-free apply: read override from self and apply manually.
+    final override = getOverrideFor(item);
+    if (override == null) return item.copyWith(viewCount: 0, viewOffsetMs: 0, viewedLeafCount: 0);
+    return item.copyWith(
+      viewCount: override.viewCount ?? item.viewCount,
+      viewOffsetMs: override.viewOffset ?? item.viewOffsetMs,
+      viewedLeafCount: override.viewedLeafCount ?? item.viewedLeafCount,
+      leafCount: override.leafCount ?? item.leafCount,
+      lastViewedAt: override.lastViewedAt ?? item.lastViewedAt,
+    );
+  }
+
+  Future<String?> _resolveShowKey(PlexClient client, int traktShowId, MediaItem stub) async {
+    final bridgeKey = getPlexShowKey(traktShowId);
+    if (bridgeKey != null) return bridgeKey;
+
+    final rawGuids = (stub.raw?['Guid'] as List? ?? [])
+        .map((g) => (g as Map?)?['id'] as String?)
+        .whereType<String>()
+        .toList();
+    if (rawGuids.isEmpty) return null;
+
+    final label = stub.grandparentTitle ?? stub.displayTitle;
+    final match = await _findByGuidSearch(client, rawGuids, MediaKind.show, label);
+    appLogger.t('[ResolveShow] traktShowId=$traktShowId "$label" → ${match == null ? 'not found' : 'plexKey=${match.id}'}');
+
+    if (match != null) {
+      updateBridgeMap(
+          traktShowId: traktShowId, plexKey: match.id, thumb: match.thumbPath, art: match.artPath, serverId: match.serverId);
+      return match.id;
+    }
+    return null;
+  }
+
+  Future<void> _doEnrichStubs(String? preferredServerId, Map<String, PlexClient> clientMap) async {
+    if (clientMap.isEmpty) return;
+
+    // Prune expired not-found entries so they don't accumulate indefinitely.
+    // Entries are cheap but there is no other eviction path — they are only
+    // removed when the same ID is found (updateBridgeMap/updateMovieBridgeMap)
+    // or on a full invalidateCache(). Pruning here keeps the maps bounded even
+    // after years of failed enrichments for shows the user no longer has in Plex.
+    final now = _nowEpoch;
+    _enrichNotFoundShowTs.removeWhere((_, ts) => (now - ts) >= _enrichNotFoundTtlSeconds);
+    _enrichNotFoundMovieTs.removeWhere((_, ts) => (now - ts) >= _enrichNotFoundTtlSeconds);
+
+    final orderedClients = [
+      if (preferredServerId != null && clientMap.containsKey(preferredServerId)) clientMap[preferredServerId]!,
+      ...clientMap.entries.where((e) => e.key != preferredServerId).map((e) => e.value),
+    ];
+
+    final stubs = getAllPlaybackStubs();
+
+    final needsWork = stubs.where((item) {
+      final key = item.metadata.id;
+      if (key.startsWith('trakt_episode_pb_') || key.startsWith('trakt_upnext_')) {
+        final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_').firstMatch(key);
+        if (m == null) return false;
+        final showId = int.tryParse(m.group(1)!) ?? 0;
+        if (isShowEnrichNotFound(showId)) return false;
+        return getPlexShowKey(showId) == null;
+      }
+      if (key.startsWith('trakt_movie_pb_')) {
+        final m = RegExp(r'trakt_movie_pb_(\d+)').firstMatch(key);
+        if (m == null) return false;
+        final traktId = int.tryParse(m.group(1)!) ?? 0;
+        if (isMovieEnrichNotFound(traktId)) return false;
+        return getPlexMovieKey(traktId) == null;
+      }
+      return false;
+    }).toList();
+
+    if (needsWork.isEmpty) return;
+
+    appLogger.d('TraktWatchState: enriching ${needsWork.length} stubs (parallel)');
+
+    final hasShows = needsWork.any((i) =>
+        i.metadata.id.startsWith('trakt_episode_pb_') || i.metadata.id.startsWith('trakt_upnext_'));
+    final hasMovies = needsWork.any((i) => i.metadata.id.startsWith('trakt_movie_pb_'));
+    final showGuidIndex = <String, MediaItem>{};
+    final movieGuidIndex = <String, MediaItem>{};
+    // Reuse a recently built GUID index (5-min TTL) to avoid full-library
+    // fetches on every enrichment run within the same sync window.
+    final indexStale = _guidIndexBuiltAt == null || (now - _guidIndexBuiltAt!) >= _guidIndexTtlSeconds;
+    if (indexStale) {
+      _guidIndexCache.clear();
+      for (final client in orderedClients) {
+        final sid = client.serverId;
+        if (hasShows) {
+          final idx = await client.buildGuidIndex('show');
+          _guidIndexCache['show_$sid'] = idx;
+          showGuidIndex.addAll(idx);
+        }
+        if (hasMovies) {
+          final idx = await client.buildGuidIndex('movie');
+          _guidIndexCache['movie_$sid'] = idx;
+          movieGuidIndex.addAll(idx);
+        }
+      }
+      _guidIndexBuiltAt = now;
+    } else {
+      for (final entry in _guidIndexCache.entries) {
+        if (entry.key.startsWith('show_')) showGuidIndex.addAll(entry.value);
+        if (entry.key.startsWith('movie_')) movieGuidIndex.addAll(entry.value);
+      }
+    }
+
+    var anyNotFound = false;
+    await Future.wait(
+      needsWork.map((item) async {
+        final meta = item.metadata;
+        final key = meta.id;
+        final rawGuids = (meta.raw?['Guid'] as List? ?? [])
+            .map((g) => (g as Map?)?['id'] as String?)
+            .whereType<String>()
+            .toList();
+        if (rawGuids.isEmpty) return;
+
+        bool found = false;
+        if (key.startsWith('trakt_episode_pb_') || key.startsWith('trakt_upnext_')) {
+          final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_').firstMatch(key)!;
+          final traktShowId = int.parse(m.group(1)!);
+          final showTitle = meta.grandparentTitle ?? '';
+          found = await _enrichShowStub(
+            traktShowId: traktShowId,
+            showTitle: showTitle,
+            rawGuids: rawGuids,
+            orderedClients: orderedClients,
+            guidIndex: showGuidIndex,
+          );
+        } else if (key.startsWith('trakt_movie_pb_')) {
+          final m = RegExp(r'trakt_movie_pb_(\d+)').firstMatch(key)!;
+          final traktMovieId = int.parse(m.group(1)!);
+          final title = meta.title ?? '';
+          found = await _enrichMovieStub(
+            traktMovieId: traktMovieId,
+            title: title,
+            rawGuids: rawGuids,
+            orderedClients: orderedClients,
+            guidIndex: movieGuidIndex,
+          );
+        }
+        if (!found) {
+          anyNotFound = true;
+          if (key.startsWith('trakt_episode_pb_') || key.startsWith('trakt_upnext_')) {
+            final m = RegExp(r'trakt_(?:episode_pb|upnext)_(\d+)_').firstMatch(key);
+            if (m != null) markShowEnrichNotFound(int.parse(m.group(1)!));
+          } else if (key.startsWith('trakt_movie_pb_')) {
+            final m = RegExp(r'trakt_movie_pb_(\d+)').firstMatch(key);
+            if (m != null) markMovieEnrichNotFound(int.parse(m.group(1)!));
+          }
+        }
+      }),
+    );
+
+    if (anyNotFound) await flushEnrichNotFound();
+  }
+
+  Future<bool> _enrichShowStub({
+    required int traktShowId,
+    required String showTitle,
+    required List<String> rawGuids,
+    required List<PlexClient> orderedClients,
+    required Map<String, MediaItem> guidIndex,
+  }) async {
+    MediaItem? match;
+    for (final client in orderedClients) {
+      match = await _findByGuidSearch(client, rawGuids, MediaKind.show, showTitle, guidIndex);
+      if (match != null) break;
+    }
+    if (match != null) {
+      updateBridgeMap(
+          traktShowId: traktShowId, plexKey: match.id, thumb: match.thumbPath, art: match.artPath, serverId: match.serverId);
+      return true;
+    }
+    appLogger.d('[mapping] show "$showTitle" (traktId:$traktShowId) — not found');
+    return false;
+  }
+
+  Future<bool> _enrichMovieStub({
+    required int traktMovieId,
+    required String title,
+    required List<String> rawGuids,
+    required List<PlexClient> orderedClients,
+    required Map<String, MediaItem> guidIndex,
+  }) async {
+    MediaItem? match;
+    for (final client in orderedClients) {
+      match = await _findByGuidSearch(client, rawGuids, MediaKind.movie, title, guidIndex);
+      if (match != null) break;
+    }
+    if (match != null) {
+      updateMovieBridgeMap(
+          traktMovieId: traktMovieId, plexKey: match.id, thumb: match.thumbPath, serverId: match.serverId);
+      return true;
+    }
+    appLogger.d('[mapping] movie "$title" (traktId:$traktMovieId) — not found');
+    return false;
+  }
+
+  static Future<MediaItem?> _findByGuidSearch(
+    PlexClient client,
+    List<String> rawGuids,
+    MediaKind mediaKind,
+    String label, [
+    Map<String, MediaItem> guidIndex = const {},
+  ]) async {
+    final sectionType = mediaKind == MediaKind.movie ? 'movie' : 'show';
+    final secondary = [
+      ...rawGuids.where((g) => g.startsWith('imdb://')),
+      ...rawGuids.where((g) => g.startsWith('tmdb://')),
+      ...rawGuids.where((g) => g.startsWith('tvdb://')),
+    ];
+
+    final legacyEntries = <(String source, String legacy)>[
+      for (final g in secondary.where((g) => g.startsWith('tvdb://'))) ...[
+        (g, 'com.plexapp.agents.thetvdb://${g.substring(7)}'),
+        (g, 'com.plexapp.agents.thetvdb://${g.substring(7)}/0/0'),
+      ],
+      if (mediaKind == MediaKind.movie) ...[
+        for (final g in secondary.where((g) => g.startsWith('imdb://'))) ...[
+          (g, 'com.plexapp.agents.imdb://${g.substring(7)}'),
+          (g, 'com.plexapp.agents.imdb://${g.substring(7)}/0/0'),
+        ],
+        for (final g in secondary.where((g) => g.startsWith('tmdb://'))) ...[
+          (g, 'com.plexapp.agents.themoviedb://${g.substring(7)}'),
+          (g, 'com.plexapp.agents.themoviedb://${g.substring(7)}/0/0'),
+        ],
+      ],
+    ];
+    for (final (source, legacy) in legacyEntries) {
+      try {
+        final results = await client.searchSectionsByExternalIdUri(legacy, sectionType);
+        final hit = results.where((r) => r.kind == mediaKind).firstOrNull;
+        if (hit != null) {
+          appLogger.d('[mapping] "$label" with id:"$source" using "Legacy GUID" → plex:${hit.id}');
+          return hit;
+        }
+      } catch (e) {
+        appLogger.d('[mapping] "$label" Legacy GUID error for $source', error: e);
+      }
+    }
+
+    for (final guid in secondary) {
+      final hit = guidIndex[guid];
+      if (hit != null) {
+        appLogger.d('[mapping] "$label" with id:"$guid" using "GUID index" → plex:${hit.id}');
+        return hit;
+      }
+    }
+
+    appLogger.d('[mapping] "$label" with ids:$secondary — all strategies failed');
+    return null;
+  }
+}

--- a/lib/utils/external_ids.dart
+++ b/lib/utils/external_ids.dart
@@ -15,6 +15,34 @@ class ExternalIds {
 
   bool get hasAny => imdb != null || tmdb != null || tvdb != null;
 
+  /// Parse external IDs from a Plex primary GUID string.
+  /// Handles the modern `imdb://tt123` form and the legacy Plex agent form
+  /// `com.plexapp.agents.imdb://tt123/0/0`.
+  static ExternalIds fromPrimaryGuid(String? guid) {
+    if (guid == null || guid.isEmpty) return const ExternalIds();
+    return ExternalIds.fromGuids([
+      {'id': _normalizeLegacyGuid(guid)}
+    ]);
+  }
+
+  /// Normalise a legacy `com.plexapp.agents.*` GUID to the standard scheme
+  /// that [fromGuids] already handles.  Returns the string unchanged when it
+  /// is already in standard form or unrecognised.
+  static String _normalizeLegacyGuid(String guid) {
+    const prefixes = <String, String>{
+      'agents.imdb://': 'imdb://',
+      'agents.themoviedb://': 'tmdb://',
+      'agents.thetvdb://': 'tvdb://',
+    };
+    for (final entry in prefixes.entries) {
+      final idx = guid.indexOf(entry.key);
+      if (idx == -1) continue;
+      final id = guid.substring(idx + entry.key.length).split('/').first;
+      return '${entry.value}$id';
+    }
+    return guid;
+  }
+
   factory ExternalIds.fromGuids(List<dynamic> guids) {
     String? imdb;
     int? tmdb;

--- a/lib/utils/media_navigation_helper.dart
+++ b/lib/utils/media_navigation_helper.dart
@@ -6,9 +6,14 @@ import '../screens/collection_detail_screen.dart';
 import '../screens/main_screen.dart';
 import '../screens/media_detail_screen.dart';
 import '../screens/playlist/playlist_detail_screen.dart';
+import '../services/trackers/tracker_ui_helper.dart';
+import '../services/trackers/watch_state_overlay.dart';
 import '../utils/global_key_utils.dart';
+import 'app_logger.dart';
 import 'plex_library_section_helpers.dart';
 import 'video_player_navigation.dart';
+
+export '../services/trackers/tracker_ui_helper.dart' show navigateToTrackerStubShow, navigateToTrackerMovieDetail;
 
 /// Result of media navigation indicating what action was taken
 enum MediaNavigationResult {
@@ -99,7 +104,18 @@ Future<MediaNavigationResult> navigateToMediaItem(
 
     case MediaKind.clip:
     case MediaKind.episode:
-      final result = await navigateToVideoPlayer(context, metadata: mi, isOffline: isOffline);
+      // For episodes and clips (trailers/extras), start playback directly.
+      // Resolve synthetic Trakt stubs to real Plex episodes first.
+      final resolved = await resolveTrackerEpisodeStub(context, mi);
+      if (!context.mounted) return MediaNavigationResult.navigated;
+      // If still unresolved (stub), the show wasn't found in Plex — bail early.
+      if (WatchStateOverlay.instance.stubResolver?.ownsStub(resolved.id) ?? false) {
+        ScaffoldMessenger.maybeOf(
+          context,
+        )?.showSnackBar(const SnackBar(content: Text('Could not find this show in your Plex library')));
+        return MediaNavigationResult.unsupported;
+      }
+      final result = await navigateToVideoPlayer(context, metadata: resolved, isOffline: isOffline);
       if (result == true && context.mounted) {
         onRefresh?.call(mi.id);
       }
@@ -107,7 +123,25 @@ Future<MediaNavigationResult> navigateToMediaItem(
 
     case MediaKind.movie:
       if (playDirectly) {
-        final result = await navigateToVideoPlayer(context, metadata: mi, isOffline: isOffline);
+        appLogger.d(
+          '[MovieNav] playDirectly=true id=${mi.id} title="${mi.title}" serverId=${mi.serverId} grandparentId=${mi.grandparentId}',
+        );
+        // Resolve Trakt movie stubs to real Plex items before starting playback.
+        final resolved = await resolveTrackerMovieStub(context, mi);
+        if (!context.mounted) return MediaNavigationResult.navigated;
+        if (resolved == null) {
+          appLogger.d(
+            '[MovieNav] resolveTrackerMovieStub returned null for "${mi.title}" — showing not-found snackbar',
+          );
+          ScaffoldMessenger.maybeOf(
+            context,
+          )?.showSnackBar(const SnackBar(content: Text('Could not find this movie in your Plex library')));
+          return MediaNavigationResult.unsupported;
+        }
+        appLogger.d(
+          '[MovieNav] resolved → id=${resolved.id} title="${resolved.title}" — navigating to player',
+        );
+        final result = await navigateToVideoPlayer(context, metadata: resolved, isOffline: isOffline);
         if (result == true && context.mounted) {
           onRefresh?.call(mi.id);
         }

--- a/lib/utils/video_player_navigation.dart
+++ b/lib/utils/video_player_navigation.dart
@@ -16,6 +16,11 @@ import 'app_logger.dart';
 
 const String kVideoPlayerRouteName = '/video_player';
 
+// Guards against concurrent pushes of the same item (e.g. hero card GestureDetector
+// and Play button InkWell both firing for the same tap). Set synchronously before
+// the first await so the second concurrent call sees it immediately.
+String? _pendingNavigationKey;
+
 class WatchTogetherPlaybackNavigationException implements Exception {
   final String message;
 
@@ -56,82 +61,99 @@ Future<bool?> navigateToVideoPlayer(
   TranscodeQualityPreset? selectedQualityPreset,
   bool usePushReplacement = false,
   bool isOffline = false,
+  void Function(int viewOffsetMs, String ratingKey)? onPlaybackExit,
 }) async {
-  final navigator = Navigator.of(context);
-  final downloadProvider = context.read<DownloadProvider>();
-  // Use the manager-routed lookup so Jellyfin items don't trip the
-  // Plex-only client. The player branches on the returned type internally.
-  final manager = context.read<MultiServerProvider>().serverManager;
-  final mediaClient = isOffline ? null : manager.getClient(metadata.serverId ?? '');
+  // Guard: prevent concurrent navigation to the same item.
+  if (!usePushReplacement) {
+    if (_pendingNavigationKey == metadata.id) return null;
+    _pendingNavigationKey = metadata.id;
+  }
 
-  int mediaIndex = selectedMediaIndex ?? 0;
-  if (selectedMediaIndex == null) {
+  try {
+    final navigator = Navigator.of(context);
+    final downloadProvider = context.read<DownloadProvider>();
+    final manager = context.read<MultiServerProvider>().serverManager;
+    final mediaClient = isOffline ? null : manager.getClient(metadata.serverId ?? '');
+
+    int mediaIndex = selectedMediaIndex ?? 0;
+    if (selectedMediaIndex == null) {
+      try {
+        final settingsService = await SettingsService.getInstance();
+        final seriesKey = metadata.grandparentId ?? metadata.id;
+        final savedPreference = settingsService.read(SettingsService.mediaVersionPreferences)[seriesKey];
+        if (savedPreference != null) {
+          mediaIndex = savedPreference;
+        }
+      } catch (_) {}
+    }
+
+    // Check if external player is enabled
     try {
       final settingsService = await SettingsService.getInstance();
-      final seriesKey = metadata.grandparentId ?? metadata.id;
-      final savedPreference = settingsService.read(SettingsService.mediaVersionPreferences)[seriesKey];
-      if (savedPreference != null) {
-        mediaIndex = savedPreference;
-      }
-    } catch (_) {}
-  }
+      if (settingsService.read(SettingsService.useExternalPlayer)) {
+        bool launched = false;
 
-  // Check if external player is enabled
-  try {
-    final settingsService = await SettingsService.getInstance();
-    if (settingsService.read(SettingsService.useExternalPlayer)) {
-      bool launched = false;
-
-      if (isOffline) {
-        final globalKey = metadata.globalKey;
-        final videoPath = await downloadProvider.getVideoFilePath(globalKey);
-        if (videoPath != null && context.mounted) {
-          final videoUrl = videoPath.contains('://') ? videoPath : 'file://$videoPath';
-          launched = await ExternalPlayerService.launch(context: context, videoUrl: videoUrl);
+        if (isOffline) {
+          final globalKey = metadata.globalKey;
+          final videoPath = await downloadProvider.getVideoFilePath(globalKey);
+          if (videoPath != null && context.mounted) {
+            final videoUrl = videoPath.contains('://') ? videoPath : 'file://$videoPath';
+            launched = await ExternalPlayerService.launch(context: context, videoUrl: videoUrl);
+          }
+        } else if (context.mounted) {
+          launched = await ExternalPlayerService.launch(
+            context: context,
+            metadata: metadata,
+            client: mediaClient,
+            mediaIndex: mediaIndex,
+          );
+        } else if (context.mounted) {
+          launched = await ExternalPlayerService.launch(
+            context: context,
+            metadata: metadata,
+            client: mediaClient,
+            mediaIndex: mediaIndex,
+            mediaSourceId: selectedMediaSourceId,
+          );
         }
-      } else if (context.mounted) {
-        launched = await ExternalPlayerService.launch(
-          context: context,
-          metadata: metadata,
-          client: mediaClient,
-          mediaIndex: mediaIndex,
-          mediaSourceId: selectedMediaSourceId,
-        );
+
+        if (launched) return null;
       }
-
-      if (launched) return null;
+    } catch (e) {
+      appLogger.w('External player launch failed, falling back to built-in player', error: e);
     }
-  } catch (e) {
-    appLogger.w('External player launch failed, falling back to built-in player', error: e);
-  }
 
-  // Prevent stacking an identical video player when already active
-  if (!usePushReplacement &&
-      VideoPlayerScreenState.activeId == metadata.id &&
-      VideoPlayerScreenState.activeMediaIndex == mediaIndex) {
-    appLogger.d(
-      'Video player already active for ${metadata.id} (mediaIndex=$mediaIndex), skipping duplicate navigation',
+    // Prevent stacking an identical video player when already active
+    if (!usePushReplacement &&
+        VideoPlayerScreenState.activeId == metadata.id &&
+        VideoPlayerScreenState.activeMediaIndex == mediaIndex) {
+      appLogger.d(
+        'Video player already active for ${metadata.id} (mediaIndex=$mediaIndex), skipping duplicate navigation',
+      );
+      return null;
+    }
+
+    final route = PageRouteBuilder<bool>(
+      settings: const RouteSettings(name: kVideoPlayerRouteName),
+      pageBuilder: (context, animation, secondaryAnimation) => VideoPlayerScreen(
+        metadata: metadata,
+        preferredAudioTrack: preferredAudioTrack,
+        preferredSubtitleTrack: preferredSubtitleTrack,
+        preferredSecondarySubtitleTrack: preferredSecondarySubtitleTrack,
+        selectedMediaIndex: mediaIndex,
+        selectedMediaSourceId: selectedMediaSourceId,
+        selectedQualityPreset: selectedQualityPreset,
+        isOffline: isOffline,
+        onPlaybackExit: onPlaybackExit,
+      ),
+      transitionDuration: Duration.zero,
+      reverseTransitionDuration: Duration.zero,
     );
-    return null;
+
+    return usePushReplacement ? navigator.pushReplacement<bool, bool>(route) : navigator.push<bool>(route);
+  } finally {
+    if (!usePushReplacement) _pendingNavigationKey = null;
   }
-
-  final route = PageRouteBuilder<bool>(
-    settings: const RouteSettings(name: kVideoPlayerRouteName),
-    pageBuilder: (context, animation, secondaryAnimation) => VideoPlayerScreen(
-      metadata: metadata,
-      preferredAudioTrack: preferredAudioTrack,
-      preferredSubtitleTrack: preferredSubtitleTrack,
-      preferredSecondarySubtitleTrack: preferredSecondarySubtitleTrack,
-      selectedMediaIndex: mediaIndex,
-      selectedMediaSourceId: selectedMediaSourceId,
-      selectedQualityPreset: selectedQualityPreset,
-      isOffline: isOffline,
-    ),
-    transitionDuration: Duration.zero,
-    reverseTransitionDuration: Duration.zero,
-  );
-
-  return usePushReplacement ? navigator.pushReplacement<bool, bool>(route) : navigator.push<bool>(route);
 }
 
 /// Navigates to the video player and optionally refreshes content when returning.
@@ -153,6 +175,7 @@ Future<bool?> navigateToVideoPlayerWithRefresh(
   required MediaItem metadata,
   bool isOffline = false,
   VoidCallback? onRefresh,
+  void Function(int viewOffsetMs, String ratingKey)? onPlaybackExit,
   AudioTrack? preferredAudioTrack,
   SubtitleTrack? preferredSubtitleTrack,
   SubtitleTrack? preferredSecondarySubtitleTrack,
@@ -160,6 +183,10 @@ Future<bool?> navigateToVideoPlayerWithRefresh(
   String? selectedMediaSourceId,
   bool usePushReplacement = false,
 }) async {
+  appLogger.d(
+    '[NavWithRefresh] entering — title="${metadata.title}" id=${metadata.id} isOffline=$isOffline onRefresh=${onRefresh != null ? "set" : "NULL"}',
+  );
+
   final result = await navigateToVideoPlayer(
     context,
     metadata: metadata,
@@ -170,13 +197,18 @@ Future<bool?> navigateToVideoPlayerWithRefresh(
     selectedMediaIndex: selectedMediaIndex,
     selectedMediaSourceId: selectedMediaSourceId,
     usePushReplacement: usePushReplacement,
+    onPlaybackExit: onPlaybackExit,
   );
 
-  appLogger.d('Returned from playback, refreshing metadata');
+  appLogger.d(
+    '[NavWithRefresh] player returned result=$result, onRefresh=${onRefresh != null ? "set" : "NULL"} — calling now',
+  );
 
   if (!isOffline && onRefresh != null && context.mounted) {
     onRefresh();
   }
+
+  appLogger.d('[NavWithRefresh] onRefresh call completed');
 
   return result;
 }

--- a/lib/utils/watch_state_notifier.dart
+++ b/lib/utils/watch_state_notifier.dart
@@ -42,6 +42,9 @@ class WatchStateEvent with HierarchicalEventMixin {
   /// New progress value (for progressUpdate)
   final int? viewOffset;
 
+  /// Progress as a fraction (0.0–1.0). Populated by notifyProgress().
+  final double? progressPercent;
+
   /// Whether item is now considered watched (>90% progress or marked)
   final bool? isNowWatched;
 
@@ -58,6 +61,7 @@ class WatchStateEvent with HierarchicalEventMixin {
     required this.mediaType,
     this.cacheServerId,
     this.viewOffset,
+    this.progressPercent,
     this.isNowWatched,
     this.librarySectionID,
   }) : globalKey = buildGlobalKey(serverId, itemId);
@@ -128,6 +132,7 @@ class WatchStateNotifier extends BaseNotifier<WatchStateEvent> {
         parentChain: item.parentChain,
         mediaType: item.kind.id,
         viewOffset: viewOffset,
+        progressPercent: duration > 0 ? viewOffset / duration : null,
         isNowWatched: isNowWatched,
         librarySectionID: item.libraryId,
       ),

--- a/lib/widgets/media_card.dart
+++ b/lib/widgets/media_card.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
@@ -19,6 +20,7 @@ import '../screens/media_detail_screen.dart';
 import '../utils/content_utils.dart';
 import '../utils/provider_extensions.dart';
 import '../utils/formatters.dart';
+import '../services/trackers/watch_state_overlay.dart';
 import '../utils/media_navigation_helper.dart';
 import '../utils/snackbar_helper.dart';
 import '../theme/mono_tokens.dart';
@@ -927,7 +929,15 @@ class _MediaCardHelpers {
 /// Whether this media item has a clickable title that navigates somewhere.
 /// Episodes/seasons navigate to their parent show; movies navigate to their detail page.
 bool _hasClickableTitle(MediaItem mi) {
-  if (mi.isEpisode) return mi.grandparentId != null;
+  if (mi.isEpisode) {
+    if (mi.grandparentId != null) return true;
+    // Trakt stubs have no grandparentId yet — resolved async on tap.
+    if ((mi.id.startsWith('trakt_episode_pb_') || mi.id.startsWith('trakt_upnext_')) &&
+        mi.grandparentTitle != null) {
+      return true;
+    }
+    return false;
+  }
   if (mi.isSeason) return mi.parentId != null;
   if (mi.isMovie) return true;
   return false;
@@ -974,6 +984,19 @@ void _navigateToSeason(BuildContext context, MediaItem episode, {bool isOffline 
 /// For episodes/seasons: navigates to the parent show with season pre-selected.
 /// For movies and other types: navigates to the item's own detail page.
 void _navigateToDetail(BuildContext context, MediaItem mi, {bool isOffline = false}) {
+  // Tracker episode/upnext stubs with no resolved Plex key — resolve async via search.
+  final stubResolver = WatchStateOverlay.instance.stubResolver;
+  if (mi.isEpisode && mi.grandparentId == null && (stubResolver?.ownsStub(mi.id) ?? false)) {
+    unawaited(navigateToTrackerStubShow(context, mi, isOffline: isOffline));
+    return;
+  }
+
+  // Tracker movie stubs: resolve bridge map and navigate async.
+  if (mi.isMovie && (stubResolver?.ownsStub(mi.id) ?? false)) {
+    unawaited(navigateToTrackerMovieDetail(context, mi, isOffline: isOffline));
+    return;
+  }
+
   MediaItem target = mi;
   int? initialSeasonIndex;
 

--- a/lib/widgets/media_context_menu.dart
+++ b/lib/widgets/media_context_menu.dart
@@ -13,6 +13,9 @@ import '../media/media_server_client.dart';
 import '../media/media_version.dart';
 import '../mixins/controller_disposer_mixin.dart';
 import '../services/plex_client.dart';
+import '../services/trackers/tracker_sync_notifier.dart';
+import '../services/trackers/tracker_ui_helper.dart';
+import '../services/trackers/watch_state_overlay.dart';
 import '../services/media_list_playback_launcher.dart';
 import '../services/playlist_items_loader.dart';
 import '../services/trackers/tracker_coordinator.dart';
@@ -561,13 +564,27 @@ class MediaContextMenuState extends State<MediaContextMenu> {
             // Resolve the right backend client — Plex hits scrobble, Jellyfin
             // hits /UserPlayedItems. WatchStateNotifier event is fired in both
             // paths so cross-screen UI updates regardless of backend.
+            //
+            final target = await resolveTrackerItemForAction(context, mediaItem!);
+            if (!context.mounted || target == null) break;
+            final wasStub = target.id != mediaItem.id;
             await _executeAction(context, () async {
-              final item = mediaItem;
-              final client = context.tryGetMediaClientForServer(_itemServerId!);
-              if (client != null && item != null) {
-                await client.markWatched(item);
-                unawaited(TrackerCoordinator.instance.markWatched(item, client));
+              // Evict BEFORE markWatched: WatchStateNotifier fires synchronously
+              // inside markWatched, which would trigger a CW refresh with the
+              // stale cache. Evicting first ensures that refresh sees 0 items
+              // for this show/movie.
+              if (wasStub || WatchStateOverlay.instance.hasActiveAuthority) {
+                WatchStateOverlay.instance.evictFromPlayback(target);
+                TrackerSyncNotifier.instance.notifySync();
               }
+              final client = context.tryGetMediaClientForServer(target.serverId ?? _itemServerId!);
+              if (client != null) {
+                await client.markWatched(target);
+                unawaited(TrackerCoordinator.instance.markWatched(target, client));
+              }
+              // No triggerPostPlaybackSync here — an immediate force-sync races
+              // TraktSyncService's history push and restores the old cache.
+              // The next natural sync (foreground, manual refresh) confirms.
             }, t.messages.markedAsWatched);
           }
           break;
@@ -595,18 +612,41 @@ class MediaContextMenuState extends State<MediaContextMenu> {
           break;
 
         case 'remove_from_continue_watching':
-          // Remove from Continue Watching without affecting watch status or progress
-          // This preserves the progression for partially watched items
-          // and doesn't mark unwatched next episodes as watched
+          // For tracker stubs (synthetic Trakt IDs), Plex's removeFromContinueWatching
+          // has no effect. Instead, mark as watched so Trakt removes the item from
+          // /sync/playback, then force a re-sync so the UI updates.
+          // For native Plex items, use the normal removeFromContinueWatching path.
           try {
-            final client = _getMediaClientForItem();
-            await client.removeFromContinueWatching(mediaItem!);
+            final isOffline = context.read<OfflineModeProvider>().isOffline;
+            final item = mediaItem!;
+            // Tracker stubs require a network call to signal the tracker (e.g. Trakt's
+            // /sync/playback). When offline there is nothing to do — suppress with info.
+            if (isOffline && (WatchStateOverlay.instance.stubResolver?.ownsStub(item.id) ?? false)) {
+              if (context.mounted) {
+                showAppSnackBar(context, 'Connect to the internet to remove tracker items from Continue Watching');
+              }
+              break;
+            }
+            final target = isOffline ? item : await resolveTrackerItemForAction(context, item);
+            if (!context.mounted || target == null) break;
+            if (target.id != item.id) {
+              // Tracker stub: mark watched so Trakt drops it from /sync/playback.
+              // triggerPostPlaybackSync() is safe here (unlike mark_watched) because
+              // no TraktSyncService history push races this path — we are removing,
+              // not adding, so the re-sync will see the eviction correctly.
+              final client = context.tryGetMediaClientForServer(target.serverId ?? _itemServerId!);
+              if (client != null) await client.markWatched(target);
+              TrackerSyncNotifier.instance.triggerPostPlaybackSync();
+            } else {
+              final client = _getMediaClientForItem();
+              await client.removeFromContinueWatching(item);
+            }
             if (context.mounted) {
               showSuccessSnackBar(context, t.messages.removedFromContinueWatching);
               if (widget.onRemoveFromContinueWatching != null) {
                 widget.onRemoveFromContinueWatching!();
               } else {
-                _notifyRefresh(mediaItem.id);
+                _notifyRefresh(item.id);
               }
             }
           } catch (e) {
@@ -1352,14 +1392,17 @@ class MediaContextMenuState extends State<MediaContextMenu> {
   /// Handle download action
   Future<void> _handleDownload(BuildContext context) async {
     final downloadProvider = Provider.of<DownloadProvider>(context, listen: false);
-    final item = _mediaItem!;
+    // Resolve tracker stubs (e.g. trakt_upnext_*) to real Plex items before
+    // download so the download manager receives a valid Plex rating key.
+    final target = await resolveTrackerItemForAction(context, _mediaItem!);
+    if (!context.mounted || target == null) return;
     // Backend-agnostic resolve so Jellyfin items can be downloaded too.
     final client = context.getMediaClientWithFallback(_itemServerId);
 
     try {
       final result = await showDownloadOptionsAndQueue(
         context,
-        metadata: item,
+        metadata: target,
         client: client,
         downloadProvider: downloadProvider,
       );

--- a/lib/widgets/rating_bottom_sheet.dart
+++ b/lib/widgets/rating_bottom_sheet.dart
@@ -15,13 +15,10 @@ import '../media/media_item.dart';
 import '../media/media_server_client.dart';
 import '../providers/trackers_provider.dart';
 import '../providers/trakt_account_provider.dart';
-import '../services/trackers/anilist/anilist_tracker.dart';
-import '../services/trackers/mal/mal_tracker.dart';
-import '../services/trackers/simkl/simkl_tracker.dart';
 import '../services/trackers/tracker.dart';
 import '../services/trackers/tracker_constants.dart';
 import '../services/trackers/tracker_id_resolver.dart';
-import '../services/trakt/trakt_scrobble_service.dart';
+import '../services/trackers/tracker_rating_service.dart';
 import '../utils/app_logger.dart';
 import '../utils/snackbar_helper.dart';
 import 'app_icon.dart';
@@ -245,63 +242,58 @@ class _RatingBottomSheetState extends State<RatingBottomSheet> {
     );
   }
 
+  _TrackerRatingSource _buildSource({
+    required TrackerService service,
+    required String title,
+    required String? username,
+    required String logoAsset,
+  }) {
+    final rating = TrackerRatingService.instance;
+    return _TrackerRatingSource(
+      service: service,
+      title: title,
+      username: username,
+      connectedLabel: t.trakt.connected,
+      logoAsset: logoAsset,
+      getRating: (ctx) => rating.getRating(service, ctx),
+      onRate: (ctx, score) => rating.rate(service, ctx, score),
+      onClear: (ctx) => rating.clearRating(service, ctx),
+    );
+  }
+
   List<_TrackerRatingSource> _trackerSources(TraktAccountProvider trakt, TrackersProvider trackers) {
     final sources = <_TrackerRatingSource>[];
     if (trakt.isConnected) {
-      sources.add(
-        _TrackerRatingSource(
-          service: TrackerService.trakt,
-          title: t.trakt.title,
-          username: trakt.username,
-          connectedLabel: t.trakt.connected,
-          logoAsset: 'assets/trakt_circlemark.svg',
-          getRating: TraktScrobbleService.instance.getRating,
-          onRate: TraktScrobbleService.instance.rate,
-          onClear: TraktScrobbleService.instance.clearRating,
-        ),
-      );
+      sources.add(_buildSource(
+        service: TrackerService.trakt,
+        title: t.trakt.title,
+        username: trakt.username,
+        logoAsset: 'assets/trakt_circlemark.svg',
+      ));
     }
     if (trackers.isMalConnected) {
-      sources.add(
-        _TrackerRatingSource(
-          service: TrackerService.mal,
-          title: t.trackers.services.mal,
-          username: trackers.malUsername,
-          connectedLabel: t.trakt.connected,
-          logoAsset: 'assets/mal_mark.svg',
-          getRating: MalTracker.instance.getRating,
-          onRate: MalTracker.instance.rate,
-          onClear: MalTracker.instance.clearRating,
-        ),
-      );
+      sources.add(_buildSource(
+        service: TrackerService.mal,
+        title: t.trackers.services.mal,
+        username: trackers.malUsername,
+        logoAsset: 'assets/mal_mark.svg',
+      ));
     }
     if (trackers.isAnilistConnected) {
-      sources.add(
-        _TrackerRatingSource(
-          service: TrackerService.anilist,
-          title: t.trackers.services.anilist,
-          username: trackers.anilistUsername,
-          connectedLabel: t.trakt.connected,
-          logoAsset: 'assets/anilist_mark.svg',
-          getRating: AnilistTracker.instance.getRating,
-          onRate: AnilistTracker.instance.rate,
-          onClear: AnilistTracker.instance.clearRating,
-        ),
-      );
+      sources.add(_buildSource(
+        service: TrackerService.anilist,
+        title: t.trackers.services.anilist,
+        username: trackers.anilistUsername,
+        logoAsset: 'assets/anilist_mark.svg',
+      ));
     }
     if (trackers.isSimklConnected) {
-      sources.add(
-        _TrackerRatingSource(
-          service: TrackerService.simkl,
-          title: t.trackers.services.simkl,
-          username: trackers.simklUsername,
-          connectedLabel: t.trakt.connected,
-          logoAsset: 'assets/simkl_mark.svg',
-          getRating: SimklTracker.instance.getRating,
-          onRate: SimklTracker.instance.rate,
-          onClear: SimklTracker.instance.clearRating,
-        ),
-      );
+      sources.add(_buildSource(
+        service: TrackerService.simkl,
+        title: t.trackers.services.simkl,
+        username: trackers.simklUsername,
+        logoAsset: 'assets/simkl_mark.svg',
+      ));
     }
     return sources;
   }


### PR DESCRIPTION
## Tracker Watch State Authority

Adds support for using a connected tracker as the authoritative source for watch history — watched status, progress, Continue Watching, and the Playlists tab — replacing Plex's native data before it reaches the UI. Trakt is the first tracker to support this; the architecture is built to accommodate others.

---

### Motivation

Plex only knows what you watched through Plex. If you watch something on another app, device, or client, that progress does not exist in Plex. A tracker that aggregates across all clients does. This feature surfaces that data in Plezy without requiring the user to reconcile two watch histories manually.

---

### Features

- **Unified watch history** — watched badges and resume points reflect everything you've watched, not just what Plex saw
- **Cross-client Continue Watching** — pick up where you left off even if you started an episode on another device or app
- **Tracker watchlist as Playlists** — your curated tracker list takes over the Playlists tab, putting what you actually want to watch front and center
- **One-tap activation** — a single toggle in the tracker's settings turns the feature on or off
- **Non-destructive** — flipping the toggle off instantly restores Plex-native data; nothing is migrated or rewritten

---

### What is not affected

**Plex watch data is read-only from Plezy's perspective.** The overlay replaces data at render time; nothing writes to or modifies Plex's own watch state. The tracker's watchlist is likewise read-only — Plezy never mutates the list on the tracker side.

All other features — library browsing, metadata, playback, search — are unaffected. The overlay is applied as a final step before the UI renders and has no side effects beyond watched fields and the Playlists tab content.

Users who do not enable the toggle see no behavioral change.

---

### How it works

A small shared layer sits between Plex and the UI. When a tracker is connected and turned on, that layer quietly swaps Plex's watch data for the tracker's right before the screen renders — that's it.

The UI never talks to a specific tracker. It just asks the shared layer for the latest data. That means adding another tracker later (Simkl, AniList, MAL) is a small job, not a rewrite — fill in one contract and it works everywhere.

---

### Testing

AI assisted in building this feature, but every step was reviewed and tested in code by me. This has been running in daily use for several weeks across multiple devices and libraries. The following paths were verified:

- Cold boot with authority enabled and a large tracker history
- Profile switching mid-session
- Offline playback — tracker data is served from cache; stub actions (e.g. Remove from Continue Watching) are blocked with a clear message rather than silently failing
- Toggling authority on and off at runtime, with screens reverting to Plex-native data immediately
- Continue Watching items started outside Plezy resolving to the correct Plex episode
- Playlists tab swaps to the tracker's watchlist when authority is on and back to Plex playlists when off; items resolve only to entries the user actually has in their Plex library

---

### What's next

Trakt ships first. Simkl, AniList, and MAL can plug into the same layer when we're ready — the groundwork is already done.

---

Let me if you have feedback on any part of this scope, architecture, or specific pieces that don't fit the direction you have in mind for the project.