### PR TITLE
feat(linux): Update layout to support Linux Mobile

### DIFF
--- a/lib/utils/platform_detector.dart
+++ b/lib/utils/platform_detector.dart
@@ -235,14 +235,15 @@ class PlatformDetector {
     return isDesktop(context) || isTV();
   }
 
-  /// Detects if running on a mobile platform (iOS or Android).
+  /// Detects if running on a mobile platform (iOS, Android or Linux Mobile).
   /// Excludes TV platforms (Android TV / Apple TV) even though the underlying
   /// OS is iOS or Android.
   /// Uses Theme for consistent platform detection across the app.
   static bool isMobile(BuildContext context) {
     if (isTV()) return false;
     final platform = Theme.of(context).platform;
-    return platform == TargetPlatform.iOS || platform == TargetPlatform.android;
+    return platform == TargetPlatform.iOS || platform == TargetPlatform.android ||
+      (platform == TargetPlatform.linux && getDiagonalInches(context) <= 7.0);
   }
 
   static bool isHandheld(BuildContext context) {
@@ -317,17 +318,21 @@ class PlatformDetector {
     isAutomotive: isAutomotive(),
   );
 
-  /// Detects if the device is likely a tablet based on screen size
-  /// Uses diagonal screen size to determine if device is a tablet
-  static bool isTablet(BuildContext context) {
+  /// Gets diagonal screen size.
+  /// Used to determine if a device is a tablet. Also, used to detect if a device is on LinuxMobile
+  static num getDiagonalInches(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
     final diagonal = sqrt(size.width * size.width + size.height * size.height);
     final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
 
     // Convert diagonal from logical pixels to inches (assuming 160 DPI as baseline)
-    final diagonalInches = diagonal / (devicePixelRatio * 160 / 2.54);
+    return diagonal / (devicePixelRatio * 160 / 2.54);
+  }
 
-    return diagonalInches >= 7.0;
+  /// Detects if the device is likely a tablet based on screen size
+  /// Uses diagonal screen size to determine if device is a tablet
+  static bool isTablet(BuildContext context) {
+    return getDiagonalInches(context) >= 7.0;
   }
 
   static bool isPhone(BuildContext context) {


### PR DESCRIPTION
I'm running Plezy on a Linux Mobile device and this change makes the experience much more pleasant without the side bar :smile: 

Before:
<img width="3072" height="4080" alt="Plezy with a side bar feeling a bit clunky at mobile width" src="https://github.com/user-attachments/assets/2522925a-e686-4003-a81c-2100ed426dc4" />


After:
<img width="3072" height="4080" alt="screenshot of Plezy on a linux mobile device displaying nicely" src="https://github.com/user-attachments/assets/27338c64-e61d-407c-94a1-c37e20dc7d0d" />

