### PR TITLE
fix: coalesce held timeline seeks on direct play

### DIFF
--- a/lib/widgets/video_controls/desktop_video_controls.dart
+++ b/lib/widgets/video_controls/desktop_video_controls.dart
@@ -533,15 +533,13 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
   KeyEventResult _handleTimelineKeyEvent(FocusNode _, KeyEvent event) {
     final key = event.logicalKey;
 
-    // Handle key release to reset progressive seek state
+    // Handle key release: commit the accumulated scrub target with a single
+    // seek (a no-op when nothing is pending) and reset progressive seek state.
     if (event is KeyUpEvent) {
       if (key == LogicalKeyboardKey.arrowLeft || key == LogicalKeyboardKey.arrowRight) {
-        if (_trackControlsState.isTranscoding) {
-          _flushTimelinePreviewSeek();
-          _resetSeekState();
-          return KeyEventResult.handled;
-        }
+        _flushTimelinePreviewSeek();
         _resetSeekState();
+        return KeyEventResult.handled;
       }
       return KeyEventResult.ignored;
     }
@@ -605,22 +603,22 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
       final stepMs = (baseStepMs * effectiveMultiplier).clamp(500, 120_000).toInt();
       final step = Duration(milliseconds: stepMs);
 
-      final newPosition = isForward ? position + step : position - step;
+      // Accumulate the scrub target from a stable base — the in-flight preview
+      // when a burst is already running, otherwise the live position — so the
+      // marker never snaps back when a real seek lands mid-burst.
+      final previewBase = _timelinePreviewPosition ?? position;
+      final rawTarget = isForward ? previewBase + step : previewBase - step;
+      final target = Duration(milliseconds: rawTarget.inMilliseconds.clamp(0, duration.inMilliseconds));
+      _setTimelinePreviewPosition(target);
 
-      // Clamp to valid range
-      final clampedPosition = Duration(milliseconds: newPosition.inMilliseconds.clamp(0, duration.inMilliseconds));
-
-      if (_trackControlsState.isTranscoding) {
-        final previewBase = _timelinePreviewPosition ?? position;
-        final previewPosition = isForward ? previewBase + step : previewBase - step;
-        final clampedPreview = Duration(milliseconds: previewPosition.inMilliseconds.clamp(0, duration.inMilliseconds));
-        _setTimelinePreviewPosition(clampedPreview);
-        _scheduleTimelinePreviewSeekFlush();
-        widget.onFocusActivity?.call();
-        return KeyEventResult.handled;
-      }
-
-      widget.onSeek(clampedPosition);
+      // Move only the preview while the key is held; commit a single seek once
+      // the burst pauses (debounce) or the key is released. Firing a real seek
+      // per key-repeat floods a direct/progressive stream with overlapping range
+      // requests and wedges low-power devices (e.g. Fire TV Stick) in BUFFERING.
+      // The player's `buffering` flag lags the key-repeat rate, so it can't gate
+      // this reliably — coalescing unconditionally matches the existing transcode
+      // path and cannot flood regardless of hardware.
+      _scheduleTimelinePreviewSeekFlush();
       widget.onFocusActivity?.call();
       return KeyEventResult.handled;
     }


### PR DESCRIPTION
On current hardware you won't notice this, but on weaker devices (I hit it on a
Fire TV Stick 4K) the rendering can't keep up and the buffering gets tangled —
a spinning wheel that never clears, recovered only by leaving and re-entering
playback.

Holding fast-forward fires a real seek on every key-repeat; on a direct stream
each one re-issues an HTTP range request until ExoPlayer wedges in
STATE_BUFFERING. The timeline already coalesces held seeks for transcodes — this
routes direct play through that same preview/debounce path, committing a single
seek on release. No new settings, no native changes.

Disclosure: written with help from an AI coding assistant.