### PR TITLE
fix(browse): keep show in browse after deleting its downloads

### DIFF
--- a/lib/screens/libraries/tabs/library_browse_tab.dart
+++ b/lib/screens/libraries/tabs/library_browse_tab.dart
@@ -153,6 +153,13 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
 
   @override
   void onDeletionEvent(DeletionEvent event) {
+    // Browse is online-only (the Libraries tab is hidden when offline), so it
+    // always reflects server-side content. A download-only deletion removes
+    // local files but leaves the item on the server, so it must not affect the
+    // browse grid. Without this guard, deleting every downloaded episode of a
+    // show drives its leafCount to zero and evicts the show from browse.
+    if (event.isDownloadOnly) return;
+
     // If we have an item that matches the rating key exactly, remove it and rebuild indices
     final matchEntry = loadedItems.entries.where((e) => e.value.id == event.itemId).firstOrNull;
     if (matchEntry != null) {


### PR DESCRIPTION
BUG: if you have downloaded episode of a show and you use the delete downloads button the show disappears from the browseable shows (Until you restart) You can still search for the show you just can't browse there. this fixes the issue

The browse grid listens for DeletionEvents and decrements each show's leafCount, evicting the show when the count hits zero. Download-only deletions (isDownloadOnly: true) fired one event per episode, so deleting every downloaded episode of a show drove its leafCount to zero and removed it from browse - even though the content still exists on the server.

Browse is online-only (the Libraries tab is hidden when offline) and always reflects server-side content, so it must ignore download-only deletions. Add a guard at the top of onDeletionEvent, matching the existing isDownloadOnly contract already honored by media_detail_screen.