### PR TITLE
feat: add client-side Watchlist with bookmarking, grouped grid UI, and navigation integration

### DIFF
--- a/lib/database/app_database.dart
+++ b/lib/database/app_database.dart
@@ -47,6 +47,7 @@ enum OfflineActionType {
     ApiCache,
     OfflineWatchProgress,
     SyncRules,
+    WatchlistItems,
     Connections,
     Profiles,
     ProfileConnections,
@@ -61,7 +62,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 16;
+  int get schemaVersion => 17;
 
   @override
   MigrationStrategy get migration {
@@ -220,6 +221,12 @@ class AppDatabase extends _$AppDatabase {
             'SyncRules.includeSpecials column',
             () => m.addColumn(syncRules, syncRules.includeSpecials),
           );
+        }
+        if (from < 17) {
+          appLogger.i('Adding WatchlistItems table (v17 migration)');
+          await _ignoreAlreadyExists('WatchlistItems', () => m.createTable(watchlistItems));
+          await _ignoreAlreadyExists('idx_watchlist_profile', () => m.create(idxWatchlistProfile));
+          await _ignoreAlreadyExists('idx_watchlist_kind', () => m.create(idxWatchlistKind));
         }
       },
     );

--- a/lib/database/app_database.g.dart
+++ b/lib/database/app_database.g.dart
@@ -3768,6 +3768,776 @@ class SyncRulesCompanion extends UpdateCompanion<SyncRuleItem> {
   }
 }
 
+class $WatchlistItemsTable extends WatchlistItems
+    with TableInfo<$WatchlistItemsTable, WatchlistItem> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $WatchlistItemsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _profileIdMeta = const VerificationMeta(
+    'profileId',
+  );
+  @override
+  late final GeneratedColumn<String> profileId = GeneratedColumn<String>(
+    'profile_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _globalKeyMeta = const VerificationMeta(
+    'globalKey',
+  );
+  @override
+  late final GeneratedColumn<String> globalKey = GeneratedColumn<String>(
+    'global_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _serverIdMeta = const VerificationMeta(
+    'serverId',
+  );
+  @override
+  late final GeneratedColumn<String> serverId = GeneratedColumn<String>(
+    'server_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _clientScopeIdMeta = const VerificationMeta(
+    'clientScopeId',
+  );
+  @override
+  late final GeneratedColumn<String> clientScopeId = GeneratedColumn<String>(
+    'client_scope_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _ratingKeyMeta = const VerificationMeta(
+    'ratingKey',
+  );
+  @override
+  late final GeneratedColumn<String> ratingKey = GeneratedColumn<String>(
+    'rating_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _kindMeta = const VerificationMeta('kind');
+  @override
+  late final GeneratedColumn<String> kind = GeneratedColumn<String>(
+    'kind',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+    'title',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _thumbPathMeta = const VerificationMeta(
+    'thumbPath',
+  );
+  @override
+  late final GeneratedColumn<String> thumbPath = GeneratedColumn<String>(
+    'thumb_path',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _backdropPathMeta = const VerificationMeta(
+    'backdropPath',
+  );
+  @override
+  late final GeneratedColumn<String> backdropPath = GeneratedColumn<String>(
+    'backdrop_path',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _yearMeta = const VerificationMeta('year');
+  @override
+  late final GeneratedColumn<int> year = GeneratedColumn<int>(
+    'year',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _indexMeta = const VerificationMeta('index');
+  @override
+  late final GeneratedColumn<int> index = GeneratedColumn<int>(
+    'index',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _parentTitleMeta = const VerificationMeta(
+    'parentTitle',
+  );
+  @override
+  late final GeneratedColumn<String> parentTitle = GeneratedColumn<String>(
+    'parent_title',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _addedAtMeta = const VerificationMeta(
+    'addedAt',
+  );
+  @override
+  late final GeneratedColumn<int> addedAt = GeneratedColumn<int>(
+    'added_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    profileId,
+    globalKey,
+    serverId,
+    clientScopeId,
+    ratingKey,
+    kind,
+    title,
+    thumbPath,
+    backdropPath,
+    year,
+    index,
+    parentTitle,
+    addedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'watchlist_items';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<WatchlistItem> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('profile_id')) {
+      context.handle(
+        _profileIdMeta,
+        profileId.isAcceptableOrUnknown(data['profile_id']!, _profileIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_profileIdMeta);
+    }
+    if (data.containsKey('global_key')) {
+      context.handle(
+        _globalKeyMeta,
+        globalKey.isAcceptableOrUnknown(data['global_key']!, _globalKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_globalKeyMeta);
+    }
+    if (data.containsKey('server_id')) {
+      context.handle(
+        _serverIdMeta,
+        serverId.isAcceptableOrUnknown(data['server_id']!, _serverIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_serverIdMeta);
+    }
+    if (data.containsKey('client_scope_id')) {
+      context.handle(
+        _clientScopeIdMeta,
+        clientScopeId.isAcceptableOrUnknown(
+          data['client_scope_id']!,
+          _clientScopeIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('rating_key')) {
+      context.handle(
+        _ratingKeyMeta,
+        ratingKey.isAcceptableOrUnknown(data['rating_key']!, _ratingKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_ratingKeyMeta);
+    }
+    if (data.containsKey('kind')) {
+      context.handle(
+        _kindMeta,
+        kind.isAcceptableOrUnknown(data['kind']!, _kindMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_kindMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+        _titleMeta,
+        title.isAcceptableOrUnknown(data['title']!, _titleMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('thumb_path')) {
+      context.handle(
+        _thumbPathMeta,
+        thumbPath.isAcceptableOrUnknown(data['thumb_path']!, _thumbPathMeta),
+      );
+    }
+    if (data.containsKey('backdrop_path')) {
+      context.handle(
+        _backdropPathMeta,
+        backdropPath.isAcceptableOrUnknown(
+          data['backdrop_path']!,
+          _backdropPathMeta,
+        ),
+      );
+    }
+    if (data.containsKey('year')) {
+      context.handle(
+        _yearMeta,
+        year.isAcceptableOrUnknown(data['year']!, _yearMeta),
+      );
+    }
+    if (data.containsKey('index')) {
+      context.handle(
+        _indexMeta,
+        index.isAcceptableOrUnknown(data['index']!, _indexMeta),
+      );
+    }
+    if (data.containsKey('parent_title')) {
+      context.handle(
+        _parentTitleMeta,
+        parentTitle.isAcceptableOrUnknown(
+          data['parent_title']!,
+          _parentTitleMeta,
+        ),
+      );
+    }
+    if (data.containsKey('added_at')) {
+      context.handle(
+        _addedAtMeta,
+        addedAt.isAcceptableOrUnknown(data['added_at']!, _addedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_addedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {profileId, globalKey};
+  @override
+  WatchlistItem map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return WatchlistItem(
+      profileId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}profile_id'],
+      )!,
+      globalKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}global_key'],
+      )!,
+      serverId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}server_id'],
+      )!,
+      clientScopeId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}client_scope_id'],
+      ),
+      ratingKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}rating_key'],
+      )!,
+      kind: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}kind'],
+      )!,
+      title: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}title'],
+      )!,
+      thumbPath: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}thumb_path'],
+      ),
+      backdropPath: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}backdrop_path'],
+      ),
+      year: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}year'],
+      ),
+      index: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}index'],
+      ),
+      parentTitle: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}parent_title'],
+      ),
+      addedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}added_at'],
+      )!,
+    );
+  }
+
+  @override
+  $WatchlistItemsTable createAlias(String alias) {
+    return $WatchlistItemsTable(attachedDatabase, alias);
+  }
+}
+
+class WatchlistItem extends DataClass implements Insertable<WatchlistItem> {
+  final String profileId;
+  final String globalKey;
+  final String serverId;
+  final String? clientScopeId;
+  final String ratingKey;
+  final String kind;
+  final String title;
+  final String? thumbPath;
+  final String? backdropPath;
+  final int? year;
+  final int? index;
+  final String? parentTitle;
+  final int addedAt;
+  const WatchlistItem({
+    required this.profileId,
+    required this.globalKey,
+    required this.serverId,
+    this.clientScopeId,
+    required this.ratingKey,
+    required this.kind,
+    required this.title,
+    this.thumbPath,
+    this.backdropPath,
+    this.year,
+    this.index,
+    this.parentTitle,
+    required this.addedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['profile_id'] = Variable<String>(profileId);
+    map['global_key'] = Variable<String>(globalKey);
+    map['server_id'] = Variable<String>(serverId);
+    if (!nullToAbsent || clientScopeId != null) {
+      map['client_scope_id'] = Variable<String>(clientScopeId);
+    }
+    map['rating_key'] = Variable<String>(ratingKey);
+    map['kind'] = Variable<String>(kind);
+    map['title'] = Variable<String>(title);
+    if (!nullToAbsent || thumbPath != null) {
+      map['thumb_path'] = Variable<String>(thumbPath);
+    }
+    if (!nullToAbsent || backdropPath != null) {
+      map['backdrop_path'] = Variable<String>(backdropPath);
+    }
+    if (!nullToAbsent || year != null) {
+      map['year'] = Variable<int>(year);
+    }
+    if (!nullToAbsent || index != null) {
+      map['index'] = Variable<int>(index);
+    }
+    if (!nullToAbsent || parentTitle != null) {
+      map['parent_title'] = Variable<String>(parentTitle);
+    }
+    map['added_at'] = Variable<int>(addedAt);
+    return map;
+  }
+
+  WatchlistItemsCompanion toCompanion(bool nullToAbsent) {
+    return WatchlistItemsCompanion(
+      profileId: Value(profileId),
+      globalKey: Value(globalKey),
+      serverId: Value(serverId),
+      clientScopeId: clientScopeId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(clientScopeId),
+      ratingKey: Value(ratingKey),
+      kind: Value(kind),
+      title: Value(title),
+      thumbPath: thumbPath == null && nullToAbsent
+          ? const Value.absent()
+          : Value(thumbPath),
+      backdropPath: backdropPath == null && nullToAbsent
+          ? const Value.absent()
+          : Value(backdropPath),
+      year: year == null && nullToAbsent ? const Value.absent() : Value(year),
+      index: index == null && nullToAbsent
+          ? const Value.absent()
+          : Value(index),
+      parentTitle: parentTitle == null && nullToAbsent
+          ? const Value.absent()
+          : Value(parentTitle),
+      addedAt: Value(addedAt),
+    );
+  }
+
+  factory WatchlistItem.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return WatchlistItem(
+      profileId: serializer.fromJson<String>(json['profileId']),
+      globalKey: serializer.fromJson<String>(json['globalKey']),
+      serverId: serializer.fromJson<String>(json['serverId']),
+      clientScopeId: serializer.fromJson<String?>(json['clientScopeId']),
+      ratingKey: serializer.fromJson<String>(json['ratingKey']),
+      kind: serializer.fromJson<String>(json['kind']),
+      title: serializer.fromJson<String>(json['title']),
+      thumbPath: serializer.fromJson<String?>(json['thumbPath']),
+      backdropPath: serializer.fromJson<String?>(json['backdropPath']),
+      year: serializer.fromJson<int?>(json['year']),
+      index: serializer.fromJson<int?>(json['index']),
+      parentTitle: serializer.fromJson<String?>(json['parentTitle']),
+      addedAt: serializer.fromJson<int>(json['addedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'profileId': serializer.toJson<String>(profileId),
+      'globalKey': serializer.toJson<String>(globalKey),
+      'serverId': serializer.toJson<String>(serverId),
+      'clientScopeId': serializer.toJson<String?>(clientScopeId),
+      'ratingKey': serializer.toJson<String>(ratingKey),
+      'kind': serializer.toJson<String>(kind),
+      'title': serializer.toJson<String>(title),
+      'thumbPath': serializer.toJson<String?>(thumbPath),
+      'backdropPath': serializer.toJson<String?>(backdropPath),
+      'year': serializer.toJson<int?>(year),
+      'index': serializer.toJson<int?>(index),
+      'parentTitle': serializer.toJson<String?>(parentTitle),
+      'addedAt': serializer.toJson<int>(addedAt),
+    };
+  }
+
+  WatchlistItem copyWith({
+    String? profileId,
+    String? globalKey,
+    String? serverId,
+    Value<String?> clientScopeId = const Value.absent(),
+    String? ratingKey,
+    String? kind,
+    String? title,
+    Value<String?> thumbPath = const Value.absent(),
+    Value<String?> backdropPath = const Value.absent(),
+    Value<int?> year = const Value.absent(),
+    Value<int?> index = const Value.absent(),
+    Value<String?> parentTitle = const Value.absent(),
+    int? addedAt,
+  }) => WatchlistItem(
+    profileId: profileId ?? this.profileId,
+    globalKey: globalKey ?? this.globalKey,
+    serverId: serverId ?? this.serverId,
+    clientScopeId: clientScopeId.present
+        ? clientScopeId.value
+        : this.clientScopeId,
+    ratingKey: ratingKey ?? this.ratingKey,
+    kind: kind ?? this.kind,
+    title: title ?? this.title,
+    thumbPath: thumbPath.present ? thumbPath.value : this.thumbPath,
+    backdropPath: backdropPath.present ? backdropPath.value : this.backdropPath,
+    year: year.present ? year.value : this.year,
+    index: index.present ? index.value : this.index,
+    parentTitle: parentTitle.present ? parentTitle.value : this.parentTitle,
+    addedAt: addedAt ?? this.addedAt,
+  );
+  WatchlistItem copyWithCompanion(WatchlistItemsCompanion data) {
+    return WatchlistItem(
+      profileId: data.profileId.present ? data.profileId.value : this.profileId,
+      globalKey: data.globalKey.present ? data.globalKey.value : this.globalKey,
+      serverId: data.serverId.present ? data.serverId.value : this.serverId,
+      clientScopeId: data.clientScopeId.present
+          ? data.clientScopeId.value
+          : this.clientScopeId,
+      ratingKey: data.ratingKey.present ? data.ratingKey.value : this.ratingKey,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      title: data.title.present ? data.title.value : this.title,
+      thumbPath: data.thumbPath.present ? data.thumbPath.value : this.thumbPath,
+      backdropPath: data.backdropPath.present
+          ? data.backdropPath.value
+          : this.backdropPath,
+      year: data.year.present ? data.year.value : this.year,
+      index: data.index.present ? data.index.value : this.index,
+      parentTitle: data.parentTitle.present
+          ? data.parentTitle.value
+          : this.parentTitle,
+      addedAt: data.addedAt.present ? data.addedAt.value : this.addedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WatchlistItem(')
+          ..write('profileId: $profileId, ')
+          ..write('globalKey: $globalKey, ')
+          ..write('serverId: $serverId, ')
+          ..write('clientScopeId: $clientScopeId, ')
+          ..write('ratingKey: $ratingKey, ')
+          ..write('kind: $kind, ')
+          ..write('title: $title, ')
+          ..write('thumbPath: $thumbPath, ')
+          ..write('backdropPath: $backdropPath, ')
+          ..write('year: $year, ')
+          ..write('index: $index, ')
+          ..write('parentTitle: $parentTitle, ')
+          ..write('addedAt: $addedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    profileId,
+    globalKey,
+    serverId,
+    clientScopeId,
+    ratingKey,
+    kind,
+    title,
+    thumbPath,
+    backdropPath,
+    year,
+    index,
+    parentTitle,
+    addedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is WatchlistItem &&
+          other.profileId == this.profileId &&
+          other.globalKey == this.globalKey &&
+          other.serverId == this.serverId &&
+          other.clientScopeId == this.clientScopeId &&
+          other.ratingKey == this.ratingKey &&
+          other.kind == this.kind &&
+          other.title == this.title &&
+          other.thumbPath == this.thumbPath &&
+          other.backdropPath == this.backdropPath &&
+          other.year == this.year &&
+          other.index == this.index &&
+          other.parentTitle == this.parentTitle &&
+          other.addedAt == this.addedAt);
+}
+
+class WatchlistItemsCompanion extends UpdateCompanion<WatchlistItem> {
+  final Value<String> profileId;
+  final Value<String> globalKey;
+  final Value<String> serverId;
+  final Value<String?> clientScopeId;
+  final Value<String> ratingKey;
+  final Value<String> kind;
+  final Value<String> title;
+  final Value<String?> thumbPath;
+  final Value<String?> backdropPath;
+  final Value<int?> year;
+  final Value<int?> index;
+  final Value<String?> parentTitle;
+  final Value<int> addedAt;
+  final Value<int> rowid;
+  const WatchlistItemsCompanion({
+    this.profileId = const Value.absent(),
+    this.globalKey = const Value.absent(),
+    this.serverId = const Value.absent(),
+    this.clientScopeId = const Value.absent(),
+    this.ratingKey = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.title = const Value.absent(),
+    this.thumbPath = const Value.absent(),
+    this.backdropPath = const Value.absent(),
+    this.year = const Value.absent(),
+    this.index = const Value.absent(),
+    this.parentTitle = const Value.absent(),
+    this.addedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  WatchlistItemsCompanion.insert({
+    required String profileId,
+    required String globalKey,
+    required String serverId,
+    this.clientScopeId = const Value.absent(),
+    required String ratingKey,
+    required String kind,
+    required String title,
+    this.thumbPath = const Value.absent(),
+    this.backdropPath = const Value.absent(),
+    this.year = const Value.absent(),
+    this.index = const Value.absent(),
+    this.parentTitle = const Value.absent(),
+    required int addedAt,
+    this.rowid = const Value.absent(),
+  }) : profileId = Value(profileId),
+       globalKey = Value(globalKey),
+       serverId = Value(serverId),
+       ratingKey = Value(ratingKey),
+       kind = Value(kind),
+       title = Value(title),
+       addedAt = Value(addedAt);
+  static Insertable<WatchlistItem> custom({
+    Expression<String>? profileId,
+    Expression<String>? globalKey,
+    Expression<String>? serverId,
+    Expression<String>? clientScopeId,
+    Expression<String>? ratingKey,
+    Expression<String>? kind,
+    Expression<String>? title,
+    Expression<String>? thumbPath,
+    Expression<String>? backdropPath,
+    Expression<int>? year,
+    Expression<int>? index,
+    Expression<String>? parentTitle,
+    Expression<int>? addedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (profileId != null) 'profile_id': profileId,
+      if (globalKey != null) 'global_key': globalKey,
+      if (serverId != null) 'server_id': serverId,
+      if (clientScopeId != null) 'client_scope_id': clientScopeId,
+      if (ratingKey != null) 'rating_key': ratingKey,
+      if (kind != null) 'kind': kind,
+      if (title != null) 'title': title,
+      if (thumbPath != null) 'thumb_path': thumbPath,
+      if (backdropPath != null) 'backdrop_path': backdropPath,
+      if (year != null) 'year': year,
+      if (index != null) 'index': index,
+      if (parentTitle != null) 'parent_title': parentTitle,
+      if (addedAt != null) 'added_at': addedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  WatchlistItemsCompanion copyWith({
+    Value<String>? profileId,
+    Value<String>? globalKey,
+    Value<String>? serverId,
+    Value<String?>? clientScopeId,
+    Value<String>? ratingKey,
+    Value<String>? kind,
+    Value<String>? title,
+    Value<String?>? thumbPath,
+    Value<String?>? backdropPath,
+    Value<int?>? year,
+    Value<int?>? index,
+    Value<String?>? parentTitle,
+    Value<int>? addedAt,
+    Value<int>? rowid,
+  }) {
+    return WatchlistItemsCompanion(
+      profileId: profileId ?? this.profileId,
+      globalKey: globalKey ?? this.globalKey,
+      serverId: serverId ?? this.serverId,
+      clientScopeId: clientScopeId ?? this.clientScopeId,
+      ratingKey: ratingKey ?? this.ratingKey,
+      kind: kind ?? this.kind,
+      title: title ?? this.title,
+      thumbPath: thumbPath ?? this.thumbPath,
+      backdropPath: backdropPath ?? this.backdropPath,
+      year: year ?? this.year,
+      index: index ?? this.index,
+      parentTitle: parentTitle ?? this.parentTitle,
+      addedAt: addedAt ?? this.addedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (profileId.present) {
+      map['profile_id'] = Variable<String>(profileId.value);
+    }
+    if (globalKey.present) {
+      map['global_key'] = Variable<String>(globalKey.value);
+    }
+    if (serverId.present) {
+      map['server_id'] = Variable<String>(serverId.value);
+    }
+    if (clientScopeId.present) {
+      map['client_scope_id'] = Variable<String>(clientScopeId.value);
+    }
+    if (ratingKey.present) {
+      map['rating_key'] = Variable<String>(ratingKey.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(kind.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (thumbPath.present) {
+      map['thumb_path'] = Variable<String>(thumbPath.value);
+    }
+    if (backdropPath.present) {
+      map['backdrop_path'] = Variable<String>(backdropPath.value);
+    }
+    if (year.present) {
+      map['year'] = Variable<int>(year.value);
+    }
+    if (index.present) {
+      map['index'] = Variable<int>(index.value);
+    }
+    if (parentTitle.present) {
+      map['parent_title'] = Variable<String>(parentTitle.value);
+    }
+    if (addedAt.present) {
+      map['added_at'] = Variable<int>(addedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('WatchlistItemsCompanion(')
+          ..write('profileId: $profileId, ')
+          ..write('globalKey: $globalKey, ')
+          ..write('serverId: $serverId, ')
+          ..write('clientScopeId: $clientScopeId, ')
+          ..write('ratingKey: $ratingKey, ')
+          ..write('kind: $kind, ')
+          ..write('title: $title, ')
+          ..write('thumbPath: $thumbPath, ')
+          ..write('backdropPath: $backdropPath, ')
+          ..write('year: $year, ')
+          ..write('index: $index, ')
+          ..write('parentTitle: $parentTitle, ')
+          ..write('addedAt: $addedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $ConnectionsTable extends Connections
     with TableInfo<$ConnectionsTable, ConnectionRow> {
   @override
@@ -5312,6 +6082,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $OfflineWatchProgressTable offlineWatchProgress =
       $OfflineWatchProgressTable(this);
   late final $SyncRulesTable syncRules = $SyncRulesTable(this);
+  late final $WatchlistItemsTable watchlistItems = $WatchlistItemsTable(this);
   late final $ConnectionsTable connections = $ConnectionsTable(this);
   late final $ProfilesTable profiles = $ProfilesTable(this);
   late final $ProfileConnectionsTable profileConnections =
@@ -5352,6 +6123,14 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'idx_sync_rules_profile',
     'CREATE INDEX idx_sync_rules_profile ON sync_rules (profile_id)',
   );
+  late final Index idxWatchlistProfile = Index(
+    'idx_watchlist_profile',
+    'CREATE INDEX idx_watchlist_profile ON watchlist_items (profile_id)',
+  );
+  late final Index idxWatchlistKind = Index(
+    'idx_watchlist_kind',
+    'CREATE INDEX idx_watchlist_kind ON watchlist_items (kind)',
+  );
   late final Index idxConnectionsKind = Index(
     'idx_connections_kind',
     'CREATE INDEX idx_connections_kind ON connections (kind)',
@@ -5379,6 +6158,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     apiCache,
     offlineWatchProgress,
     syncRules,
+    watchlistItems,
     connections,
     profiles,
     profileConnections,
@@ -5391,6 +6171,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     idxOfflineWatchProgressServer,
     idxOfflineWatchProgressProfile,
     idxSyncRulesProfile,
+    idxWatchlistProfile,
+    idxWatchlistKind,
     idxConnectionsKind,
     idxProfilesKind,
     idxProfileConnectionsConnectionId,
@@ -7240,6 +8022,366 @@ typedef $$SyncRulesTableProcessedTableManager =
       SyncRuleItem,
       PrefetchHooks Function()
     >;
+typedef $$WatchlistItemsTableCreateCompanionBuilder =
+    WatchlistItemsCompanion Function({
+      required String profileId,
+      required String globalKey,
+      required String serverId,
+      Value<String?> clientScopeId,
+      required String ratingKey,
+      required String kind,
+      required String title,
+      Value<String?> thumbPath,
+      Value<String?> backdropPath,
+      Value<int?> year,
+      Value<int?> index,
+      Value<String?> parentTitle,
+      required int addedAt,
+      Value<int> rowid,
+    });
+typedef $$WatchlistItemsTableUpdateCompanionBuilder =
+    WatchlistItemsCompanion Function({
+      Value<String> profileId,
+      Value<String> globalKey,
+      Value<String> serverId,
+      Value<String?> clientScopeId,
+      Value<String> ratingKey,
+      Value<String> kind,
+      Value<String> title,
+      Value<String?> thumbPath,
+      Value<String?> backdropPath,
+      Value<int?> year,
+      Value<int?> index,
+      Value<String?> parentTitle,
+      Value<int> addedAt,
+      Value<int> rowid,
+    });
+
+class $$WatchlistItemsTableFilterComposer
+    extends Composer<_$AppDatabase, $WatchlistItemsTable> {
+  $$WatchlistItemsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get profileId => $composableBuilder(
+    column: $table.profileId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get globalKey => $composableBuilder(
+    column: $table.globalKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get serverId => $composableBuilder(
+    column: $table.serverId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get clientScopeId => $composableBuilder(
+    column: $table.clientScopeId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get ratingKey => $composableBuilder(
+    column: $table.ratingKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get thumbPath => $composableBuilder(
+    column: $table.thumbPath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get backdropPath => $composableBuilder(
+    column: $table.backdropPath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get year => $composableBuilder(
+    column: $table.year,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get index => $composableBuilder(
+    column: $table.index,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get parentTitle => $composableBuilder(
+    column: $table.parentTitle,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get addedAt => $composableBuilder(
+    column: $table.addedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$WatchlistItemsTableOrderingComposer
+    extends Composer<_$AppDatabase, $WatchlistItemsTable> {
+  $$WatchlistItemsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get profileId => $composableBuilder(
+    column: $table.profileId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get globalKey => $composableBuilder(
+    column: $table.globalKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get serverId => $composableBuilder(
+    column: $table.serverId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get clientScopeId => $composableBuilder(
+    column: $table.clientScopeId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get ratingKey => $composableBuilder(
+    column: $table.ratingKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get kind => $composableBuilder(
+    column: $table.kind,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get title => $composableBuilder(
+    column: $table.title,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get thumbPath => $composableBuilder(
+    column: $table.thumbPath,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get backdropPath => $composableBuilder(
+    column: $table.backdropPath,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get year => $composableBuilder(
+    column: $table.year,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get index => $composableBuilder(
+    column: $table.index,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get parentTitle => $composableBuilder(
+    column: $table.parentTitle,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get addedAt => $composableBuilder(
+    column: $table.addedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$WatchlistItemsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $WatchlistItemsTable> {
+  $$WatchlistItemsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get profileId =>
+      $composableBuilder(column: $table.profileId, builder: (column) => column);
+
+  GeneratedColumn<String> get globalKey =>
+      $composableBuilder(column: $table.globalKey, builder: (column) => column);
+
+  GeneratedColumn<String> get serverId =>
+      $composableBuilder(column: $table.serverId, builder: (column) => column);
+
+  GeneratedColumn<String> get clientScopeId => $composableBuilder(
+    column: $table.clientScopeId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get ratingKey =>
+      $composableBuilder(column: $table.ratingKey, builder: (column) => column);
+
+  GeneratedColumn<String> get kind =>
+      $composableBuilder(column: $table.kind, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get thumbPath =>
+      $composableBuilder(column: $table.thumbPath, builder: (column) => column);
+
+  GeneratedColumn<String> get backdropPath => $composableBuilder(
+    column: $table.backdropPath,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get year =>
+      $composableBuilder(column: $table.year, builder: (column) => column);
+
+  GeneratedColumn<int> get index =>
+      $composableBuilder(column: $table.index, builder: (column) => column);
+
+  GeneratedColumn<String> get parentTitle => $composableBuilder(
+    column: $table.parentTitle,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get addedAt =>
+      $composableBuilder(column: $table.addedAt, builder: (column) => column);
+}
+
+class $$WatchlistItemsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $WatchlistItemsTable,
+          WatchlistItem,
+          $$WatchlistItemsTableFilterComposer,
+          $$WatchlistItemsTableOrderingComposer,
+          $$WatchlistItemsTableAnnotationComposer,
+          $$WatchlistItemsTableCreateCompanionBuilder,
+          $$WatchlistItemsTableUpdateCompanionBuilder,
+          (
+            WatchlistItem,
+            BaseReferences<_$AppDatabase, $WatchlistItemsTable, WatchlistItem>,
+          ),
+          WatchlistItem,
+          PrefetchHooks Function()
+        > {
+  $$WatchlistItemsTableTableManager(
+    _$AppDatabase db,
+    $WatchlistItemsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$WatchlistItemsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$WatchlistItemsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$WatchlistItemsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> profileId = const Value.absent(),
+                Value<String> globalKey = const Value.absent(),
+                Value<String> serverId = const Value.absent(),
+                Value<String?> clientScopeId = const Value.absent(),
+                Value<String> ratingKey = const Value.absent(),
+                Value<String> kind = const Value.absent(),
+                Value<String> title = const Value.absent(),
+                Value<String?> thumbPath = const Value.absent(),
+                Value<String?> backdropPath = const Value.absent(),
+                Value<int?> year = const Value.absent(),
+                Value<int?> index = const Value.absent(),
+                Value<String?> parentTitle = const Value.absent(),
+                Value<int> addedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => WatchlistItemsCompanion(
+                profileId: profileId,
+                globalKey: globalKey,
+                serverId: serverId,
+                clientScopeId: clientScopeId,
+                ratingKey: ratingKey,
+                kind: kind,
+                title: title,
+                thumbPath: thumbPath,
+                backdropPath: backdropPath,
+                year: year,
+                index: index,
+                parentTitle: parentTitle,
+                addedAt: addedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String profileId,
+                required String globalKey,
+                required String serverId,
+                Value<String?> clientScopeId = const Value.absent(),
+                required String ratingKey,
+                required String kind,
+                required String title,
+                Value<String?> thumbPath = const Value.absent(),
+                Value<String?> backdropPath = const Value.absent(),
+                Value<int?> year = const Value.absent(),
+                Value<int?> index = const Value.absent(),
+                Value<String?> parentTitle = const Value.absent(),
+                required int addedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => WatchlistItemsCompanion.insert(
+                profileId: profileId,
+                globalKey: globalKey,
+                serverId: serverId,
+                clientScopeId: clientScopeId,
+                ratingKey: ratingKey,
+                kind: kind,
+                title: title,
+                thumbPath: thumbPath,
+                backdropPath: backdropPath,
+                year: year,
+                index: index,
+                parentTitle: parentTitle,
+                addedAt: addedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$WatchlistItemsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $WatchlistItemsTable,
+      WatchlistItem,
+      $$WatchlistItemsTableFilterComposer,
+      $$WatchlistItemsTableOrderingComposer,
+      $$WatchlistItemsTableAnnotationComposer,
+      $$WatchlistItemsTableCreateCompanionBuilder,
+      $$WatchlistItemsTableUpdateCompanionBuilder,
+      (
+        WatchlistItem,
+        BaseReferences<_$AppDatabase, $WatchlistItemsTable, WatchlistItem>,
+      ),
+      WatchlistItem,
+      PrefetchHooks Function()
+    >;
 typedef $$ConnectionsTableCreateCompanionBuilder =
     ConnectionsCompanion Function({
       required String id,
@@ -8259,6 +9401,8 @@ class $AppDatabaseManager {
       $$OfflineWatchProgressTableTableManager(_db, _db.offlineWatchProgress);
   $$SyncRulesTableTableManager get syncRules =>
       $$SyncRulesTableTableManager(_db, _db.syncRules);
+  $$WatchlistItemsTableTableManager get watchlistItems =>
+      $$WatchlistItemsTableTableManager(_db, _db.watchlistItems);
   $$ConnectionsTableTableManager get connections =>
       $$ConnectionsTableTableManager(_db, _db.connections);
   $$ProfilesTableTableManager get profiles =>

--- a/lib/database/tables.dart
+++ b/lib/database/tables.dart
@@ -104,6 +104,33 @@ class SyncRules extends Table {
   BoolColumn get includeSpecials => boolean().withDefault(const Constant(true))();
 }
 
+/// Profile-scoped watchlist bookmark for movies, shows, seasons, and episodes.
+///
+/// Composite primary key `(profileId, globalKey)` gives each profile an
+/// independent watchlist. Display metadata (title, thumb, year, etc.) is
+/// stored locally so the watchlist works offline.
+@DataClassName('WatchlistItem')
+@TableIndex(name: 'idx_watchlist_profile', columns: {#profileId})
+@TableIndex(name: 'idx_watchlist_kind', columns: {#kind})
+class WatchlistItems extends Table {
+  TextColumn get profileId => text()();
+  TextColumn get globalKey => text()();
+  TextColumn get serverId => text()();
+  TextColumn get clientScopeId => text().nullable()();
+  TextColumn get ratingKey => text()();
+  TextColumn get kind => text()(); // 'movie', 'show', 'season', 'episode'
+  TextColumn get title => text()();
+  TextColumn get thumbPath => text().nullable()();
+  TextColumn get backdropPath => text().nullable()();
+  IntColumn get year => integer().nullable()();
+  IntColumn get index => integer().nullable()();
+  TextColumn get parentTitle => text().nullable()();
+  IntColumn get addedAt => integer()(); // ms since epoch
+
+  @override
+  Set<Column> get primaryKey => {profileId, globalKey};
+}
+
 /// Persisted media-server connections.
 ///
 /// One row per "connection" the user has added — a Plex account (with its

--- a/lib/database/watchlist_operations.dart
+++ b/lib/database/watchlist_operations.dart
@@ -1,0 +1,81 @@
+import 'package:drift/drift.dart';
+
+import 'app_database.dart';
+
+extension WatchlistDatabaseOperations on AppDatabase {
+  /// Streams all watchlist items for [profileId], emitting on every change.
+  Stream<List<WatchlistItem>> watchWatchlist(String profileId) {
+    return (select(watchlistItems)..where((t) => t.profileId.equals(profileId))).watch();
+  }
+
+  /// Toggles the bookmark for the given composite key: inserts if not
+  /// present, deletes if present. Returns `true` when the item was added
+  /// and `false` when it was removed.
+  Future<bool> toggleBookmark({
+    required String profileId,
+    required String serverId,
+    String? clientScopeId,
+    required String ratingKey,
+    required String globalKey,
+    required String kind,
+    required String title,
+    String? thumbPath,
+    String? backdropPath,
+    int? year,
+    int? index,
+    String? parentTitle,
+  }) async {
+    final exists = await isBookmarked(profileId, globalKey);
+    if (exists) {
+      await (delete(watchlistItems)..where((t) => t.profileId.equals(profileId) & t.globalKey.equals(globalKey))).go();
+      return false;
+    }
+
+    await into(watchlistItems).insert(
+      WatchlistItemsCompanion.insert(
+        profileId: profileId,
+        globalKey: globalKey,
+        serverId: serverId,
+        clientScopeId: Value(clientScopeId),
+        ratingKey: ratingKey,
+        kind: kind,
+        title: title,
+        thumbPath: Value(thumbPath),
+        backdropPath: Value(backdropPath),
+        year: Value(year),
+        index: Value(index),
+        parentTitle: Value(parentTitle),
+        addedAt: DateTime.now().millisecondsSinceEpoch,
+      ),
+      onConflict: DoUpdate(
+        (_) => WatchlistItemsCompanion(
+          serverId: Value(serverId),
+          clientScopeId: Value(clientScopeId),
+          ratingKey: Value(ratingKey),
+          kind: Value(kind),
+          title: Value(title),
+          thumbPath: Value(thumbPath),
+          backdropPath: Value(backdropPath),
+          year: Value(year),
+          index: Value(index),
+          parentTitle: Value(parentTitle),
+          addedAt: Value(DateTime.now().millisecondsSinceEpoch),
+        ),
+      ),
+    );
+    return true;
+  }
+
+  /// Returns whether a row exists for the given profile + global key pair.
+  Future<bool> isBookmarked(String profileId, String globalKey) async {
+    final rows = await (select(watchlistItems)
+          ..where((t) => t.profileId.equals(profileId) & t.globalKey.equals(globalKey)))
+        .get();
+    return rows.isNotEmpty;
+  }
+
+  /// Deletes all watchlist rows for [profileId].
+  Future<void> clearAll(String profileId) async {
+    await (delete(watchlistItems)..where((t) => t.profileId.equals(profileId))).go();
+  }
+}

--- a/lib/i18n/bg.i18n.json
+++ b/lib/i18n/bg.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Разбъркано възпроизвеждане",
     "playTrailer": "Пусни трейлър",
     "markAsWatched": "Маркирай като гледано",
-    "markAsUnwatched": "Маркирай като негледано"
+    "markAsUnwatched": "Маркирай като негледано",
+    "bookmark": "Добавяне в отметки",
+    "removeBookmark": "Премахване от отметки"
   },
   "videoControls": {
     "audioLabel": "Аудио",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Библиотеки",
     "downloads": "Изтегляния",
+    "watchlist": "Отметки",
     "liveTv": "Телевизия на живо"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Вход в Jellyfin сървър. Свързва се с ${name}.",
     "borrowFromAnotherProfile": "Използвай от друг профил",
     "borrowFromAnotherProfileSubtitle": "Използвай връзка от друг профил. PIN-защитените профили изискват PIN."
+  },
+  "watchlist": {
+    "title": "Отметки",
+    "movies": "Филми",
+    "shows": "Сериали",
+    "seasons": "Сезони",
+    "episodes": "Епизоди",
+    "emptyTitle": "Няма добавени отметки",
+    "emptySubtitle": "Добавете филми и сериали в отметки, за да ги намирате по-лесно.",
+    "clearAll": "Изчистване на всички",
+    "clearAllConfirm": "Премахване на всички отметки? Това действие не може да бъде отменено.",
+    "added": "Добавено в отметки",
+    "removed": "Премахнато от отметки"
   }
 }

--- a/lib/i18n/da.i18n.json
+++ b/lib/i18n/da.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Afspil tilfældigt",
     "playTrailer": "Afspil trailer",
     "markAsWatched": "Markér som set",
-    "markAsUnwatched": "Markér som uset"
+    "markAsUnwatched": "Markér som uset",
+    "bookmark": "Tilføj bogmærke",
+    "removeBookmark": "Fjern bogmærke"
   },
   "videoControls": {
     "audioLabel": "Lyd",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Biblioteker",
     "downloads": "Downloads",
+    "watchlist": "Bogmærker",
     "liveTv": "Live TV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Log ind på en Jellyfin-server. Tilknyttes ${name}.",
     "borrowFromAnotherProfile": "Lån fra en anden profil",
     "borrowFromAnotherProfileSubtitle": "Genbrug en anden profils forbindelse. PIN-beskyttede profiler kræver en PIN."
+  },
+  "watchlist": {
+    "title": "Bogmærker",
+    "movies": "Film",
+    "shows": "Serier",
+    "seasons": "Sæsoner",
+    "episodes": "Afsnit",
+    "emptyTitle": "Ingen bogmærker endnu",
+    "emptySubtitle": "Tilføj film og serier til dine bogmærker for nem adgang.",
+    "clearAll": "Ryd alle",
+    "clearAllConfirm": "Fjern alle bogmærker? Dette kan ikke fortrydes.",
+    "added": "Tilføjet til bogmærker",
+    "removed": "Fjernet fra bogmærker"
   }
 }

--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Zufallswiedergabe",
     "playTrailer": "Trailer abspielen",
     "markAsWatched": "Als gesehen markieren",
-    "markAsUnwatched": "Als ungesehen markieren"
+    "markAsUnwatched": "Als ungesehen markieren",
+    "bookmark": "Lesezeichen setzen",
+    "removeBookmark": "Lesezeichen entfernen"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Medien",
     "downloads": "Downloads",
+    "watchlist": "Merkliste",
     "liveTv": "Live-TV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Bei einem Jellyfin-Server anmelden. Wird mit ${name} verknüpft.",
     "borrowFromAnotherProfile": "Von einem anderen Profil ausleihen",
     "borrowFromAnotherProfileSubtitle": "Verbindung eines anderen Profils wiederverwenden. PIN-geschützte Profile erfordern eine PIN."
+  },
+  "watchlist": {
+    "title": "Merkliste",
+    "movies": "Filme",
+    "shows": "Serien",
+    "seasons": "Staffeln",
+    "episodes": "Episoden",
+    "emptyTitle": "Keine Einträge",
+    "emptySubtitle": "Füge Filme und Serien zur Merkliste hinzu, um sie später schnell zu finden.",
+    "clearAll": "Alle löschen",
+    "clearAllConfirm": "Alle Einträge entfernen? Dies kann nicht rückgängig gemacht werden.",
+    "added": "Zur Merkliste hinzugefügt",
+    "removed": "Von der Merkliste entfernt"
   }
 }

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -415,7 +415,9 @@
     "shufflePlay": "Shuffle play",
     "playTrailer": "Play trailer",
     "markAsWatched": "Mark as watched",
-    "markAsUnwatched": "Mark as unwatched"
+    "markAsUnwatched": "Mark as unwatched",
+    "bookmark": "Bookmark",
+    "removeBookmark": "Remove bookmark"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -817,6 +819,7 @@
   "navigation": {
     "libraries": "Libraries",
     "downloads": "Downloads",
+    "watchlist": "Watchlist",
     "liveTv": "Live TV"
   },
   "liveTv": {
@@ -1404,5 +1407,18 @@
     "connectToJellyfinCardSubtitleScoped": "Sign in to a Jellyfin server. Binds to ${name}.",
     "borrowFromAnotherProfile": "Borrow from another profile",
     "borrowFromAnotherProfileSubtitle": "Reuse another profile's connection. PIN-protected profiles require a PIN."
+  },
+  "watchlist": {
+    "title": "Watchlist",
+    "movies": "Movies",
+    "shows": "Shows",
+    "seasons": "Seasons",
+    "episodes": "Episodes",
+    "emptyTitle": "Your watchlist is empty",
+    "emptySubtitle": "Bookmark movies and shows to find them here later.",
+    "clearAll": "Clear All",
+    "clearAllConfirm": "Remove all bookmarked items? This cannot be undone.",
+    "added": "Added to watchlist",
+    "removed": "Removed from watchlist"
   }
 }

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Reproducción aleatoria",
     "playTrailer": "Reproducir tráiler",
     "markAsWatched": "Marcar como visto",
-    "markAsUnwatched": "Marcar como no visto"
+    "markAsUnwatched": "Marcar como no visto",
+    "bookmark": "Agregar a favoritos",
+    "removeBookmark": "Quitar de favoritos"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Medios",
     "downloads": "Descargas",
+    "watchlist": "Favoritos",
     "liveTv": "TV en vivo"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Inicia sesión en un servidor Jellyfin. Se vincula a ${name}.",
     "borrowFromAnotherProfile": "Tomar prestado de otro perfil",
     "borrowFromAnotherProfileSubtitle": "Reutiliza la conexión de otro perfil. Los perfiles protegidos con PIN requieren un PIN."
+  },
+  "watchlist": {
+    "title": "Favoritos",
+    "movies": "Películas",
+    "shows": "Series",
+    "seasons": "Temporadas",
+    "episodes": "Episodios",
+    "emptyTitle": "No hay favoritos",
+    "emptySubtitle": "Agrega películas y series a favoritos para encontrarlas aquí.",
+    "clearAll": "Eliminar todos",
+    "clearAllConfirm": "¿Eliminar todos los favoritos? Esto no se puede deshacer.",
+    "added": "Agregado a favoritos",
+    "removed": "Eliminado de favoritos"
   }
 }

--- a/lib/i18n/fr.i18n.json
+++ b/lib/i18n/fr.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Lecture aléatoire",
     "playTrailer": "Lire la bande-annonce",
     "markAsWatched": "Marqué comme vu",
-    "markAsUnwatched": "Marqué comme non vu"
+    "markAsUnwatched": "Marqué comme non vu",
+    "bookmark": "Ajouter aux favoris",
+    "removeBookmark": "Retirer des favoris"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Medias",
     "downloads": "Téléch.",
+    "watchlist": "Favoris",
     "liveTv": "TV direct"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Connectez-vous à un serveur Jellyfin. Lié à ${name}.",
     "borrowFromAnotherProfile": "Emprunter à un autre profil",
     "borrowFromAnotherProfileSubtitle": "Réutiliser la connexion d'un autre profil. Les profils protégés par PIN exigent un PIN."
+  },
+  "watchlist": {
+    "title": "Favoris",
+    "movies": "Films",
+    "shows": "Séries",
+    "seasons": "Saisons",
+    "episodes": "Épisodes",
+    "emptyTitle": "Aucun favori",
+    "emptySubtitle": "Ajoutez des films et séries aux favoris pour les retrouver ici.",
+    "clearAll": "Tout effacer",
+    "clearAllConfirm": "Supprimer tous les favoris ? Cette action est irréversible.",
+    "added": "Ajouté aux favoris",
+    "removed": "Retiré des favoris"
   }
 }

--- a/lib/i18n/it.i18n.json
+++ b/lib/i18n/it.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Riproduzione casuale",
     "playTrailer": "Riproduci trailer",
     "markAsWatched": "Segna come visto",
-    "markAsUnwatched": "Segna come non visto"
+    "markAsUnwatched": "Segna come non visto",
+    "bookmark": "Aggiungi ai preferiti",
+    "removeBookmark": "Rimuovi dai preferiti"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Librerie",
     "downloads": "Download",
+    "watchlist": "Preferiti",
     "liveTv": "TV Live"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Accedi a un server Jellyfin. Collegato a ${name}.",
     "borrowFromAnotherProfile": "Prendi in prestito da un altro profilo",
     "borrowFromAnotherProfileSubtitle": "Riutilizza la connessione di un altro profilo. I profili protetti da PIN richiedono un PIN."
+  },
+  "watchlist": {
+    "title": "Preferiti",
+    "movies": "Film",
+    "shows": "Serie TV",
+    "seasons": "Stagioni",
+    "episodes": "Episodi",
+    "emptyTitle": "Nessun preferito",
+    "emptySubtitle": "Aggiungi film e serie ai preferiti per ritrovarli qui.",
+    "clearAll": "Rimuovi tutti",
+    "clearAllConfirm": "Rimuovere tutti i preferiti? Non puoi annullare questa azione.",
+    "added": "Aggiunto ai preferiti",
+    "removed": "Rimosso dai preferiti"
   }
 }

--- a/lib/i18n/ja.i18n.json
+++ b/lib/i18n/ja.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "シャッフル再生",
     "playTrailer": "予告編を再生",
     "markAsWatched": "視聴済みにする",
-    "markAsUnwatched": "未視聴にする"
+    "markAsUnwatched": "未視聴にする",
+    "bookmark": "ブックマークに追加",
+    "removeBookmark": "ブックマークを解除"
   },
   "videoControls": {
     "audioLabel": "音声",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "ライブラリ",
     "downloads": "ダウンロード",
+    "watchlist": "ブックマーク",
     "liveTv": "ライブTV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Jellyfinサーバーにサインインします。${name}に紐付けられます。",
     "borrowFromAnotherProfile": "別のプロファイルから借りる",
     "borrowFromAnotherProfileSubtitle": "別のプロフィールの接続を再利用します。PIN保護されたプロフィールにはPINが必要です。"
+  },
+  "watchlist": {
+    "title": "ブックマーク",
+    "movies": "映画",
+    "shows": "ドラマ",
+    "seasons": "シーズン",
+    "episodes": "エピソード",
+    "emptyTitle": "ブックマークはありません",
+    "emptySubtitle": "映画やドラマをブックマークすると、ここから簡単に見つけられます。",
+    "clearAll": "すべて削除",
+    "clearAllConfirm": "すべてのブックマークを削除しますか？この操作は元に戻せません。",
+    "added": "ブックマークに追加しました",
+    "removed": "ブックマークを解除しました"
   }
 }

--- a/lib/i18n/ko.i18n.json
+++ b/lib/i18n/ko.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "무작위 재생",
     "playTrailer": "예고편 재생",
     "markAsWatched": "시청 완료로 표시",
-    "markAsUnwatched": "시청 안 함으로 표시"
+    "markAsUnwatched": "시청 안 함으로 표시",
+    "bookmark": "북마크 추가",
+    "removeBookmark": "북마크 제거"
   },
   "videoControls": {
     "audioLabel": "오디오",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "미디어 라이브러리",
     "downloads": "다운로드",
+    "watchlist": "북마크",
     "liveTv": "실시간 TV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Jellyfin 서버에 로그인합니다. ${name}에 연결됩니다.",
     "borrowFromAnotherProfile": "다른 프로필에서 빌리기",
     "borrowFromAnotherProfileSubtitle": "다른 프로필의 연결을 재사용합니다. PIN으로 보호된 프로필에는 PIN이 필요합니다."
+  },
+  "watchlist": {
+    "title": "북마크",
+    "movies": "영화",
+    "shows": "드라마",
+    "seasons": "시즌",
+    "episodes": "에피소드",
+    "emptyTitle": "북마크가 없습니다",
+    "emptySubtitle": "영화와 드라마를 북마크하면 여기서 쉽게 찾을 수 있습니다.",
+    "clearAll": "모두 삭제",
+    "clearAllConfirm": "모든 북마크를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+    "added": "북마크에 추가됨",
+    "removed": "북마크에서 제거됨"
   }
 }

--- a/lib/i18n/nb.i18n.json
+++ b/lib/i18n/nb.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Tilfeldig avspilling",
     "playTrailer": "Spill trailer",
     "markAsWatched": "Merk som sett",
-    "markAsUnwatched": "Merk som usett"
+    "markAsUnwatched": "Merk som usett",
+    "bookmark": "Legg til bokmerke",
+    "removeBookmark": "Fjern bokmerke"
   },
   "videoControls": {
     "audioLabel": "Lyd",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Biblioteker",
     "downloads": "Nedlastinger",
+    "watchlist": "Bokmerker",
     "liveTv": "Direkte-TV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Logg på en Jellyfin-server. Knyttes til ${name}.",
     "borrowFromAnotherProfile": "Lån fra en annen profil",
     "borrowFromAnotherProfileSubtitle": "Gjenbruk en annen profils tilkobling. PIN-beskyttede profiler krever PIN."
+  },
+  "watchlist": {
+    "title": "Bokmerker",
+    "movies": "Filmer",
+    "shows": "Serier",
+    "seasons": "Sesonger",
+    "episodes": "Episoder",
+    "emptyTitle": "Ingen bokmerker",
+    "emptySubtitle": "Legg til filmer og serier i bokmerkene dine for enkel tilgang.",
+    "clearAll": "Fjern alle",
+    "clearAllConfirm": "Fjern alle bokmerker? Dette kan ikke angres.",
+    "added": "Lagt til i bokmerker",
+    "removed": "Fjernet fra bokmerker"
   }
 }

--- a/lib/i18n/nl.i18n.json
+++ b/lib/i18n/nl.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Willekeurig afspelen",
     "playTrailer": "Trailer afspelen",
     "markAsWatched": "Markeer als gekeken",
-    "markAsUnwatched": "Markeer als ongekeken"
+    "markAsUnwatched": "Markeer als ongekeken",
+    "bookmark": "Toevoegen aan bladwijzers",
+    "removeBookmark": "Verwijderen uit bladwijzers"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Media",
     "downloads": "Downloads",
+    "watchlist": "Bladwijzers",
     "liveTv": "Live TV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Log in op een Jellyfin-server. Wordt gekoppeld aan ${name}.",
     "borrowFromAnotherProfile": "Lenen van een ander profiel",
     "borrowFromAnotherProfileSubtitle": "Hergebruik de verbinding van een ander profiel. PIN-beveiligde profielen vereisen een PIN."
+  },
+  "watchlist": {
+    "title": "Bladwijzers",
+    "movies": "Films",
+    "shows": "Series",
+    "seasons": "Seizoenen",
+    "episodes": "Afleveringen",
+    "emptyTitle": "Geen bladwijzers",
+    "emptySubtitle": "Voeg films en series toe aan bladwijzers voor snelle toegang.",
+    "clearAll": "Alles wissen",
+    "clearAllConfirm": "Alle bladwijzers verwijderen? Dit kan niet ongedaan worden gemaakt.",
+    "added": "Toegevoegd aan bladwijzers",
+    "removed": "Verwijderd uit bladwijzers"
   }
 }

--- a/lib/i18n/pl.i18n.json
+++ b/lib/i18n/pl.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Odtwarzanie losowe",
     "playTrailer": "Odtwórz zwiastun",
     "markAsWatched": "Oznacz jako obejrzane",
-    "markAsUnwatched": "Oznacz jako nieobejrzane"
+    "markAsUnwatched": "Oznacz jako nieobejrzane",
+    "bookmark": "Dodaj do zakładek",
+    "removeBookmark": "Usuń z zakładek"
   },
   "videoControls": {
     "audioLabel": "Audio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Biblioteki",
     "downloads": "Pobrania",
+    "watchlist": "Zakładki",
     "liveTv": "TV na żywo"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Zaloguj się do serwera Jellyfin. Powiązane z ${name}.",
     "borrowFromAnotherProfile": "Pożycz z innego profilu",
     "borrowFromAnotherProfileSubtitle": "Użyj połączenia z innego profilu. Profile chronione PIN wymagają PIN-u."
+  },
+  "watchlist": {
+    "title": "Zakładki",
+    "movies": "Filmy",
+    "shows": "Seriale",
+    "seasons": "Sezony",
+    "episodes": "Odcinki",
+    "emptyTitle": "Brak zakładek",
+    "emptySubtitle": "Dodaj filmy i seriale do zakładek, aby mieć do nich szybki dostęp.",
+    "clearAll": "Usuń wszystkie",
+    "clearAllConfirm": "Usunąć wszystkie zakładki? Tej operacji nie można cofnąć.",
+    "added": "Dodano do zakładek",
+    "removed": "Usunięto z zakładek"
   }
 }

--- a/lib/i18n/pt.i18n.json
+++ b/lib/i18n/pt.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Reprodução aleatória",
     "playTrailer": "Reproduzir trailer",
     "markAsWatched": "Marcar como assistido",
-    "markAsUnwatched": "Marcar como não assistido"
+    "markAsUnwatched": "Marcar como não assistido",
+    "bookmark": "Adicionar aos favoritos",
+    "removeBookmark": "Remover dos favoritos"
   },
   "videoControls": {
     "audioLabel": "Áudio",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Bibliotecas",
     "downloads": "Downloads",
+    "watchlist": "Favoritos",
     "liveTv": "TV ao Vivo"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Entre em um servidor Jellyfin. Vinculado a ${name}.",
     "borrowFromAnotherProfile": "Pegar emprestado de outro perfil",
     "borrowFromAnotherProfileSubtitle": "Reutilize a conexão de outro perfil. Perfis protegidos por PIN exigem PIN."
+  },
+  "watchlist": {
+    "title": "Favoritos",
+    "movies": "Filmes",
+    "shows": "Séries",
+    "seasons": "Temporadas",
+    "episodes": "Episódios",
+    "emptyTitle": "Nenhum favorito",
+    "emptySubtitle": "Adicione filmes e séries aos favoritos para encontrá-los aqui.",
+    "clearAll": "Remover todos",
+    "clearAllConfirm": "Remover todos os favoritos? Esta ação não pode ser desfeita.",
+    "added": "Adicionado aos favoritos",
+    "removed": "Removido dos favoritos"
   }
 }

--- a/lib/i18n/ru.i18n.json
+++ b/lib/i18n/ru.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Случайное воспроизведение",
     "playTrailer": "Воспроизвести трейлер",
     "markAsWatched": "Отметить как просмотренное",
-    "markAsUnwatched": "Отметить как непросмотренное"
+    "markAsUnwatched": "Отметить как непросмотренное",
+    "bookmark": "Добавить в закладки",
+    "removeBookmark": "Удалить из закладок"
   },
   "videoControls": {
     "audioLabel": "Аудио",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Библиотеки",
     "downloads": "Загрузки",
+    "watchlist": "Закладки",
     "liveTv": "ТВ в прямом эфире"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Войдите на сервер Jellyfin. Привязывается к ${name}.",
     "borrowFromAnotherProfile": "Одолжить из другого профиля",
     "borrowFromAnotherProfileSubtitle": "Используйте подключение другого профиля. Для профилей с PIN нужен PIN."
+  },
+  "watchlist": {
+    "title": "Закладки",
+    "movies": "Фильмы",
+    "shows": "Сериалы",
+    "seasons": "Сезоны",
+    "episodes": "Эпизоды",
+    "emptyTitle": "Нет закладок",
+    "emptySubtitle": "Добавляйте фильмы и сериалы в закладки, чтобы быстро их находить.",
+    "clearAll": "Очистить все",
+    "clearAllConfirm": "Удалить все закладки? Это действие нельзя отменить.",
+    "added": "Добавлено в закладки",
+    "removed": "Удалено из закладок"
   }
 }

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 20455 (1278 per locale)
+/// Strings: 20665 (1291 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 20441 (1277 per locale)
+/// Strings: 20455 (1278 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_bg.g.dart
+++ b/lib/i18n/strings_bg.g.dart
@@ -85,6 +85,7 @@ class TranslationsBg extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktBg trakt = _TranslationsTraktBg._(_root);
 	@override late final _TranslationsTrackersBg trackers = _TranslationsTrackersBg._(_root);
 	@override late final _TranslationsAddServerBg addServer = _TranslationsAddServerBg._(_root);
+	@override late final _TranslationsWatchlistBg watchlist = _TranslationsWatchlistBg._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsBg extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Пусни трейлър';
 	@override String get markAsWatched => 'Маркирай като гледано';
 	@override String get markAsUnwatched => 'Маркирай като негледано';
+	@override String get bookmark => 'Добавяне в отметки';
+	@override String get removeBookmark => 'Премахване от отметки';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationBg extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Библиотеки';
 	@override String get downloads => 'Изтегляния';
+	@override String get watchlist => 'Отметки';
 	@override String get liveTv => 'Телевизия на живо';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerBg extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Вход в Jellyfin сървър. Свързва се с ${name}.';
 	@override String get borrowFromAnotherProfile => 'Използвай от друг профил';
 	@override String get borrowFromAnotherProfileSubtitle => 'Използвай връзка от друг профил. PIN-защитените профили изискват PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistBg extends TranslationsWatchlistEn {
+	_TranslationsWatchlistBg._(TranslationsBg root) : this._root = root, super.internal(root);
+
+	final TranslationsBg _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Отметки';
+	@override String get movies => 'Филми';
+	@override String get shows => 'Сериали';
+	@override String get seasons => 'Сезони';
+	@override String get episodes => 'Епизоди';
+	@override String get emptyTitle => 'Няма добавени отметки';
+	@override String get emptySubtitle => 'Добавете филми и сериали в отметки, за да ги намирате по-лесно.';
+	@override String get clearAll => 'Изчистване на всички';
+	@override String get clearAllConfirm => 'Премахване на всички отметки? Това действие не може да бъде отменено.';
+	@override String get added => 'Добавено в отметки';
+	@override String get removed => 'Премахнато от отметки';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsBg {
 			'tooltips.playTrailer' => 'Пусни трейлър',
 			'tooltips.markAsWatched' => 'Маркирай като гледано',
 			'tooltips.markAsUnwatched' => 'Маркирай като негледано',
+			'tooltips.bookmark' => 'Добавяне в отметки',
+			'tooltips.removeBookmark' => 'Премахване от отметки',
 			'videoControls.audioLabel' => 'Аудио',
 			'videoControls.subtitlesLabel' => 'Субтитри',
 			'videoControls.resetToZero' => 'Нулирай до 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsBg {
 			'messages.serverLimitTitle' => 'Възпроизвеждането е неуспешно',
 			'messages.serverLimitBody' => 'Грешка на сървъра (HTTP 500). Вероятно лимит за пропускателна способност/транскодиране е отхвърлил тази сесия. Помолете собственика да го коригира.',
 			'messages.logsUploaded' => 'Логовете са качени',
-			'messages.logsUploadFailed' => 'Неуспешно качване на логовете',
-			'messages.logId' => 'ID на лога',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Неуспешно качване на логовете',
+			'messages.logId' => 'ID на лога',
 			'subtitlingStyling.text' => 'Текст',
 			'subtitlingStyling.border' => 'Рамка',
 			'subtitlingStyling.background' => 'Фон',
@@ -2669,6 +2695,7 @@ extension on TranslationsBg {
 			'licenses.licensesCount' => ({required Object count}) => '${count} лиценза',
 			'navigation.libraries' => 'Библиотеки',
 			'navigation.downloads' => 'Изтегляния',
+			'navigation.watchlist' => 'Отметки',
 			'navigation.liveTv' => 'Телевизия на живо',
 			'liveTv.title' => 'Телевизия на живо',
 			'liveTv.guide' => 'ТВ програма',
@@ -2949,11 +2976,11 @@ extension on TranslationsBg {
 			'companionRemote.pairing.validationHostFormat' => 'Форматът трябва да е IP:port (напр. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Връзката изтече. Използвайте една и съща мрежа на двете устройства.',
 			'companionRemote.pairing.sessionNotFound' => 'Устройството не е намерено. Уверете се, че Plezy работи на хоста.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Удостоверяването е неуспешно. Двете устройства трябва да използват същия Plex акаунт.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Неуспешно свързване: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Искате ли да прекъснете връзката с дистанционната сесия?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Повторно свързване...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Опит ${current} от 5',
 			'companionRemote.remote.retryNow' => 'Опитай сега',
@@ -3207,6 +3234,17 @@ extension on TranslationsBg {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Вход в Jellyfin сървър. Свързва се с ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Използвай от друг профил',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Използвай връзка от друг профил. PIN-защитените профили изискват PIN.',
+			'watchlist.title' => 'Отметки',
+			'watchlist.movies' => 'Филми',
+			'watchlist.shows' => 'Сериали',
+			'watchlist.seasons' => 'Сезони',
+			'watchlist.episodes' => 'Епизоди',
+			'watchlist.emptyTitle' => 'Няма добавени отметки',
+			'watchlist.emptySubtitle' => 'Добавете филми и сериали в отметки, за да ги намирате по-лесно.',
+			'watchlist.clearAll' => 'Изчистване на всички',
+			'watchlist.clearAllConfirm' => 'Премахване на всички отметки? Това действие не може да бъде отменено.',
+			'watchlist.added' => 'Добавено в отметки',
+			'watchlist.removed' => 'Премахнато от отметки',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_da.g.dart
+++ b/lib/i18n/strings_da.g.dart
@@ -85,6 +85,7 @@ class TranslationsDa extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktDa trakt = _TranslationsTraktDa._(_root);
 	@override late final _TranslationsTrackersDa trackers = _TranslationsTrackersDa._(_root);
 	@override late final _TranslationsAddServerDa addServer = _TranslationsAddServerDa._(_root);
+	@override late final _TranslationsWatchlistDa watchlist = _TranslationsWatchlistDa._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsDa extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Afspil trailer';
 	@override String get markAsWatched => 'Markér som set';
 	@override String get markAsUnwatched => 'Markér som uset';
+	@override String get bookmark => 'Tilføj bogmærke';
+	@override String get removeBookmark => 'Fjern bogmærke';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationDa extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Biblioteker';
 	@override String get downloads => 'Downloads';
+	@override String get watchlist => 'Bogmærker';
 	@override String get liveTv => 'Live TV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerDa extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Log ind på en Jellyfin-server. Tilknyttes ${name}.';
 	@override String get borrowFromAnotherProfile => 'Lån fra en anden profil';
 	@override String get borrowFromAnotherProfileSubtitle => 'Genbrug en anden profils forbindelse. PIN-beskyttede profiler kræver en PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistDa extends TranslationsWatchlistEn {
+	_TranslationsWatchlistDa._(TranslationsDa root) : this._root = root, super.internal(root);
+
+	final TranslationsDa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bogmærker';
+	@override String get movies => 'Film';
+	@override String get shows => 'Serier';
+	@override String get seasons => 'Sæsoner';
+	@override String get episodes => 'Afsnit';
+	@override String get emptyTitle => 'Ingen bogmærker endnu';
+	@override String get emptySubtitle => 'Tilføj film og serier til dine bogmærker for nem adgang.';
+	@override String get clearAll => 'Ryd alle';
+	@override String get clearAllConfirm => 'Fjern alle bogmærker? Dette kan ikke fortrydes.';
+	@override String get added => 'Tilføjet til bogmærker';
+	@override String get removed => 'Fjernet fra bogmærker';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsDa {
 			'tooltips.playTrailer' => 'Afspil trailer',
 			'tooltips.markAsWatched' => 'Markér som set',
 			'tooltips.markAsUnwatched' => 'Markér som uset',
+			'tooltips.bookmark' => 'Tilføj bogmærke',
+			'tooltips.removeBookmark' => 'Fjern bogmærke',
 			'videoControls.audioLabel' => 'Lyd',
 			'videoControls.subtitlesLabel' => 'Undertekster',
 			'videoControls.resetToZero' => 'Nulstil til 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsDa {
 			'messages.serverLimitTitle' => 'Afspilning mislykkedes',
 			'messages.serverLimitBody' => 'Serverfejl (HTTP 500). En båndbredde-/transkodningsgrænse afviste nok sessionen. Bed ejeren om at justere den.',
 			'messages.logsUploaded' => 'Logs uploadet',
-			'messages.logsUploadFailed' => 'Kunne ikke uploade logs',
-			'messages.logId' => 'Log-ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Kunne ikke uploade logs',
+			'messages.logId' => 'Log-ID',
 			'subtitlingStyling.text' => 'Tekst',
 			'subtitlingStyling.border' => 'Kant',
 			'subtitlingStyling.background' => 'Baggrund',
@@ -2669,6 +2695,7 @@ extension on TranslationsDa {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licenser',
 			'navigation.libraries' => 'Biblioteker',
 			'navigation.downloads' => 'Downloads',
+			'navigation.watchlist' => 'Bogmærker',
 			'navigation.liveTv' => 'Live TV',
 			'liveTv.title' => 'Live TV',
 			'liveTv.guide' => 'Guide',
@@ -2949,11 +2976,11 @@ extension on TranslationsDa {
 			'companionRemote.pairing.validationHostFormat' => 'Format skal være IP:port (f.eks. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Forbindelsen fik timeout. Brug samme netværk på begge enheder.',
 			'companionRemote.pairing.sessionNotFound' => 'Enhed ikke fundet. Sørg for, at Plezy kører på værten.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Godkendelse mislykkedes. Begge enheder skal bruge samme Plex-konto.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Kunne ikke oprette forbindelse: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Vil du afbryde fra fjernsessionen?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Genopretter forbindelse...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Forsøg ${current} af 5',
 			'companionRemote.remote.retryNow' => 'Prøv igen nu',
@@ -3207,6 +3234,17 @@ extension on TranslationsDa {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Log ind på en Jellyfin-server. Tilknyttes ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Lån fra en anden profil',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Genbrug en anden profils forbindelse. PIN-beskyttede profiler kræver en PIN.',
+			'watchlist.title' => 'Bogmærker',
+			'watchlist.movies' => 'Film',
+			'watchlist.shows' => 'Serier',
+			'watchlist.seasons' => 'Sæsoner',
+			'watchlist.episodes' => 'Afsnit',
+			'watchlist.emptyTitle' => 'Ingen bogmærker endnu',
+			'watchlist.emptySubtitle' => 'Tilføj film og serier til dine bogmærker for nem adgang.',
+			'watchlist.clearAll' => 'Ryd alle',
+			'watchlist.clearAllConfirm' => 'Fjern alle bogmærker? Dette kan ikke fortrydes.',
+			'watchlist.added' => 'Tilføjet til bogmærker',
+			'watchlist.removed' => 'Fjernet fra bogmærker',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -85,6 +85,7 @@ class TranslationsDe extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktDe trakt = _TranslationsTraktDe._(_root);
 	@override late final _TranslationsTrackersDe trackers = _TranslationsTrackersDe._(_root);
 	@override late final _TranslationsAddServerDe addServer = _TranslationsAddServerDe._(_root);
+	@override late final _TranslationsWatchlistDe watchlist = _TranslationsWatchlistDe._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsDe extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Trailer abspielen';
 	@override String get markAsWatched => 'Als gesehen markieren';
 	@override String get markAsUnwatched => 'Als ungesehen markieren';
+	@override String get bookmark => 'Lesezeichen setzen';
+	@override String get removeBookmark => 'Lesezeichen entfernen';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationDe extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Medien';
 	@override String get downloads => 'Downloads';
+	@override String get watchlist => 'Merkliste';
 	@override String get liveTv => 'Live-TV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerDe extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Bei einem Jellyfin-Server anmelden. Wird mit ${name} verknüpft.';
 	@override String get borrowFromAnotherProfile => 'Von einem anderen Profil ausleihen';
 	@override String get borrowFromAnotherProfileSubtitle => 'Verbindung eines anderen Profils wiederverwenden. PIN-geschützte Profile erfordern eine PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistDe extends TranslationsWatchlistEn {
+	_TranslationsWatchlistDe._(TranslationsDe root) : this._root = root, super.internal(root);
+
+	final TranslationsDe _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Merkliste';
+	@override String get movies => 'Filme';
+	@override String get shows => 'Serien';
+	@override String get seasons => 'Staffeln';
+	@override String get episodes => 'Episoden';
+	@override String get emptyTitle => 'Keine Einträge';
+	@override String get emptySubtitle => 'Füge Filme und Serien zur Merkliste hinzu, um sie später schnell zu finden.';
+	@override String get clearAll => 'Alle löschen';
+	@override String get clearAllConfirm => 'Alle Einträge entfernen? Dies kann nicht rückgängig gemacht werden.';
+	@override String get added => 'Zur Merkliste hinzugefügt';
+	@override String get removed => 'Von der Merkliste entfernt';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsDe {
 			'tooltips.playTrailer' => 'Trailer abspielen',
 			'tooltips.markAsWatched' => 'Als gesehen markieren',
 			'tooltips.markAsUnwatched' => 'Als ungesehen markieren',
+			'tooltips.bookmark' => 'Lesezeichen setzen',
+			'tooltips.removeBookmark' => 'Lesezeichen entfernen',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Untertitel',
 			'videoControls.resetToZero' => 'Auf 0 ms zurücksetzen',
@@ -2436,10 +2462,10 @@ extension on TranslationsDe {
 			'messages.serverLimitTitle' => 'Wiedergabe fehlgeschlagen',
 			'messages.serverLimitBody' => 'Serverfehler (HTTP 500). Ein Bandbreiten-/Transcoding-Limit lehnte diese Sitzung wohl ab. Bitte den Besitzer um Anpassung.',
 			'messages.logsUploaded' => 'Protokolle hochgeladen',
-			'messages.logsUploadFailed' => 'Protokolle konnten nicht hochgeladen werden',
-			'messages.logId' => 'Protokoll-ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Protokolle konnten nicht hochgeladen werden',
+			'messages.logId' => 'Protokoll-ID',
 			'subtitlingStyling.text' => 'Text',
 			'subtitlingStyling.border' => 'Rahmen',
 			'subtitlingStyling.background' => 'Hintergrund',
@@ -2669,6 +2695,7 @@ extension on TranslationsDe {
 			'licenses.licensesCount' => ({required Object count}) => '${count} Lizenzen',
 			'navigation.libraries' => 'Medien',
 			'navigation.downloads' => 'Downloads',
+			'navigation.watchlist' => 'Merkliste',
 			'navigation.liveTv' => 'Live-TV',
 			'liveTv.title' => 'Live-TV',
 			'liveTv.guide' => 'Programmführer',
@@ -2949,11 +2976,11 @@ extension on TranslationsDe {
 			'companionRemote.pairing.validationHostFormat' => 'Format muss IP:Port sein (z.B. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Verbindung hat Zeitlimit überschritten. Nutze auf beiden Geräten dasselbe Netzwerk.',
 			'companionRemote.pairing.sessionNotFound' => 'Gerät nicht gefunden. Stelle sicher, dass Plezy auf dem Host läuft.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Authentifizierung fehlgeschlagen. Beide Geräte benötigen dasselbe Plex-Konto.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Verbindung fehlgeschlagen: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Möchtest du die Verbindung zur Fernsteuerungssitzung trennen?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Verbindung wird wiederhergestellt...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Versuch ${current} von 5',
 			'companionRemote.remote.retryNow' => 'Jetzt wiederholen',
@@ -3207,6 +3234,17 @@ extension on TranslationsDe {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Bei einem Jellyfin-Server anmelden. Wird mit ${name} verknüpft.',
 			'addServer.borrowFromAnotherProfile' => 'Von einem anderen Profil ausleihen',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Verbindung eines anderen Profils wiederverwenden. PIN-geschützte Profile erfordern eine PIN.',
+			'watchlist.title' => 'Merkliste',
+			'watchlist.movies' => 'Filme',
+			'watchlist.shows' => 'Serien',
+			'watchlist.seasons' => 'Staffeln',
+			'watchlist.episodes' => 'Episoden',
+			'watchlist.emptyTitle' => 'Keine Einträge',
+			'watchlist.emptySubtitle' => 'Füge Filme und Serien zur Merkliste hinzu, um sie später schnell zu finden.',
+			'watchlist.clearAll' => 'Alle löschen',
+			'watchlist.clearAllConfirm' => 'Alle Einträge entfernen? Dies kann nicht rückgängig gemacht werden.',
+			'watchlist.added' => 'Zur Merkliste hinzugefügt',
+			'watchlist.removed' => 'Von der Merkliste entfernt',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -86,6 +86,7 @@ class Translations with BaseTranslations<AppLocale, Translations> {
 	late final TranslationsTraktEn trakt = TranslationsTraktEn.internal(_root);
 	late final TranslationsTrackersEn trackers = TranslationsTrackersEn.internal(_root);
 	late final TranslationsAddServerEn addServer = TranslationsAddServerEn.internal(_root);
+	late final TranslationsWatchlistEn watchlist = TranslationsWatchlistEn.internal(_root);
 }
 
 // Path: app
@@ -1300,6 +1301,12 @@ class TranslationsTooltipsEn {
 
 	/// en: 'Mark as unwatched'
 	String get markAsUnwatched => 'Mark as unwatched';
+
+	/// en: 'Bookmark'
+	String get bookmark => 'Bookmark';
+
+	/// en: 'Remove bookmark'
+	String get removeBookmark => 'Remove bookmark';
 }
 
 // Path: videoControls
@@ -2399,6 +2406,9 @@ class TranslationsNavigationEn {
 
 	/// en: 'Downloads'
 	String get downloads => 'Downloads';
+
+	/// en: 'Watchlist'
+	String get watchlist => 'Watchlist';
 
 	/// en: 'Live TV'
 	String get liveTv => 'Live TV';
@@ -3920,6 +3930,48 @@ class TranslationsAddServerEn {
 	String get borrowFromAnotherProfileSubtitle => 'Reuse another profile\'s connection. PIN-protected profiles require a PIN.';
 }
 
+// Path: watchlist
+class TranslationsWatchlistEn {
+	TranslationsWatchlistEn.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// en: 'Watchlist'
+	String get title => 'Watchlist';
+
+	/// en: 'Movies'
+	String get movies => 'Movies';
+
+	/// en: 'Shows'
+	String get shows => 'Shows';
+
+	/// en: 'Seasons'
+	String get seasons => 'Seasons';
+
+	/// en: 'Episodes'
+	String get episodes => 'Episodes';
+
+	/// en: 'Your watchlist is empty'
+	String get emptyTitle => 'Your watchlist is empty';
+
+	/// en: 'Bookmark movies and shows to find them here later.'
+	String get emptySubtitle => 'Bookmark movies and shows to find them here later.';
+
+	/// en: 'Clear All'
+	String get clearAll => 'Clear All';
+
+	/// en: 'Remove all bookmarked items? This cannot be undone.'
+	String get clearAllConfirm => 'Remove all bookmarked items? This cannot be undone.';
+
+	/// en: 'Added to watchlist'
+	String get added => 'Added to watchlist';
+
+	/// en: 'Removed from watchlist'
+	String get removed => 'Removed from watchlist';
+}
+
 // Path: hotkeys.actions
 class TranslationsHotkeysActionsEn {
 	TranslationsHotkeysActionsEn.internal(this._root);
@@ -4903,6 +4955,8 @@ extension on Translations {
 			'tooltips.playTrailer' => 'Play trailer',
 			'tooltips.markAsWatched' => 'Mark as watched',
 			'tooltips.markAsUnwatched' => 'Mark as unwatched',
+			'tooltips.bookmark' => 'Bookmark',
+			'tooltips.removeBookmark' => 'Remove bookmark',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Subtitles',
 			'videoControls.resetToZero' => 'Reset to 0ms',
@@ -5023,10 +5077,10 @@ extension on Translations {
 			'messages.noResultsFound' => 'No results found',
 			'messages.sleepTimerSet' => ({required Object label}) => 'Sleep timer set for ${label}',
 			'messages.noItemsAvailable' => 'No items available',
-			'messages.failedToCreatePlayQueueNoItems' => 'Failed to create play queue - no items',
-			'messages.failedPlayback' => ({required Object action, required Object error}) => 'Failed to ${action}: ${error}',
 			_ => null,
 		} ?? switch (path) {
+			'messages.failedToCreatePlayQueueNoItems' => 'Failed to create play queue - no items',
+			'messages.failedPlayback' => ({required Object action, required Object error}) => 'Failed to ${action}: ${error}',
 			'messages.switchingToCompatiblePlayer' => 'Switching to compatible player...',
 			'messages.serverLimitTitle' => 'Playback failed',
 			'messages.serverLimitBody' => 'Server error (HTTP 500). A bandwidth/transcoding limit likely rejected this session. Ask the owner to adjust it.',
@@ -5262,6 +5316,7 @@ extension on Translations {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licenses',
 			'navigation.libraries' => 'Libraries',
 			'navigation.downloads' => 'Downloads',
+			'navigation.watchlist' => 'Watchlist',
 			'navigation.liveTv' => 'Live TV',
 			'liveTv.title' => 'Live TV',
 			'liveTv.guide' => 'Guide',
@@ -5536,11 +5591,11 @@ extension on Translations {
 			'companionRemote.pairing.hostAddressHint' => '192.168.1.100:48632',
 			'companionRemote.pairing.connecting' => 'Connecting...',
 			'companionRemote.pairing.searchingForDevices' => 'Looking for devices...',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.noDevicesFound' => 'No devices found on your network',
 			'companionRemote.pairing.noDevicesHint' => 'Open Plezy on desktop and use the same WiFi',
 			'companionRemote.pairing.availableDevices' => 'Available Devices',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.pairing.manualConnection' => 'Manual Connection',
 			'companionRemote.pairing.cryptoInitFailed' => 'Couldn\'t start secure connection. Sign in to Plex first.',
 			'companionRemote.pairing.validationHostRequired' => 'Please enter host address',
@@ -5803,6 +5858,17 @@ extension on Translations {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Sign in to a Jellyfin server. Binds to ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Borrow from another profile',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Reuse another profile\'s connection. PIN-protected profiles require a PIN.',
+			'watchlist.title' => 'Watchlist',
+			'watchlist.movies' => 'Movies',
+			'watchlist.shows' => 'Shows',
+			'watchlist.seasons' => 'Seasons',
+			'watchlist.episodes' => 'Episodes',
+			'watchlist.emptyTitle' => 'Your watchlist is empty',
+			'watchlist.emptySubtitle' => 'Bookmark movies and shows to find them here later.',
+			'watchlist.clearAll' => 'Clear All',
+			'watchlist.clearAllConfirm' => 'Remove all bookmarked items? This cannot be undone.',
+			'watchlist.added' => 'Added to watchlist',
+			'watchlist.removed' => 'Removed from watchlist',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_es.g.dart
+++ b/lib/i18n/strings_es.g.dart
@@ -85,6 +85,7 @@ class TranslationsEs extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktEs trakt = _TranslationsTraktEs._(_root);
 	@override late final _TranslationsTrackersEs trackers = _TranslationsTrackersEs._(_root);
 	@override late final _TranslationsAddServerEs addServer = _TranslationsAddServerEs._(_root);
+	@override late final _TranslationsWatchlistEs watchlist = _TranslationsWatchlistEs._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsEs extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Reproducir tráiler';
 	@override String get markAsWatched => 'Marcar como visto';
 	@override String get markAsUnwatched => 'Marcar como no visto';
+	@override String get bookmark => 'Agregar a favoritos';
+	@override String get removeBookmark => 'Quitar de favoritos';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationEs extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Medios';
 	@override String get downloads => 'Descargas';
+	@override String get watchlist => 'Favoritos';
 	@override String get liveTv => 'TV en vivo';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerEs extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Inicia sesión en un servidor Jellyfin. Se vincula a ${name}.';
 	@override String get borrowFromAnotherProfile => 'Tomar prestado de otro perfil';
 	@override String get borrowFromAnotherProfileSubtitle => 'Reutiliza la conexión de otro perfil. Los perfiles protegidos con PIN requieren un PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistEs extends TranslationsWatchlistEn {
+	_TranslationsWatchlistEs._(TranslationsEs root) : this._root = root, super.internal(root);
+
+	final TranslationsEs _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Favoritos';
+	@override String get movies => 'Películas';
+	@override String get shows => 'Series';
+	@override String get seasons => 'Temporadas';
+	@override String get episodes => 'Episodios';
+	@override String get emptyTitle => 'No hay favoritos';
+	@override String get emptySubtitle => 'Agrega películas y series a favoritos para encontrarlas aquí.';
+	@override String get clearAll => 'Eliminar todos';
+	@override String get clearAllConfirm => '¿Eliminar todos los favoritos? Esto no se puede deshacer.';
+	@override String get added => 'Agregado a favoritos';
+	@override String get removed => 'Eliminado de favoritos';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsEs {
 			'tooltips.playTrailer' => 'Reproducir tráiler',
 			'tooltips.markAsWatched' => 'Marcar como visto',
 			'tooltips.markAsUnwatched' => 'Marcar como no visto',
+			'tooltips.bookmark' => 'Agregar a favoritos',
+			'tooltips.removeBookmark' => 'Quitar de favoritos',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Subtítulos',
 			'videoControls.resetToZero' => 'Restablecer a 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsEs {
 			'messages.serverLimitTitle' => 'Error de reproducción',
 			'messages.serverLimitBody' => 'Error del servidor (HTTP 500). Un límite de ancho de banda/transcodificación probablemente rechazó esta sesión. Pide al propietario que lo ajuste.',
 			'messages.logsUploaded' => 'Registros subidos',
-			'messages.logsUploadFailed' => 'Error al subir registros',
-			'messages.logId' => 'ID de registro',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Error al subir registros',
+			'messages.logId' => 'ID de registro',
 			'subtitlingStyling.text' => 'Texto',
 			'subtitlingStyling.border' => 'Borde',
 			'subtitlingStyling.background' => 'Fondo',
@@ -2669,6 +2695,7 @@ extension on TranslationsEs {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licencias',
 			'navigation.libraries' => 'Medios',
 			'navigation.downloads' => 'Descargas',
+			'navigation.watchlist' => 'Favoritos',
 			'navigation.liveTv' => 'TV en vivo',
 			'liveTv.title' => 'TV en vivo',
 			'liveTv.guide' => 'Guía',
@@ -2949,11 +2976,11 @@ extension on TranslationsEs {
 			'companionRemote.pairing.validationHostFormat' => 'El formato debe ser IP:puerto (ej. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Tiempo de conexión agotado. Usa la misma red en ambos dispositivos.',
 			'companionRemote.pairing.sessionNotFound' => 'Dispositivo no encontrado. Asegúrate de que Plezy esté en ejecución en el host.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Autenticación fallida. Ambos dispositivos necesitan la misma cuenta Plex.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Error al conectar: ${error}',
 			'companionRemote.remote.disconnectConfirm' => '¿Quieres desconectarte de la sesión remota?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Reconectando...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Intento ${current} de 5',
 			'companionRemote.remote.retryNow' => 'Reintentar ahora',
@@ -3207,6 +3234,17 @@ extension on TranslationsEs {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Inicia sesión en un servidor Jellyfin. Se vincula a ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Tomar prestado de otro perfil',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Reutiliza la conexión de otro perfil. Los perfiles protegidos con PIN requieren un PIN.',
+			'watchlist.title' => 'Favoritos',
+			'watchlist.movies' => 'Películas',
+			'watchlist.shows' => 'Series',
+			'watchlist.seasons' => 'Temporadas',
+			'watchlist.episodes' => 'Episodios',
+			'watchlist.emptyTitle' => 'No hay favoritos',
+			'watchlist.emptySubtitle' => 'Agrega películas y series a favoritos para encontrarlas aquí.',
+			'watchlist.clearAll' => 'Eliminar todos',
+			'watchlist.clearAllConfirm' => '¿Eliminar todos los favoritos? Esto no se puede deshacer.',
+			'watchlist.added' => 'Agregado a favoritos',
+			'watchlist.removed' => 'Eliminado de favoritos',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_fr.g.dart
+++ b/lib/i18n/strings_fr.g.dart
@@ -85,6 +85,7 @@ class TranslationsFr extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktFr trakt = _TranslationsTraktFr._(_root);
 	@override late final _TranslationsTrackersFr trackers = _TranslationsTrackersFr._(_root);
 	@override late final _TranslationsAddServerFr addServer = _TranslationsAddServerFr._(_root);
+	@override late final _TranslationsWatchlistFr watchlist = _TranslationsWatchlistFr._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsFr extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Lire la bande-annonce';
 	@override String get markAsWatched => 'Marqué comme vu';
 	@override String get markAsUnwatched => 'Marqué comme non vu';
+	@override String get bookmark => 'Ajouter aux favoris';
+	@override String get removeBookmark => 'Retirer des favoris';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationFr extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Medias';
 	@override String get downloads => 'Téléch.';
+	@override String get watchlist => 'Favoris';
 	@override String get liveTv => 'TV direct';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerFr extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Connectez-vous à un serveur Jellyfin. Lié à ${name}.';
 	@override String get borrowFromAnotherProfile => 'Emprunter à un autre profil';
 	@override String get borrowFromAnotherProfileSubtitle => 'Réutiliser la connexion d\'un autre profil. Les profils protégés par PIN exigent un PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistFr extends TranslationsWatchlistEn {
+	_TranslationsWatchlistFr._(TranslationsFr root) : this._root = root, super.internal(root);
+
+	final TranslationsFr _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Favoris';
+	@override String get movies => 'Films';
+	@override String get shows => 'Séries';
+	@override String get seasons => 'Saisons';
+	@override String get episodes => 'Épisodes';
+	@override String get emptyTitle => 'Aucun favori';
+	@override String get emptySubtitle => 'Ajoutez des films et séries aux favoris pour les retrouver ici.';
+	@override String get clearAll => 'Tout effacer';
+	@override String get clearAllConfirm => 'Supprimer tous les favoris ? Cette action est irréversible.';
+	@override String get added => 'Ajouté aux favoris';
+	@override String get removed => 'Retiré des favoris';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsFr {
 			'tooltips.playTrailer' => 'Lire la bande-annonce',
 			'tooltips.markAsWatched' => 'Marqué comme vu',
 			'tooltips.markAsUnwatched' => 'Marqué comme non vu',
+			'tooltips.bookmark' => 'Ajouter aux favoris',
+			'tooltips.removeBookmark' => 'Retirer des favoris',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Sous-titres',
 			'videoControls.resetToZero' => 'Réinitialiser à 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsFr {
 			'messages.serverLimitTitle' => 'Échec de la lecture',
 			'messages.serverLimitBody' => 'Erreur serveur (HTTP 500). Une limite de bande passante/transcodage a probablement rejeté cette session. Demandez au propriétaire de l\'ajuster.',
 			'messages.logsUploaded' => 'Logs envoyés',
-			'messages.logsUploadFailed' => 'Échec de l\'envoi des logs',
-			'messages.logId' => 'ID du log',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Échec de l\'envoi des logs',
+			'messages.logId' => 'ID du log',
 			'subtitlingStyling.text' => 'Texte',
 			'subtitlingStyling.border' => 'Bordure',
 			'subtitlingStyling.background' => 'Arrière-plan',
@@ -2669,6 +2695,7 @@ extension on TranslationsFr {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licences',
 			'navigation.libraries' => 'Medias',
 			'navigation.downloads' => 'Téléch.',
+			'navigation.watchlist' => 'Favoris',
 			'navigation.liveTv' => 'TV direct',
 			'liveTv.title' => 'TV en direct',
 			'liveTv.guide' => 'Guide',
@@ -2949,11 +2976,11 @@ extension on TranslationsFr {
 			'companionRemote.pairing.validationHostFormat' => 'Le format doit être IP:port (ex. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Connexion expirée. Utilisez le même réseau sur les deux appareils.',
 			'companionRemote.pairing.sessionNotFound' => 'Appareil introuvable. Assurez-vous que Plezy fonctionne sur l\'hôte.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Échec de l\'authentification. Les deux appareils doivent utiliser le même compte Plex.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Échec de la connexion : ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Voulez-vous vous déconnecter de la session distante ?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Reconnexion...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Tentative ${current} sur 5',
 			'companionRemote.remote.retryNow' => 'Réessayer maintenant',
@@ -3207,6 +3234,17 @@ extension on TranslationsFr {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Connectez-vous à un serveur Jellyfin. Lié à ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Emprunter à un autre profil',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Réutiliser la connexion d\'un autre profil. Les profils protégés par PIN exigent un PIN.',
+			'watchlist.title' => 'Favoris',
+			'watchlist.movies' => 'Films',
+			'watchlist.shows' => 'Séries',
+			'watchlist.seasons' => 'Saisons',
+			'watchlist.episodes' => 'Épisodes',
+			'watchlist.emptyTitle' => 'Aucun favori',
+			'watchlist.emptySubtitle' => 'Ajoutez des films et séries aux favoris pour les retrouver ici.',
+			'watchlist.clearAll' => 'Tout effacer',
+			'watchlist.clearAllConfirm' => 'Supprimer tous les favoris ? Cette action est irréversible.',
+			'watchlist.added' => 'Ajouté aux favoris',
+			'watchlist.removed' => 'Retiré des favoris',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -85,6 +85,7 @@ class TranslationsIt extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktIt trakt = _TranslationsTraktIt._(_root);
 	@override late final _TranslationsTrackersIt trackers = _TranslationsTrackersIt._(_root);
 	@override late final _TranslationsAddServerIt addServer = _TranslationsAddServerIt._(_root);
+	@override late final _TranslationsWatchlistIt watchlist = _TranslationsWatchlistIt._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsIt extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Riproduci trailer';
 	@override String get markAsWatched => 'Segna come visto';
 	@override String get markAsUnwatched => 'Segna come non visto';
+	@override String get bookmark => 'Aggiungi ai preferiti';
+	@override String get removeBookmark => 'Rimuovi dai preferiti';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationIt extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Librerie';
 	@override String get downloads => 'Download';
+	@override String get watchlist => 'Preferiti';
 	@override String get liveTv => 'TV Live';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerIt extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Accedi a un server Jellyfin. Collegato a ${name}.';
 	@override String get borrowFromAnotherProfile => 'Prendi in prestito da un altro profilo';
 	@override String get borrowFromAnotherProfileSubtitle => 'Riutilizza la connessione di un altro profilo. I profili protetti da PIN richiedono un PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistIt extends TranslationsWatchlistEn {
+	_TranslationsWatchlistIt._(TranslationsIt root) : this._root = root, super.internal(root);
+
+	final TranslationsIt _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Preferiti';
+	@override String get movies => 'Film';
+	@override String get shows => 'Serie TV';
+	@override String get seasons => 'Stagioni';
+	@override String get episodes => 'Episodi';
+	@override String get emptyTitle => 'Nessun preferito';
+	@override String get emptySubtitle => 'Aggiungi film e serie ai preferiti per ritrovarli qui.';
+	@override String get clearAll => 'Rimuovi tutti';
+	@override String get clearAllConfirm => 'Rimuovere tutti i preferiti? Non puoi annullare questa azione.';
+	@override String get added => 'Aggiunto ai preferiti';
+	@override String get removed => 'Rimosso dai preferiti';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsIt {
 			'tooltips.playTrailer' => 'Riproduci trailer',
 			'tooltips.markAsWatched' => 'Segna come visto',
 			'tooltips.markAsUnwatched' => 'Segna come non visto',
+			'tooltips.bookmark' => 'Aggiungi ai preferiti',
+			'tooltips.removeBookmark' => 'Rimuovi dai preferiti',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Sottotitoli',
 			'videoControls.resetToZero' => 'Riporta a 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsIt {
 			'messages.serverLimitTitle' => 'Riproduzione non riuscita',
 			'messages.serverLimitBody' => 'Errore server (HTTP 500). Un limite di banda/transcodifica probabilmente ha rifiutato questa sessione. Chiedi al proprietario di modificarlo.',
 			'messages.logsUploaded' => 'Log caricati',
-			'messages.logsUploadFailed' => 'Caricamento log fallito',
-			'messages.logId' => 'ID log',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Caricamento log fallito',
+			'messages.logId' => 'ID log',
 			'subtitlingStyling.text' => 'Testo',
 			'subtitlingStyling.border' => 'Bordo',
 			'subtitlingStyling.background' => 'Sfondo',
@@ -2669,6 +2695,7 @@ extension on TranslationsIt {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licenze',
 			'navigation.libraries' => 'Librerie',
 			'navigation.downloads' => 'Download',
+			'navigation.watchlist' => 'Preferiti',
 			'navigation.liveTv' => 'TV Live',
 			'liveTv.title' => 'TV in diretta',
 			'liveTv.guide' => 'Guida',
@@ -2949,11 +2976,11 @@ extension on TranslationsIt {
 			'companionRemote.pairing.validationHostFormat' => 'Il formato deve essere IP:porta (es. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Connessione scaduta. Usa la stessa rete su entrambi i dispositivi.',
 			'companionRemote.pairing.sessionNotFound' => 'Dispositivo non trovato. Assicurati che Plezy sia in esecuzione sull\'host.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Autenticazione non riuscita. Entrambi i dispositivi devono usare lo stesso account Plex.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Connessione fallita: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Vuoi disconnetterti dalla sessione remota?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Riconnessione...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Tentativo ${current} di 5',
 			'companionRemote.remote.retryNow' => 'Riprova ora',
@@ -3207,6 +3234,17 @@ extension on TranslationsIt {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Accedi a un server Jellyfin. Collegato a ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Prendi in prestito da un altro profilo',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Riutilizza la connessione di un altro profilo. I profili protetti da PIN richiedono un PIN.',
+			'watchlist.title' => 'Preferiti',
+			'watchlist.movies' => 'Film',
+			'watchlist.shows' => 'Serie TV',
+			'watchlist.seasons' => 'Stagioni',
+			'watchlist.episodes' => 'Episodi',
+			'watchlist.emptyTitle' => 'Nessun preferito',
+			'watchlist.emptySubtitle' => 'Aggiungi film e serie ai preferiti per ritrovarli qui.',
+			'watchlist.clearAll' => 'Rimuovi tutti',
+			'watchlist.clearAllConfirm' => 'Rimuovere tutti i preferiti? Non puoi annullare questa azione.',
+			'watchlist.added' => 'Aggiunto ai preferiti',
+			'watchlist.removed' => 'Rimosso dai preferiti',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -85,6 +85,7 @@ class TranslationsJa extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktJa trakt = _TranslationsTraktJa._(_root);
 	@override late final _TranslationsTrackersJa trackers = _TranslationsTrackersJa._(_root);
 	@override late final _TranslationsAddServerJa addServer = _TranslationsAddServerJa._(_root);
+	@override late final _TranslationsWatchlistJa watchlist = _TranslationsWatchlistJa._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsJa extends TranslationsTooltipsEn {
 	@override String get playTrailer => '予告編を再生';
 	@override String get markAsWatched => '視聴済みにする';
 	@override String get markAsUnwatched => '未視聴にする';
+	@override String get bookmark => 'ブックマークに追加';
+	@override String get removeBookmark => 'ブックマークを解除';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationJa extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'ライブラリ';
 	@override String get downloads => 'ダウンロード';
+	@override String get watchlist => 'ブックマーク';
 	@override String get liveTv => 'ライブTV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerJa extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Jellyfinサーバーにサインインします。${name}に紐付けられます。';
 	@override String get borrowFromAnotherProfile => '別のプロファイルから借りる';
 	@override String get borrowFromAnotherProfileSubtitle => '別のプロフィールの接続を再利用します。PIN保護されたプロフィールにはPINが必要です。';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistJa extends TranslationsWatchlistEn {
+	_TranslationsWatchlistJa._(TranslationsJa root) : this._root = root, super.internal(root);
+
+	final TranslationsJa _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'ブックマーク';
+	@override String get movies => '映画';
+	@override String get shows => 'ドラマ';
+	@override String get seasons => 'シーズン';
+	@override String get episodes => 'エピソード';
+	@override String get emptyTitle => 'ブックマークはありません';
+	@override String get emptySubtitle => '映画やドラマをブックマークすると、ここから簡単に見つけられます。';
+	@override String get clearAll => 'すべて削除';
+	@override String get clearAllConfirm => 'すべてのブックマークを削除しますか？この操作は元に戻せません。';
+	@override String get added => 'ブックマークに追加しました';
+	@override String get removed => 'ブックマークを解除しました';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsJa {
 			'tooltips.playTrailer' => '予告編を再生',
 			'tooltips.markAsWatched' => '視聴済みにする',
 			'tooltips.markAsUnwatched' => '未視聴にする',
+			'tooltips.bookmark' => 'ブックマークに追加',
+			'tooltips.removeBookmark' => 'ブックマークを解除',
 			'videoControls.audioLabel' => '音声',
 			'videoControls.subtitlesLabel' => '字幕',
 			'videoControls.resetToZero' => '0msにリセット',
@@ -2436,10 +2462,10 @@ extension on TranslationsJa {
 			'messages.serverLimitTitle' => '再生に失敗しました',
 			'messages.serverLimitBody' => 'サーバーエラー（HTTP 500）。帯域幅/トランスコード制限により拒否された可能性があります。所有者に調整を依頼してください。',
 			'messages.logsUploaded' => 'ログをアップロードしました',
-			'messages.logsUploadFailed' => 'ログのアップロードに失敗しました',
-			'messages.logId' => 'ログID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'ログのアップロードに失敗しました',
+			'messages.logId' => 'ログID',
 			'subtitlingStyling.text' => 'テキスト',
 			'subtitlingStyling.border' => '枠線',
 			'subtitlingStyling.background' => '背景',
@@ -2669,6 +2695,7 @@ extension on TranslationsJa {
 			'licenses.licensesCount' => ({required Object count}) => '${count}件のライセンス',
 			'navigation.libraries' => 'ライブラリ',
 			'navigation.downloads' => 'ダウンロード',
+			'navigation.watchlist' => 'ブックマーク',
 			'navigation.liveTv' => 'ライブTV',
 			'liveTv.title' => 'ライブTV',
 			'liveTv.guide' => '番組表',
@@ -2949,11 +2976,11 @@ extension on TranslationsJa {
 			'companionRemote.pairing.validationHostFormat' => '形式はIP:ポートである必要があります（例: 192.168.1.100:48632）',
 			'companionRemote.pairing.connectionTimedOut' => '接続がタイムアウトしました。両方のデバイスで同じネットワークを使用してください。',
 			'companionRemote.pairing.sessionNotFound' => 'デバイスが見つかりません。ホストでPlezyが実行中か確認してください。',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => '認証に失敗しました。両方のデバイスで同じPlexアカウントが必要です。',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => '接続に失敗しました: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'リモートセッションから切断しますか？',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => '再接続中...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => '試行 ${current}/5',
 			'companionRemote.remote.retryNow' => '今すぐ再試行',
@@ -3207,6 +3234,17 @@ extension on TranslationsJa {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Jellyfinサーバーにサインインします。${name}に紐付けられます。',
 			'addServer.borrowFromAnotherProfile' => '別のプロファイルから借りる',
 			'addServer.borrowFromAnotherProfileSubtitle' => '別のプロフィールの接続を再利用します。PIN保護されたプロフィールにはPINが必要です。',
+			'watchlist.title' => 'ブックマーク',
+			'watchlist.movies' => '映画',
+			'watchlist.shows' => 'ドラマ',
+			'watchlist.seasons' => 'シーズン',
+			'watchlist.episodes' => 'エピソード',
+			'watchlist.emptyTitle' => 'ブックマークはありません',
+			'watchlist.emptySubtitle' => '映画やドラマをブックマークすると、ここから簡単に見つけられます。',
+			'watchlist.clearAll' => 'すべて削除',
+			'watchlist.clearAllConfirm' => 'すべてのブックマークを削除しますか？この操作は元に戻せません。',
+			'watchlist.added' => 'ブックマークに追加しました',
+			'watchlist.removed' => 'ブックマークを解除しました',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -85,6 +85,7 @@ class TranslationsKo extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktKo trakt = _TranslationsTraktKo._(_root);
 	@override late final _TranslationsTrackersKo trackers = _TranslationsTrackersKo._(_root);
 	@override late final _TranslationsAddServerKo addServer = _TranslationsAddServerKo._(_root);
+	@override late final _TranslationsWatchlistKo watchlist = _TranslationsWatchlistKo._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsKo extends TranslationsTooltipsEn {
 	@override String get playTrailer => '예고편 재생';
 	@override String get markAsWatched => '시청 완료로 표시';
 	@override String get markAsUnwatched => '시청 안 함으로 표시';
+	@override String get bookmark => '북마크 추가';
+	@override String get removeBookmark => '북마크 제거';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationKo extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => '미디어 라이브러리';
 	@override String get downloads => '다운로드';
+	@override String get watchlist => '북마크';
 	@override String get liveTv => '실시간 TV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerKo extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Jellyfin 서버에 로그인합니다. ${name}에 연결됩니다.';
 	@override String get borrowFromAnotherProfile => '다른 프로필에서 빌리기';
 	@override String get borrowFromAnotherProfileSubtitle => '다른 프로필의 연결을 재사용합니다. PIN으로 보호된 프로필에는 PIN이 필요합니다.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistKo extends TranslationsWatchlistEn {
+	_TranslationsWatchlistKo._(TranslationsKo root) : this._root = root, super.internal(root);
+
+	final TranslationsKo _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '북마크';
+	@override String get movies => '영화';
+	@override String get shows => '드라마';
+	@override String get seasons => '시즌';
+	@override String get episodes => '에피소드';
+	@override String get emptyTitle => '북마크가 없습니다';
+	@override String get emptySubtitle => '영화와 드라마를 북마크하면 여기서 쉽게 찾을 수 있습니다.';
+	@override String get clearAll => '모두 삭제';
+	@override String get clearAllConfirm => '모든 북마크를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.';
+	@override String get added => '북마크에 추가됨';
+	@override String get removed => '북마크에서 제거됨';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsKo {
 			'tooltips.playTrailer' => '예고편 재생',
 			'tooltips.markAsWatched' => '시청 완료로 표시',
 			'tooltips.markAsUnwatched' => '시청 안 함으로 표시',
+			'tooltips.bookmark' => '북마크 추가',
+			'tooltips.removeBookmark' => '북마크 제거',
 			'videoControls.audioLabel' => '오디오',
 			'videoControls.subtitlesLabel' => '자막',
 			'videoControls.resetToZero' => '0ms로 재설정',
@@ -2436,10 +2462,10 @@ extension on TranslationsKo {
 			'messages.serverLimitTitle' => '재생 실패',
 			'messages.serverLimitBody' => '서버 오류(HTTP 500). 대역폭/트랜스코딩 제한으로 세션이 거부된 것 같습니다. 소유자에게 조정을 요청하세요.',
 			'messages.logsUploaded' => '로그 업로드 완료',
-			'messages.logsUploadFailed' => '로그 업로드 실패',
-			'messages.logId' => '로그 ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => '로그 업로드 실패',
+			'messages.logId' => '로그 ID',
 			'subtitlingStyling.text' => '텍스트',
 			'subtitlingStyling.border' => '테두리',
 			'subtitlingStyling.background' => '배경',
@@ -2669,6 +2695,7 @@ extension on TranslationsKo {
 			'licenses.licensesCount' => ({required Object count}) => '${count} 개의 라이선스',
 			'navigation.libraries' => '미디어 라이브러리',
 			'navigation.downloads' => '다운로드',
+			'navigation.watchlist' => '북마크',
 			'navigation.liveTv' => '실시간 TV',
 			'liveTv.title' => '실시간 TV',
 			'liveTv.guide' => '편성표',
@@ -2949,11 +2976,11 @@ extension on TranslationsKo {
 			'companionRemote.pairing.validationHostFormat' => '형식은 IP:포트여야 합니다 (예: 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => '연결 시간이 초과되었습니다. 두 기기에서 같은 네트워크를 사용하세요.',
 			'companionRemote.pairing.sessionNotFound' => '기기를 찾을 수 없습니다. 호스트에서 Plezy가 실행 중인지 확인하세요.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => '인증에 실패했습니다. 두 기기 모두 같은 Plex 계정이 필요합니다.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => '연결 실패: ${error}',
 			'companionRemote.remote.disconnectConfirm' => '원격 세션 연결을 해제하시겠습니까?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => '재연결 중...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => '${current}/5 시도 중',
 			'companionRemote.remote.retryNow' => '지금 재시도',
@@ -3207,6 +3234,17 @@ extension on TranslationsKo {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Jellyfin 서버에 로그인합니다. ${name}에 연결됩니다.',
 			'addServer.borrowFromAnotherProfile' => '다른 프로필에서 빌리기',
 			'addServer.borrowFromAnotherProfileSubtitle' => '다른 프로필의 연결을 재사용합니다. PIN으로 보호된 프로필에는 PIN이 필요합니다.',
+			'watchlist.title' => '북마크',
+			'watchlist.movies' => '영화',
+			'watchlist.shows' => '드라마',
+			'watchlist.seasons' => '시즌',
+			'watchlist.episodes' => '에피소드',
+			'watchlist.emptyTitle' => '북마크가 없습니다',
+			'watchlist.emptySubtitle' => '영화와 드라마를 북마크하면 여기서 쉽게 찾을 수 있습니다.',
+			'watchlist.clearAll' => '모두 삭제',
+			'watchlist.clearAllConfirm' => '모든 북마크를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.',
+			'watchlist.added' => '북마크에 추가됨',
+			'watchlist.removed' => '북마크에서 제거됨',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_nb.g.dart
+++ b/lib/i18n/strings_nb.g.dart
@@ -85,6 +85,7 @@ class TranslationsNb extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktNb trakt = _TranslationsTraktNb._(_root);
 	@override late final _TranslationsTrackersNb trackers = _TranslationsTrackersNb._(_root);
 	@override late final _TranslationsAddServerNb addServer = _TranslationsAddServerNb._(_root);
+	@override late final _TranslationsWatchlistNb watchlist = _TranslationsWatchlistNb._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsNb extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Spill trailer';
 	@override String get markAsWatched => 'Merk som sett';
 	@override String get markAsUnwatched => 'Merk som usett';
+	@override String get bookmark => 'Legg til bokmerke';
+	@override String get removeBookmark => 'Fjern bokmerke';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationNb extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Biblioteker';
 	@override String get downloads => 'Nedlastinger';
+	@override String get watchlist => 'Bokmerker';
 	@override String get liveTv => 'Direkte-TV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerNb extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Logg på en Jellyfin-server. Knyttes til ${name}.';
 	@override String get borrowFromAnotherProfile => 'Lån fra en annen profil';
 	@override String get borrowFromAnotherProfileSubtitle => 'Gjenbruk en annen profils tilkobling. PIN-beskyttede profiler krever PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistNb extends TranslationsWatchlistEn {
+	_TranslationsWatchlistNb._(TranslationsNb root) : this._root = root, super.internal(root);
+
+	final TranslationsNb _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bokmerker';
+	@override String get movies => 'Filmer';
+	@override String get shows => 'Serier';
+	@override String get seasons => 'Sesonger';
+	@override String get episodes => 'Episoder';
+	@override String get emptyTitle => 'Ingen bokmerker';
+	@override String get emptySubtitle => 'Legg til filmer og serier i bokmerkene dine for enkel tilgang.';
+	@override String get clearAll => 'Fjern alle';
+	@override String get clearAllConfirm => 'Fjern alle bokmerker? Dette kan ikke angres.';
+	@override String get added => 'Lagt til i bokmerker';
+	@override String get removed => 'Fjernet fra bokmerker';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsNb {
 			'tooltips.playTrailer' => 'Spill trailer',
 			'tooltips.markAsWatched' => 'Merk som sett',
 			'tooltips.markAsUnwatched' => 'Merk som usett',
+			'tooltips.bookmark' => 'Legg til bokmerke',
+			'tooltips.removeBookmark' => 'Fjern bokmerke',
 			'videoControls.audioLabel' => 'Lyd',
 			'videoControls.subtitlesLabel' => 'Undertekster',
 			'videoControls.resetToZero' => 'Tilbakestill til 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsNb {
 			'messages.serverLimitTitle' => 'Avspilling mislyktes',
 			'messages.serverLimitBody' => 'Serverfeil (HTTP 500). En båndbredde-/transkodingsgrense avviste trolig økten. Be eieren justere den.',
 			'messages.logsUploaded' => 'Logger lastet opp',
-			'messages.logsUploadFailed' => 'Kunne ikke laste opp logger',
-			'messages.logId' => 'Logg-ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Kunne ikke laste opp logger',
+			'messages.logId' => 'Logg-ID',
 			'subtitlingStyling.text' => 'Tekst',
 			'subtitlingStyling.border' => 'Kantlinje',
 			'subtitlingStyling.background' => 'Bakgrunn',
@@ -2669,6 +2695,7 @@ extension on TranslationsNb {
 			'licenses.licensesCount' => ({required Object count}) => '${count} lisenser',
 			'navigation.libraries' => 'Biblioteker',
 			'navigation.downloads' => 'Nedlastinger',
+			'navigation.watchlist' => 'Bokmerker',
 			'navigation.liveTv' => 'Direkte-TV',
 			'liveTv.title' => 'Direkte-TV',
 			'liveTv.guide' => 'Programguide',
@@ -2949,11 +2976,11 @@ extension on TranslationsNb {
 			'companionRemote.pairing.validationHostFormat' => 'Format må være IP:port (f.eks. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Tilkoblingen fikk tidsavbrudd. Bruk samme nettverk på begge enheter.',
 			'companionRemote.pairing.sessionNotFound' => 'Enhet ikke funnet. Sørg for at Plezy kjører på verten.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Autentisering mislyktes. Begge enheter må bruke samme Plex-konto.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Kunne ikke koble til: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Vil du koble fra fjernøkten?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Kobler til på nytt...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Forsøk ${current} av 5',
 			'companionRemote.remote.retryNow' => 'Prøv nå',
@@ -3207,6 +3234,17 @@ extension on TranslationsNb {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Logg på en Jellyfin-server. Knyttes til ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Lån fra en annen profil',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Gjenbruk en annen profils tilkobling. PIN-beskyttede profiler krever PIN.',
+			'watchlist.title' => 'Bokmerker',
+			'watchlist.movies' => 'Filmer',
+			'watchlist.shows' => 'Serier',
+			'watchlist.seasons' => 'Sesonger',
+			'watchlist.episodes' => 'Episoder',
+			'watchlist.emptyTitle' => 'Ingen bokmerker',
+			'watchlist.emptySubtitle' => 'Legg til filmer og serier i bokmerkene dine for enkel tilgang.',
+			'watchlist.clearAll' => 'Fjern alle',
+			'watchlist.clearAllConfirm' => 'Fjern alle bokmerker? Dette kan ikke angres.',
+			'watchlist.added' => 'Lagt til i bokmerker',
+			'watchlist.removed' => 'Fjernet fra bokmerker',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_nl.g.dart
+++ b/lib/i18n/strings_nl.g.dart
@@ -85,6 +85,7 @@ class TranslationsNl extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktNl trakt = _TranslationsTraktNl._(_root);
 	@override late final _TranslationsTrackersNl trackers = _TranslationsTrackersNl._(_root);
 	@override late final _TranslationsAddServerNl addServer = _TranslationsAddServerNl._(_root);
+	@override late final _TranslationsWatchlistNl watchlist = _TranslationsWatchlistNl._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsNl extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Trailer afspelen';
 	@override String get markAsWatched => 'Markeer als gekeken';
 	@override String get markAsUnwatched => 'Markeer als ongekeken';
+	@override String get bookmark => 'Toevoegen aan bladwijzers';
+	@override String get removeBookmark => 'Verwijderen uit bladwijzers';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationNl extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Media';
 	@override String get downloads => 'Downloads';
+	@override String get watchlist => 'Bladwijzers';
 	@override String get liveTv => 'Live TV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerNl extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Log in op een Jellyfin-server. Wordt gekoppeld aan ${name}.';
 	@override String get borrowFromAnotherProfile => 'Lenen van een ander profiel';
 	@override String get borrowFromAnotherProfileSubtitle => 'Hergebruik de verbinding van een ander profiel. PIN-beveiligde profielen vereisen een PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistNl extends TranslationsWatchlistEn {
+	_TranslationsWatchlistNl._(TranslationsNl root) : this._root = root, super.internal(root);
+
+	final TranslationsNl _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bladwijzers';
+	@override String get movies => 'Films';
+	@override String get shows => 'Series';
+	@override String get seasons => 'Seizoenen';
+	@override String get episodes => 'Afleveringen';
+	@override String get emptyTitle => 'Geen bladwijzers';
+	@override String get emptySubtitle => 'Voeg films en series toe aan bladwijzers voor snelle toegang.';
+	@override String get clearAll => 'Alles wissen';
+	@override String get clearAllConfirm => 'Alle bladwijzers verwijderen? Dit kan niet ongedaan worden gemaakt.';
+	@override String get added => 'Toegevoegd aan bladwijzers';
+	@override String get removed => 'Verwijderd uit bladwijzers';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsNl {
 			'tooltips.playTrailer' => 'Trailer afspelen',
 			'tooltips.markAsWatched' => 'Markeer als gekeken',
 			'tooltips.markAsUnwatched' => 'Markeer als ongekeken',
+			'tooltips.bookmark' => 'Toevoegen aan bladwijzers',
+			'tooltips.removeBookmark' => 'Verwijderen uit bladwijzers',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Ondertitels',
 			'videoControls.resetToZero' => 'Reset naar 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsNl {
 			'messages.serverLimitTitle' => 'Afspelen mislukt',
 			'messages.serverLimitBody' => 'Serverfout (HTTP 500). Waarschijnlijk weigerde een bandbreedte-/transcodeerlimiet deze sessie. Vraag de eigenaar dit aan te passen.',
 			'messages.logsUploaded' => 'Logs geüpload',
-			'messages.logsUploadFailed' => 'Uploaden van logs mislukt',
-			'messages.logId' => 'Log-ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Uploaden van logs mislukt',
+			'messages.logId' => 'Log-ID',
 			'subtitlingStyling.text' => 'Tekst',
 			'subtitlingStyling.border' => 'Rand',
 			'subtitlingStyling.background' => 'Achtergrond',
@@ -2669,6 +2695,7 @@ extension on TranslationsNl {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licenties',
 			'navigation.libraries' => 'Media',
 			'navigation.downloads' => 'Downloads',
+			'navigation.watchlist' => 'Bladwijzers',
 			'navigation.liveTv' => 'Live TV',
 			'liveTv.title' => 'Live TV',
 			'liveTv.guide' => 'Gids',
@@ -2949,11 +2976,11 @@ extension on TranslationsNl {
 			'companionRemote.pairing.validationHostFormat' => 'Formaat moet IP:poort zijn (bijv. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Verbinding verlopen. Gebruik hetzelfde netwerk op beide apparaten.',
 			'companionRemote.pairing.sessionNotFound' => 'Apparaat niet gevonden. Zorg dat Plezy op de host draait.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Authenticatie mislukt. Beide apparaten hebben hetzelfde Plex-account nodig.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Kan niet verbinden: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Wil je de verbinding met de externe sessie verbreken?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Opnieuw verbinden...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Poging ${current} van 5',
 			'companionRemote.remote.retryNow' => 'Nu opnieuw proberen',
@@ -3207,6 +3234,17 @@ extension on TranslationsNl {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Log in op een Jellyfin-server. Wordt gekoppeld aan ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Lenen van een ander profiel',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Hergebruik de verbinding van een ander profiel. PIN-beveiligde profielen vereisen een PIN.',
+			'watchlist.title' => 'Bladwijzers',
+			'watchlist.movies' => 'Films',
+			'watchlist.shows' => 'Series',
+			'watchlist.seasons' => 'Seizoenen',
+			'watchlist.episodes' => 'Afleveringen',
+			'watchlist.emptyTitle' => 'Geen bladwijzers',
+			'watchlist.emptySubtitle' => 'Voeg films en series toe aan bladwijzers voor snelle toegang.',
+			'watchlist.clearAll' => 'Alles wissen',
+			'watchlist.clearAllConfirm' => 'Alle bladwijzers verwijderen? Dit kan niet ongedaan worden gemaakt.',
+			'watchlist.added' => 'Toegevoegd aan bladwijzers',
+			'watchlist.removed' => 'Verwijderd uit bladwijzers',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_pl.g.dart
+++ b/lib/i18n/strings_pl.g.dart
@@ -85,6 +85,7 @@ class TranslationsPl extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktPl trakt = _TranslationsTraktPl._(_root);
 	@override late final _TranslationsTrackersPl trackers = _TranslationsTrackersPl._(_root);
 	@override late final _TranslationsAddServerPl addServer = _TranslationsAddServerPl._(_root);
+	@override late final _TranslationsWatchlistPl watchlist = _TranslationsWatchlistPl._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsPl extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Odtwórz zwiastun';
 	@override String get markAsWatched => 'Oznacz jako obejrzane';
 	@override String get markAsUnwatched => 'Oznacz jako nieobejrzane';
+	@override String get bookmark => 'Dodaj do zakładek';
+	@override String get removeBookmark => 'Usuń z zakładek';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationPl extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Biblioteki';
 	@override String get downloads => 'Pobrania';
+	@override String get watchlist => 'Zakładki';
 	@override String get liveTv => 'TV na żywo';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerPl extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Zaloguj się do serwera Jellyfin. Powiązane z ${name}.';
 	@override String get borrowFromAnotherProfile => 'Pożycz z innego profilu';
 	@override String get borrowFromAnotherProfileSubtitle => 'Użyj połączenia z innego profilu. Profile chronione PIN wymagają PIN-u.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistPl extends TranslationsWatchlistEn {
+	_TranslationsWatchlistPl._(TranslationsPl root) : this._root = root, super.internal(root);
+
+	final TranslationsPl _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Zakładki';
+	@override String get movies => 'Filmy';
+	@override String get shows => 'Seriale';
+	@override String get seasons => 'Sezony';
+	@override String get episodes => 'Odcinki';
+	@override String get emptyTitle => 'Brak zakładek';
+	@override String get emptySubtitle => 'Dodaj filmy i seriale do zakładek, aby mieć do nich szybki dostęp.';
+	@override String get clearAll => 'Usuń wszystkie';
+	@override String get clearAllConfirm => 'Usunąć wszystkie zakładki? Tej operacji nie można cofnąć.';
+	@override String get added => 'Dodano do zakładek';
+	@override String get removed => 'Usunięto z zakładek';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsPl {
 			'tooltips.playTrailer' => 'Odtwórz zwiastun',
 			'tooltips.markAsWatched' => 'Oznacz jako obejrzane',
 			'tooltips.markAsUnwatched' => 'Oznacz jako nieobejrzane',
+			'tooltips.bookmark' => 'Dodaj do zakładek',
+			'tooltips.removeBookmark' => 'Usuń z zakładek',
 			'videoControls.audioLabel' => 'Audio',
 			'videoControls.subtitlesLabel' => 'Napisy',
 			'videoControls.resetToZero' => 'Zresetuj do 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsPl {
 			'messages.serverLimitTitle' => 'Odtwarzanie nie powiodło się',
 			'messages.serverLimitBody' => 'Błąd serwera (HTTP 500). Limit przepustowości/transkodowania prawdopodobnie odrzucił tę sesję. Poproś właściciela o zmianę.',
 			'messages.logsUploaded' => 'Logi przesłane',
-			'messages.logsUploadFailed' => 'Nie udało się przesłać logów',
-			'messages.logId' => 'ID logu',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Nie udało się przesłać logów',
+			'messages.logId' => 'ID logu',
 			'subtitlingStyling.text' => 'Tekst',
 			'subtitlingStyling.border' => 'Obramowanie',
 			'subtitlingStyling.background' => 'Tło',
@@ -2669,6 +2695,7 @@ extension on TranslationsPl {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licencji',
 			'navigation.libraries' => 'Biblioteki',
 			'navigation.downloads' => 'Pobrania',
+			'navigation.watchlist' => 'Zakładki',
 			'navigation.liveTv' => 'TV na żywo',
 			'liveTv.title' => 'TV na żywo',
 			'liveTv.guide' => 'Przewodnik',
@@ -2949,11 +2976,11 @@ extension on TranslationsPl {
 			'companionRemote.pairing.validationHostFormat' => 'Format musi być IP:port (np. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Limit czasu połączenia. Użyj tej samej sieci na obu urządzeniach.',
 			'companionRemote.pairing.sessionNotFound' => 'Nie znaleziono urządzenia. Upewnij się, że Plezy działa na hoście.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Uwierzytelnianie nie powiodło się. Oba urządzenia muszą używać tego samego konta Plex.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Nie udało się połączyć: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Czy chcesz się rozłączyć od sesji zdalnej?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Ponowne łączenie...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Próba ${current} z 5',
 			'companionRemote.remote.retryNow' => 'Ponów teraz',
@@ -3207,6 +3234,17 @@ extension on TranslationsPl {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Zaloguj się do serwera Jellyfin. Powiązane z ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Pożycz z innego profilu',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Użyj połączenia z innego profilu. Profile chronione PIN wymagają PIN-u.',
+			'watchlist.title' => 'Zakładki',
+			'watchlist.movies' => 'Filmy',
+			'watchlist.shows' => 'Seriale',
+			'watchlist.seasons' => 'Sezony',
+			'watchlist.episodes' => 'Odcinki',
+			'watchlist.emptyTitle' => 'Brak zakładek',
+			'watchlist.emptySubtitle' => 'Dodaj filmy i seriale do zakładek, aby mieć do nich szybki dostęp.',
+			'watchlist.clearAll' => 'Usuń wszystkie',
+			'watchlist.clearAllConfirm' => 'Usunąć wszystkie zakładki? Tej operacji nie można cofnąć.',
+			'watchlist.added' => 'Dodano do zakładek',
+			'watchlist.removed' => 'Usunięto z zakładek',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_pt.g.dart
+++ b/lib/i18n/strings_pt.g.dart
@@ -85,6 +85,7 @@ class TranslationsPt extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktPt trakt = _TranslationsTraktPt._(_root);
 	@override late final _TranslationsTrackersPt trackers = _TranslationsTrackersPt._(_root);
 	@override late final _TranslationsAddServerPt addServer = _TranslationsAddServerPt._(_root);
+	@override late final _TranslationsWatchlistPt watchlist = _TranslationsWatchlistPt._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsPt extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Reproduzir trailer';
 	@override String get markAsWatched => 'Marcar como assistido';
 	@override String get markAsUnwatched => 'Marcar como não assistido';
+	@override String get bookmark => 'Adicionar aos favoritos';
+	@override String get removeBookmark => 'Remover dos favoritos';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationPt extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Bibliotecas';
 	@override String get downloads => 'Downloads';
+	@override String get watchlist => 'Favoritos';
 	@override String get liveTv => 'TV ao Vivo';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerPt extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Entre em um servidor Jellyfin. Vinculado a ${name}.';
 	@override String get borrowFromAnotherProfile => 'Pegar emprestado de outro perfil';
 	@override String get borrowFromAnotherProfileSubtitle => 'Reutilize a conexão de outro perfil. Perfis protegidos por PIN exigem PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistPt extends TranslationsWatchlistEn {
+	_TranslationsWatchlistPt._(TranslationsPt root) : this._root = root, super.internal(root);
+
+	final TranslationsPt _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Favoritos';
+	@override String get movies => 'Filmes';
+	@override String get shows => 'Séries';
+	@override String get seasons => 'Temporadas';
+	@override String get episodes => 'Episódios';
+	@override String get emptyTitle => 'Nenhum favorito';
+	@override String get emptySubtitle => 'Adicione filmes e séries aos favoritos para encontrá-los aqui.';
+	@override String get clearAll => 'Remover todos';
+	@override String get clearAllConfirm => 'Remover todos os favoritos? Esta ação não pode ser desfeita.';
+	@override String get added => 'Adicionado aos favoritos';
+	@override String get removed => 'Removido dos favoritos';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsPt {
 			'tooltips.playTrailer' => 'Reproduzir trailer',
 			'tooltips.markAsWatched' => 'Marcar como assistido',
 			'tooltips.markAsUnwatched' => 'Marcar como não assistido',
+			'tooltips.bookmark' => 'Adicionar aos favoritos',
+			'tooltips.removeBookmark' => 'Remover dos favoritos',
 			'videoControls.audioLabel' => 'Áudio',
 			'videoControls.subtitlesLabel' => 'Legendas',
 			'videoControls.resetToZero' => 'Redefinir para 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsPt {
 			'messages.serverLimitTitle' => 'Falha na reprodução',
 			'messages.serverLimitBody' => 'Erro do servidor (HTTP 500). Um limite de largura de banda/transcodificação provavelmente rejeitou esta sessão. Peça ao dono para ajustar.',
 			'messages.logsUploaded' => 'Logs enviados',
-			'messages.logsUploadFailed' => 'Falha ao enviar logs',
-			'messages.logId' => 'ID do Log',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Falha ao enviar logs',
+			'messages.logId' => 'ID do Log',
 			'subtitlingStyling.text' => 'Texto',
 			'subtitlingStyling.border' => 'Borda',
 			'subtitlingStyling.background' => 'Fundo',
@@ -2669,6 +2695,7 @@ extension on TranslationsPt {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licenças',
 			'navigation.libraries' => 'Bibliotecas',
 			'navigation.downloads' => 'Downloads',
+			'navigation.watchlist' => 'Favoritos',
 			'navigation.liveTv' => 'TV ao Vivo',
 			'liveTv.title' => 'TV ao Vivo',
 			'liveTv.guide' => 'Guia',
@@ -2949,11 +2976,11 @@ extension on TranslationsPt {
 			'companionRemote.pairing.validationHostFormat' => 'O formato deve ser IP:porta (ex. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Conexão expirou. Use a mesma rede nos dois dispositivos.',
 			'companionRemote.pairing.sessionNotFound' => 'Dispositivo não encontrado. Verifique se Plezy está rodando no host.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Falha na autenticação. Ambos os dispositivos precisam da mesma conta Plex.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Falha ao conectar: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Deseja desconectar da sessão remota?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Reconectando...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Tentativa ${current} de 5',
 			'companionRemote.remote.retryNow' => 'Tentar Agora',
@@ -3207,6 +3234,17 @@ extension on TranslationsPt {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Entre em um servidor Jellyfin. Vinculado a ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Pegar emprestado de outro perfil',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Reutilize a conexão de outro perfil. Perfis protegidos por PIN exigem PIN.',
+			'watchlist.title' => 'Favoritos',
+			'watchlist.movies' => 'Filmes',
+			'watchlist.shows' => 'Séries',
+			'watchlist.seasons' => 'Temporadas',
+			'watchlist.episodes' => 'Episódios',
+			'watchlist.emptyTitle' => 'Nenhum favorito',
+			'watchlist.emptySubtitle' => 'Adicione filmes e séries aos favoritos para encontrá-los aqui.',
+			'watchlist.clearAll' => 'Remover todos',
+			'watchlist.clearAllConfirm' => 'Remover todos os favoritos? Esta ação não pode ser desfeita.',
+			'watchlist.added' => 'Adicionado aos favoritos',
+			'watchlist.removed' => 'Removido dos favoritos',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_ru.g.dart
+++ b/lib/i18n/strings_ru.g.dart
@@ -85,6 +85,7 @@ class TranslationsRu extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktRu trakt = _TranslationsTraktRu._(_root);
 	@override late final _TranslationsTrackersRu trackers = _TranslationsTrackersRu._(_root);
 	@override late final _TranslationsAddServerRu addServer = _TranslationsAddServerRu._(_root);
+	@override late final _TranslationsWatchlistRu watchlist = _TranslationsWatchlistRu._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsRu extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Воспроизвести трейлер';
 	@override String get markAsWatched => 'Отметить как просмотренное';
 	@override String get markAsUnwatched => 'Отметить как непросмотренное';
+	@override String get bookmark => 'Добавить в закладки';
+	@override String get removeBookmark => 'Удалить из закладок';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationRu extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Библиотеки';
 	@override String get downloads => 'Загрузки';
+	@override String get watchlist => 'Закладки';
 	@override String get liveTv => 'ТВ в прямом эфире';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerRu extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Войдите на сервер Jellyfin. Привязывается к ${name}.';
 	@override String get borrowFromAnotherProfile => 'Одолжить из другого профиля';
 	@override String get borrowFromAnotherProfileSubtitle => 'Используйте подключение другого профиля. Для профилей с PIN нужен PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistRu extends TranslationsWatchlistEn {
+	_TranslationsWatchlistRu._(TranslationsRu root) : this._root = root, super.internal(root);
+
+	final TranslationsRu _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Закладки';
+	@override String get movies => 'Фильмы';
+	@override String get shows => 'Сериалы';
+	@override String get seasons => 'Сезоны';
+	@override String get episodes => 'Эпизоды';
+	@override String get emptyTitle => 'Нет закладок';
+	@override String get emptySubtitle => 'Добавляйте фильмы и сериалы в закладки, чтобы быстро их находить.';
+	@override String get clearAll => 'Очистить все';
+	@override String get clearAllConfirm => 'Удалить все закладки? Это действие нельзя отменить.';
+	@override String get added => 'Добавлено в закладки';
+	@override String get removed => 'Удалено из закладок';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsRu {
 			'tooltips.playTrailer' => 'Воспроизвести трейлер',
 			'tooltips.markAsWatched' => 'Отметить как просмотренное',
 			'tooltips.markAsUnwatched' => 'Отметить как непросмотренное',
+			'tooltips.bookmark' => 'Добавить в закладки',
+			'tooltips.removeBookmark' => 'Удалить из закладок',
 			'videoControls.audioLabel' => 'Аудио',
 			'videoControls.subtitlesLabel' => 'Субтитры',
 			'videoControls.resetToZero' => 'Сбросить до 0мс',
@@ -2436,10 +2462,10 @@ extension on TranslationsRu {
 			'messages.serverLimitTitle' => 'Ошибка воспроизведения',
 			'messages.serverLimitBody' => 'Ошибка сервера (HTTP 500). Лимит пропускной способности/транскодирования, вероятно, отклонил сессию. Попросите владельца изменить настройки.',
 			'messages.logsUploaded' => 'Логи загружены',
-			'messages.logsUploadFailed' => 'Не удалось загрузить логи',
-			'messages.logId' => 'ID лога',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Не удалось загрузить логи',
+			'messages.logId' => 'ID лога',
 			'subtitlingStyling.text' => 'Текст',
 			'subtitlingStyling.border' => 'Обводка',
 			'subtitlingStyling.background' => 'Фон',
@@ -2669,6 +2695,7 @@ extension on TranslationsRu {
 			'licenses.licensesCount' => ({required Object count}) => '${count} лицензий',
 			'navigation.libraries' => 'Библиотеки',
 			'navigation.downloads' => 'Загрузки',
+			'navigation.watchlist' => 'Закладки',
 			'navigation.liveTv' => 'ТВ в прямом эфире',
 			'liveTv.title' => 'ТВ в прямом эфире',
 			'liveTv.guide' => 'Программа',
@@ -2949,11 +2976,11 @@ extension on TranslationsRu {
 			'companionRemote.pairing.validationHostFormat' => 'Формат должен быть IP:порт (например, 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Время подключения истекло. Используйте одну сеть на обоих устройствах.',
 			'companionRemote.pairing.sessionNotFound' => 'Устройство не найдено. Убедитесь, что Plezy запущен на хосте.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Аутентификация не удалась. На обоих устройствах нужен один аккаунт Plex.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Не удалось подключиться: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Отключиться от удалённой сессии?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Переподключение...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Попытка ${current} из 5',
 			'companionRemote.remote.retryNow' => 'Повторить сейчас',
@@ -3207,6 +3234,17 @@ extension on TranslationsRu {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Войдите на сервер Jellyfin. Привязывается к ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Одолжить из другого профиля',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Используйте подключение другого профиля. Для профилей с PIN нужен PIN.',
+			'watchlist.title' => 'Закладки',
+			'watchlist.movies' => 'Фильмы',
+			'watchlist.shows' => 'Сериалы',
+			'watchlist.seasons' => 'Сезоны',
+			'watchlist.episodes' => 'Эпизоды',
+			'watchlist.emptyTitle' => 'Нет закладок',
+			'watchlist.emptySubtitle' => 'Добавляйте фильмы и сериалы в закладки, чтобы быстро их находить.',
+			'watchlist.clearAll' => 'Очистить все',
+			'watchlist.clearAllConfirm' => 'Удалить все закладки? Это действие нельзя отменить.',
+			'watchlist.added' => 'Добавлено в закладки',
+			'watchlist.removed' => 'Удалено из закладок',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_sv.g.dart
+++ b/lib/i18n/strings_sv.g.dart
@@ -85,6 +85,7 @@ class TranslationsSv extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktSv trakt = _TranslationsTraktSv._(_root);
 	@override late final _TranslationsTrackersSv trackers = _TranslationsTrackersSv._(_root);
 	@override late final _TranslationsAddServerSv addServer = _TranslationsAddServerSv._(_root);
+	@override late final _TranslationsWatchlistSv watchlist = _TranslationsWatchlistSv._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsSv extends TranslationsTooltipsEn {
 	@override String get playTrailer => 'Spela trailer';
 	@override String get markAsWatched => 'Markera som sedd';
 	@override String get markAsUnwatched => 'Markera som osedd';
+	@override String get bookmark => 'Lägg till bokmärke';
+	@override String get removeBookmark => 'Ta bort bokmärke';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationSv extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => 'Bibliotek';
 	@override String get downloads => 'Nerladdat';
+	@override String get watchlist => 'Bokmärken';
 	@override String get liveTv => 'Live-TV';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerSv extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => 'Logga in på en Jellyfin-server. Kopplas till ${name}.';
 	@override String get borrowFromAnotherProfile => 'Låna från en annan profil';
 	@override String get borrowFromAnotherProfileSubtitle => 'Återanvänd en annan profils anslutning. PIN-skyddade profiler kräver en PIN.';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistSv extends TranslationsWatchlistEn {
+	_TranslationsWatchlistSv._(TranslationsSv root) : this._root = root, super.internal(root);
+
+	final TranslationsSv _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Bokmärken';
+	@override String get movies => 'Filmer';
+	@override String get shows => 'Serier';
+	@override String get seasons => 'Säsonger';
+	@override String get episodes => 'Avsnitt';
+	@override String get emptyTitle => 'Inga bokmärken';
+	@override String get emptySubtitle => 'Lägg till filmer och serier i dina bokmärken för enkel åtkomst.';
+	@override String get clearAll => 'Rensa alla';
+	@override String get clearAllConfirm => 'Ta bort alla bokmärken? Detta kan inte ångras.';
+	@override String get added => 'Tillagt i bokmärken';
+	@override String get removed => 'Borttaget från bokmärken';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsSv {
 			'tooltips.playTrailer' => 'Spela trailer',
 			'tooltips.markAsWatched' => 'Markera som sedd',
 			'tooltips.markAsUnwatched' => 'Markera som osedd',
+			'tooltips.bookmark' => 'Lägg till bokmärke',
+			'tooltips.removeBookmark' => 'Ta bort bokmärke',
 			'videoControls.audioLabel' => 'Ljud',
 			'videoControls.subtitlesLabel' => 'Undertexter',
 			'videoControls.resetToZero' => 'Återställ till 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsSv {
 			'messages.serverLimitTitle' => 'Uppspelningen misslyckades',
 			'messages.serverLimitBody' => 'Serverfel (HTTP 500). En bandbredds-/transkodningsgräns avvisade troligen sessionen. Be ägaren justera den.',
 			'messages.logsUploaded' => 'Loggar uppladdade',
-			'messages.logsUploadFailed' => 'Uppladdning av loggar misslyckades',
-			'messages.logId' => 'Logg-ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => 'Uppladdning av loggar misslyckades',
+			'messages.logId' => 'Logg-ID',
 			'subtitlingStyling.text' => 'Text',
 			'subtitlingStyling.border' => 'Kantlinje',
 			'subtitlingStyling.background' => 'Bakgrund',
@@ -2669,6 +2695,7 @@ extension on TranslationsSv {
 			'licenses.licensesCount' => ({required Object count}) => '${count} licenser',
 			'navigation.libraries' => 'Bibliotek',
 			'navigation.downloads' => 'Nerladdat',
+			'navigation.watchlist' => 'Bokmärken',
 			'navigation.liveTv' => 'Live-TV',
 			'liveTv.title' => 'Live-TV',
 			'liveTv.guide' => 'Programguide',
@@ -2949,11 +2976,11 @@ extension on TranslationsSv {
 			'companionRemote.pairing.validationHostFormat' => 'Format måste vara IP:port (t.ex. 192.168.1.100:48632)',
 			'companionRemote.pairing.connectionTimedOut' => 'Anslutningen tog för lång tid. Använd samma nätverk på båda enheter.',
 			'companionRemote.pairing.sessionNotFound' => 'Enhet hittades inte. Kontrollera att Plezy körs på värden.',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => 'Autentisering misslyckades. Båda enheter behöver samma Plex-konto.',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => 'Kunde inte ansluta: ${error}',
 			'companionRemote.remote.disconnectConfirm' => 'Vill du koppla från fjärrsessionen?',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => 'Återansluter...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => 'Försök ${current} av 5',
 			'companionRemote.remote.retryNow' => 'Försök nu',
@@ -3207,6 +3234,17 @@ extension on TranslationsSv {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => 'Logga in på en Jellyfin-server. Kopplas till ${name}.',
 			'addServer.borrowFromAnotherProfile' => 'Låna från en annan profil',
 			'addServer.borrowFromAnotherProfileSubtitle' => 'Återanvänd en annan profils anslutning. PIN-skyddade profiler kräver en PIN.',
+			'watchlist.title' => 'Bokmärken',
+			'watchlist.movies' => 'Filmer',
+			'watchlist.shows' => 'Serier',
+			'watchlist.seasons' => 'Säsonger',
+			'watchlist.episodes' => 'Avsnitt',
+			'watchlist.emptyTitle' => 'Inga bokmärken',
+			'watchlist.emptySubtitle' => 'Lägg till filmer och serier i dina bokmärken för enkel åtkomst.',
+			'watchlist.clearAll' => 'Rensa alla',
+			'watchlist.clearAllConfirm' => 'Ta bort alla bokmärken? Detta kan inte ångras.',
+			'watchlist.added' => 'Tillagt i bokmärken',
+			'watchlist.removed' => 'Borttaget från bokmärken',
 			_ => null,
 		};
 	}

--- a/lib/i18n/strings_zh.g.dart
+++ b/lib/i18n/strings_zh.g.dart
@@ -85,6 +85,7 @@ class TranslationsZh extends Translations with BaseTranslations<AppLocale, Trans
 	@override late final _TranslationsTraktZh trakt = _TranslationsTraktZh._(_root);
 	@override late final _TranslationsTrackersZh trackers = _TranslationsTrackersZh._(_root);
 	@override late final _TranslationsAddServerZh addServer = _TranslationsAddServerZh._(_root);
+	@override late final _TranslationsWatchlistZh watchlist = _TranslationsWatchlistZh._(_root);
 }
 
 // Path: app
@@ -562,6 +563,8 @@ class _TranslationsTooltipsZh extends TranslationsTooltipsEn {
 	@override String get playTrailer => '播放预告片';
 	@override String get markAsWatched => '标记为已观看';
 	@override String get markAsUnwatched => '标记为未观看';
+	@override String get bookmark => '添加书签';
+	@override String get removeBookmark => '移除书签';
 }
 
 // Path: videoControls
@@ -1033,6 +1036,7 @@ class _TranslationsNavigationZh extends TranslationsNavigationEn {
 	// Translations
 	@override String get libraries => '媒体库';
 	@override String get downloads => '下载';
+	@override String get watchlist => '书签';
 	@override String get liveTv => '电视直播';
 }
 
@@ -1637,6 +1641,26 @@ class _TranslationsAddServerZh extends TranslationsAddServerEn {
 	@override String connectToJellyfinCardSubtitleScoped({required Object name}) => '登录到 Jellyfin 服务器。绑定到 ${name}。';
 	@override String get borrowFromAnotherProfile => '从另一个配置文件借用';
 	@override String get borrowFromAnotherProfileSubtitle => '复用另一个个人资料的连接。受 PIN 保护的个人资料需要 PIN。';
+}
+
+// Path: watchlist
+class _TranslationsWatchlistZh extends TranslationsWatchlistEn {
+	_TranslationsWatchlistZh._(TranslationsZh root) : this._root = root, super.internal(root);
+
+	final TranslationsZh _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => '书签';
+	@override String get movies => '电影';
+	@override String get shows => '剧集';
+	@override String get seasons => '季度';
+	@override String get episodes => '集数';
+	@override String get emptyTitle => '暂无书签';
+	@override String get emptySubtitle => '将电影和剧集添加到书签，方便以后查找。';
+	@override String get clearAll => '清除全部';
+	@override String get clearAllConfirm => '删除所有书签？此操作无法撤销。';
+	@override String get added => '已添加到书签';
+	@override String get removed => '已从书签移除';
 }
 
 // Path: hotkeys.actions
@@ -2310,6 +2334,8 @@ extension on TranslationsZh {
 			'tooltips.playTrailer' => '播放预告片',
 			'tooltips.markAsWatched' => '标记为已观看',
 			'tooltips.markAsUnwatched' => '标记为未观看',
+			'tooltips.bookmark' => '添加书签',
+			'tooltips.removeBookmark' => '移除书签',
 			'videoControls.audioLabel' => '音频',
 			'videoControls.subtitlesLabel' => '字幕',
 			'videoControls.resetToZero' => '重置为 0ms',
@@ -2436,10 +2462,10 @@ extension on TranslationsZh {
 			'messages.serverLimitTitle' => '播放失败',
 			'messages.serverLimitBody' => '服务器错误 (HTTP 500)。带宽/转码限制可能拒绝了此会话。请让所有者调整。',
 			'messages.logsUploaded' => '日志已上传',
-			'messages.logsUploadFailed' => '上传日志失败',
-			'messages.logId' => '日志 ID',
 			_ => null,
 		} ?? switch (path) {
+			'messages.logsUploadFailed' => '上传日志失败',
+			'messages.logId' => '日志 ID',
 			'subtitlingStyling.text' => '文本',
 			'subtitlingStyling.border' => '边框',
 			'subtitlingStyling.background' => '背景',
@@ -2669,6 +2695,7 @@ extension on TranslationsZh {
 			'licenses.licensesCount' => ({required Object count}) => '${count} 个许可证',
 			'navigation.libraries' => '媒体库',
 			'navigation.downloads' => '下载',
+			'navigation.watchlist' => '书签',
 			'navigation.liveTv' => '电视直播',
 			'liveTv.title' => '电视直播',
 			'liveTv.guide' => '节目指南',
@@ -2949,11 +2976,11 @@ extension on TranslationsZh {
 			'companionRemote.pairing.validationHostFormat' => '格式必须为IP:端口（例如 192.168.1.100:48632）',
 			'companionRemote.pairing.connectionTimedOut' => '连接超时。请在两台设备上使用同一网络。',
 			'companionRemote.pairing.sessionNotFound' => '未找到设备。请确认 Plezy 正在主机上运行。',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.pairing.authFailed' => '认证失败。两台设备需要使用同一 Plex 账号。',
 			'companionRemote.pairing.failedToConnect' => ({required Object error}) => '连接失败：${error}',
 			'companionRemote.remote.disconnectConfirm' => '是否要断开远程会话的连接？',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.remote.reconnecting' => '重新连接中...',
 			'companionRemote.remote.attemptOf' => ({required Object current}) => '第 ${current} 次尝试，共 5 次',
 			'companionRemote.remote.retryNow' => '立即重试',
@@ -3207,6 +3234,17 @@ extension on TranslationsZh {
 			'addServer.connectToJellyfinCardSubtitleScoped' => ({required Object name}) => '登录到 Jellyfin 服务器。绑定到 ${name}。',
 			'addServer.borrowFromAnotherProfile' => '从另一个配置文件借用',
 			'addServer.borrowFromAnotherProfileSubtitle' => '复用另一个个人资料的连接。受 PIN 保护的个人资料需要 PIN。',
+			'watchlist.title' => '书签',
+			'watchlist.movies' => '电影',
+			'watchlist.shows' => '剧集',
+			'watchlist.seasons' => '季度',
+			'watchlist.episodes' => '集数',
+			'watchlist.emptyTitle' => '暂无书签',
+			'watchlist.emptySubtitle' => '将电影和剧集添加到书签，方便以后查找。',
+			'watchlist.clearAll' => '清除全部',
+			'watchlist.clearAllConfirm' => '删除所有书签？此操作无法撤销。',
+			'watchlist.added' => '已添加到书签',
+			'watchlist.removed' => '已从书签移除',
 			_ => null,
 		};
 	}

--- a/lib/i18n/sv.i18n.json
+++ b/lib/i18n/sv.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "Blanda uppspelning",
     "playTrailer": "Spela trailer",
     "markAsWatched": "Markera som sedd",
-    "markAsUnwatched": "Markera som osedd"
+    "markAsUnwatched": "Markera som osedd",
+    "bookmark": "Lägg till bokmärke",
+    "removeBookmark": "Ta bort bokmärke"
   },
   "videoControls": {
     "audioLabel": "Ljud",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "Bibliotek",
     "downloads": "Nerladdat",
+    "watchlist": "Bokmärken",
     "liveTv": "Live-TV"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "Logga in på en Jellyfin-server. Kopplas till ${name}.",
     "borrowFromAnotherProfile": "Låna från en annan profil",
     "borrowFromAnotherProfileSubtitle": "Återanvänd en annan profils anslutning. PIN-skyddade profiler kräver en PIN."
+  },
+  "watchlist": {
+    "title": "Bokmärken",
+    "movies": "Filmer",
+    "shows": "Serier",
+    "seasons": "Säsonger",
+    "episodes": "Avsnitt",
+    "emptyTitle": "Inga bokmärken",
+    "emptySubtitle": "Lägg till filmer och serier i dina bokmärken för enkel åtkomst.",
+    "clearAll": "Rensa alla",
+    "clearAllConfirm": "Ta bort alla bokmärken? Detta kan inte ångras.",
+    "added": "Tillagt i bokmärken",
+    "removed": "Borttaget från bokmärken"
   }
 }

--- a/lib/i18n/zh.i18n.json
+++ b/lib/i18n/zh.i18n.json
@@ -409,7 +409,9 @@
     "shufflePlay": "随机播放",
     "playTrailer": "播放预告片",
     "markAsWatched": "标记为已观看",
-    "markAsUnwatched": "标记为未观看"
+    "markAsUnwatched": "标记为未观看",
+    "bookmark": "添加书签",
+    "removeBookmark": "移除书签"
   },
   "videoControls": {
     "audioLabel": "音频",
@@ -811,6 +813,7 @@
   "navigation": {
     "libraries": "媒体库",
     "downloads": "下载",
+    "watchlist": "书签",
     "liveTv": "电视直播"
   },
   "liveTv": {
@@ -1395,5 +1398,18 @@
     "connectToJellyfinCardSubtitleScoped": "登录到 Jellyfin 服务器。绑定到 ${name}。",
     "borrowFromAnotherProfile": "从另一个配置文件借用",
     "borrowFromAnotherProfileSubtitle": "复用另一个个人资料的连接。受 PIN 保护的个人资料需要 PIN。"
+  },
+  "watchlist": {
+    "title": "书签",
+    "movies": "电影",
+    "shows": "剧集",
+    "seasons": "季度",
+    "episodes": "集数",
+    "emptyTitle": "暂无书签",
+    "emptySubtitle": "将电影和剧集添加到书签，方便以后查找。",
+    "clearAll": "清除全部",
+    "clearAllConfirm": "删除所有书签？此操作无法撤销。",
+    "added": "已添加到书签",
+    "removed": "已从书签移除"
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ import 'providers/user_profile_provider.dart';
 import 'providers/multi_server_provider.dart';
 import 'providers/theme_provider.dart';
 import 'providers/download_provider.dart';
+import 'providers/watchlist_provider.dart';
 import 'providers/offline_mode_provider.dart';
 import 'providers/offline_watch_provider.dart';
 import 'providers/shader_provider.dart';
@@ -769,6 +770,16 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
           create: (context) => DownloadProvider(downloadManager: _downloadManager, database: _appDatabase),
           update: (context, activeProfile, previous) {
             final provider = previous ?? DownloadProvider(downloadManager: _downloadManager, database: _appDatabase);
+            provider.setActiveProfileId(activeProfile.activeId);
+            return provider;
+          },
+        ),
+        // Watchlist provider. Bookmarks are profile-scoped and reload when the
+        // active profile changes.
+        ChangeNotifierProxyProvider<ActiveProfileProvider, WatchlistProvider>(
+          create: (context) => WatchlistProvider(database: _appDatabase),
+          update: (context, activeProfile, previous) {
+            final provider = previous ?? WatchlistProvider(database: _appDatabase);
             provider.setActiveProfileId(activeProfile.activeId);
             return provider;
           },

--- a/lib/navigation/navigation_tabs.dart
+++ b/lib/navigation/navigation_tabs.dart
@@ -6,7 +6,7 @@ import '../i18n/strings.g.dart';
 import '../utils/platform_detector.dart';
 
 /// Navigation tab identifiers
-enum NavigationTabId { discover, libraries, liveTv, search, downloads, settings }
+enum NavigationTabId { discover, libraries, liveTv, search, downloads, watchlist, settings }
 
 /// Represents a navigation tab with its configuration
 class NavigationTab {
@@ -64,6 +64,7 @@ String _getLibrariesLabel() => t.navigation.libraries;
 String _getLiveTvLabel() => t.navigation.liveTv;
 String _getSearchLabel() => t.common.search;
 String _getDownloadsLabel() => t.navigation.downloads;
+String _getWatchlistLabel() => t.navigation.watchlist;
 String _getSettingsLabel() => t.common.settings;
 
 /// All navigation tabs in display order
@@ -82,6 +83,12 @@ const allNavigationTabs = [
     onlineOnly: false,
     icon: Symbols.download_rounded,
     getLabel: _getDownloadsLabel,
+  ),
+  NavigationTab(
+    id: NavigationTabId.watchlist,
+    onlineOnly: false,
+    icon: Symbols.bookmark_rounded,
+    getLabel: _getWatchlistLabel,
   ),
   NavigationTab(
     id: NavigationTabId.settings,

--- a/lib/providers/watchlist_provider.dart
+++ b/lib/providers/watchlist_provider.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../database/app_database.dart';
+import '../database/watchlist_operations.dart';
+import '../media/media_item.dart';
+import '../mixins/disposable_change_notifier_mixin.dart';
+
+/// Provider for reactive, profile-scoped watchlist state.
+///
+/// Items are loaded via a Drift [watchWatchlist] stream that re-emits on every
+/// insert or delete. [toggleBookmark] applies an optimistic local update and
+/// delegates to the database; the stream reconciles state shortly after.
+class WatchlistProvider extends ChangeNotifier with DisposableChangeNotifierMixin {
+  final AppDatabase _database;
+
+  /// All items keyed by their [globalKey].
+  Map<String, WatchlistItem> _items = {};
+
+  StreamSubscription<List<WatchlistItem>>? _watchSub;
+  String? _activeProfileId;
+
+  WatchlistProvider({required AppDatabase database}) : _database = database;
+
+  // ---------------------------------------------------------------------------
+  // Public read-only state
+  // ---------------------------------------------------------------------------
+
+  /// Returns an unmodifiable view of all watchlist items.
+  Map<String, WatchlistItem> get items => Map.unmodifiable(_items);
+
+  /// Set of all bookmarked global keys (O(1) lookups).
+  Set<String> get bookmarkedKeys => _items.keys.toSet();
+
+  /// Returns `true` when [globalKey] is currently bookmarked.
+  bool isBookmarked(String globalKey) => _items.containsKey(globalKey);
+
+  /// Items filtered to movies only.
+  List<WatchlistItem> get movies =>
+      _items.values.where((i) => i.kind == 'movie').toList();
+
+  /// Items filtered to shows only.
+  List<WatchlistItem> get shows =>
+      _items.values.where((i) => i.kind == 'show').toList();
+
+  /// Items filtered to seasons only.
+  List<WatchlistItem> get seasons =>
+      _items.values.where((i) => i.kind == 'season').toList();
+
+  /// Items filtered to episodes only.
+  List<WatchlistItem> get episodes =>
+      _items.values.where((i) => i.kind == 'episode').toList();
+
+  // ---------------------------------------------------------------------------
+  // Profile lifecycle
+  // ---------------------------------------------------------------------------
+
+  /// Switch the watchlist scope to [profileId]. Cancels any existing
+  /// subscription, starts a new [watchWatchlist] stream for the given profile,
+  /// and populates [_items] from the initial snapshot.
+  void setActiveProfileId(String? profileId) {
+    if (_activeProfileId == profileId) return;
+    _activeProfileId = profileId;
+
+    _watchSub?.cancel();
+    _watchSub = null;
+
+    if (profileId == null) {
+      _items = {};
+      safeNotifyListeners();
+      return;
+    }
+
+    _watchSub = _database.watchWatchlist(profileId).listen(
+      _onWatchlistUpdate,
+      onError: (Object error) {
+        // Silently handle stream errors — the next profile switch or retoggle
+        // will repopulate from a fresh snapshot.
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Mutations
+  // ---------------------------------------------------------------------------
+
+  /// Toggles the bookmark for [metadata]. Adds the item to the watchlist if it
+  /// is not currently bookmarked; removes it if it is. Updates [_items]
+  /// immediately for responsive UI feedback.
+  Future<void> toggleBookmark(MediaItem metadata) async {
+    final profileId = _activeProfileId;
+    if (profileId == null) return;
+
+    final globalKey = metadata.globalKey;
+    final serverId = metadata.serverId ?? '';
+
+    final added = await _database.toggleBookmark(
+      profileId: profileId,
+      serverId: serverId,
+      ratingKey: metadata.id,
+      globalKey: globalKey,
+      kind: metadata.kind.id,
+      title: metadata.title ?? '',
+      thumbPath: metadata.thumbPath,
+      backdropPath: metadata.artPath,
+      year: metadata.year,
+      index: metadata.index,
+      parentTitle: metadata.parentTitle,
+    );
+
+    // Optimistic local update — the stream will reconcile shortly after.
+    if (added) {
+      _items[globalKey] = WatchlistItem(
+        profileId: profileId,
+        globalKey: globalKey,
+        serverId: serverId,
+        clientScopeId: null,
+        ratingKey: metadata.id,
+        kind: metadata.kind.id,
+        title: metadata.title ?? '',
+        thumbPath: metadata.thumbPath,
+        backdropPath: metadata.artPath,
+        year: metadata.year,
+        index: metadata.index,
+        parentTitle: metadata.parentTitle,
+        addedAt: DateTime.now().millisecondsSinceEpoch,
+      );
+    } else {
+      _items.remove(globalKey);
+    }
+    safeNotifyListeners();
+  }
+
+  /// Deletes all watchlist rows for the active profile.
+  Future<void> clearAll() async {
+    final profileId = _activeProfileId;
+    if (profileId == null) return;
+    await _database.clearAll(profileId);
+    // The stream subscription will emit an empty list and update _items.
+    // Apply local update immediately for responsiveness.
+    _items = {};
+    safeNotifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Stream handling
+  // ---------------------------------------------------------------------------
+
+  void _onWatchlistUpdate(List<WatchlistItem> items) {
+    _items = {for (final item in items) item.globalKey: item};
+    safeNotifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  @override
+  void dispose() {
+    _watchSub?.cancel();
+    _watchSub = null;
+    super.dispose();
+  }
+}

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -58,6 +58,7 @@ import 'libraries/libraries_screen.dart';
 import 'livetv/live_tv_screen.dart';
 import 'search_screen.dart';
 import 'downloads/downloads_screen.dart';
+import 'watchlist/watchlist_screen.dart';
 import 'settings/settings_screen.dart';
 import 'profile/profile_switch_screen.dart';
 import '../services/system_shelf_service.dart';
@@ -219,6 +220,7 @@ class _MainScreenState extends State<MainScreen>
   final GlobalKey<State<LiveTvScreen>> _liveTvKey = GlobalKey();
   final GlobalKey<State<SearchScreen>> _searchKey = GlobalKey();
   final GlobalKey<State<DownloadsScreen>> _downloadsKey = GlobalKey();
+  final GlobalKey<State<WatchlistScreen>> _watchlistKey = GlobalKey();
   final GlobalKey<State<SettingsScreen>> _settingsKey = GlobalKey();
   final GlobalKey<SideNavigationRailState> _sideNavKey = GlobalKey();
 
@@ -918,6 +920,7 @@ class _MainScreenState extends State<MainScreen>
           NavigationTabId.liveTv => LiveTvScreen(key: _liveTvKey),
           NavigationTabId.search => SearchScreen(key: _searchKey),
           NavigationTabId.downloads => DownloadsScreen(key: _downloadsKey),
+          NavigationTabId.watchlist => WatchlistScreen(key: _watchlistKey),
           NavigationTabId.settings => SettingsScreen(key: _settingsKey),
         },
     ];
@@ -1524,6 +1527,7 @@ class _MainScreenState extends State<MainScreen>
       NavigationTabId.liveTv => _liveTvKey,
       NavigationTabId.search => _searchKey,
       NavigationTabId.downloads => _downloadsKey,
+      NavigationTabId.watchlist => _watchlistKey,
       NavigationTabId.settings => _settingsKey,
     };
   }

--- a/lib/screens/media_detail/action_buttons.dart
+++ b/lib/screens/media_detail/action_buttons.dart
@@ -1,6 +1,17 @@
 part of '../media_detail_screen.dart';
 
 extension _MediaDetailActionButtons on _MediaDetailScreenState {
+  /// Returns `true` when [WatchlistProvider] is available in the widget tree.
+  /// Tests that predate the watchlist feature may not provide it.
+  bool get _hasWatchlistProvider {
+    try {
+      context.read<WatchlistProvider>();
+      return true;
+    } on ProviderNotFoundException {
+      return false;
+    }
+  }
+
   Widget _buildActionButtons(MediaItem metadata) {
     final isTv = PlatformDetector.isTV();
     final tvScale = TvLayoutConstants.scaleOf(context);
@@ -194,6 +205,27 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
           _buildWatchedToggleButton(metadata, actionButtonStyle, tvScale, showFocus: state.showFocus),
     );
 
+    final bookmarkAction = _hasWatchlistProvider
+        ? FocusableAction(
+            debugLabel: 'detail_bookmark',
+            onPressed: () => unawaited(_handleBookmarkTogglePressed(metadata)),
+            builder: (context, state) {
+              final isBookmarked =
+                  context.select<WatchlistProvider, bool>((wp) => wp.isBookmarked(metadata.globalKey));
+              return IconButton.filledTonal(
+                onPressed: () => unawaited(_handleBookmarkTogglePressed(metadata)),
+                icon: AppIcon(
+                  isBookmarked ? Symbols.bookmark_rounded : Symbols.bookmark,
+                  fill: 1,
+                ),
+                tooltip: isBookmarked ? t.tooltips.removeBookmark : t.tooltips.bookmark,
+                iconSize: PlatformDetector.isTV() ? 21 * tvScale : 20,
+                style: actionButtonStyle(showFocus: state.showFocus),
+              );
+            },
+          )
+        : null;
+
     void showMoreActions() => _contextMenuKey.currentState?.showContextMenu(context);
 
     final moreActionsAction = widget.isOffline
@@ -216,6 +248,7 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
       ?shuffleAction,
       ?downloadAction,
       watchedAction,
+      ?bookmarkAction,
       ?moreActionsAction,
     ];
 
@@ -241,18 +274,18 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
 
     List<FocusableAction> compactActionsFor(double maxWidth) {
       if (widget.isOffline) {
-        final compact = <FocusableAction>[playAction, watchedAction];
-        if (maxWidth.isFinite && estimatedRowWidth(compact) > maxWidth) return [playAction];
+        final compact = <FocusableAction>[playAction, watchedAction, ?bookmarkAction];
+        if (maxWidth.isFinite && estimatedRowWidth(compact) > maxWidth) return [playAction, ?bookmarkAction];
         return compact;
       }
 
-      final medium = <FocusableAction>[playAction, ?downloadAction, watchedAction, ?moreActionsAction];
+      final medium = <FocusableAction>[playAction, ?downloadAction, watchedAction, ?bookmarkAction, ?moreActionsAction];
       if (!maxWidth.isFinite || estimatedRowWidth(medium) <= maxWidth) return medium;
 
-      final compact = <FocusableAction>[playAction, watchedAction, ?moreActionsAction];
+      final compact = <FocusableAction>[playAction, watchedAction, ?bookmarkAction, ?moreActionsAction];
       if (estimatedRowWidth(compact) <= maxWidth) return compact;
 
-      return [playAction, ?moreActionsAction];
+      return [playAction, ?bookmarkAction, ?moreActionsAction];
     }
 
     Widget actionBar(List<FocusableAction> actions) {
@@ -294,6 +327,23 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
         case WatchMarkOutcome.skipped:
           break;
       }
+    } catch (e) {
+      if (mounted) {
+        showErrorSnackBar(context, t.messages.errorLoading(error: e.toString()));
+      }
+    }
+  }
+
+  Future<void> _handleBookmarkTogglePressed(MediaItem metadata) async {
+    try {
+      final watchlistProvider = context.read<WatchlistProvider>();
+      final isBookmarked = watchlistProvider.isBookmarked(metadata.globalKey);
+      await watchlistProvider.toggleBookmark(metadata);
+      if (!mounted) return;
+      showSuccessSnackBar(
+        context,
+        isBookmarked ? t.watchlist.removed : t.watchlist.added,
+      );
     } catch (e) {
       if (mounted) {
         showErrorSnackBar(context, t.messages.errorLoading(error: e.toString()));

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -55,6 +55,7 @@ import '../utils/layout_constants.dart';
 import '../providers/download_provider.dart';
 import '../providers/offline_watch_provider.dart';
 import '../providers/watch_state_store.dart';
+import '../providers/watchlist_provider.dart';
 import '../theme/mono_tokens.dart';
 import '../utils/app_logger.dart';
 import '../utils/formatters.dart';

--- a/lib/screens/watchlist/watchlist_screen.dart
+++ b/lib/screens/watchlist/watchlist_screen.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../../database/app_database.dart';
+import '../../media/media_backend.dart';
+import '../../media/media_item.dart';
+import '../../media/media_kind.dart';
+import '../../providers/watchlist_provider.dart';
+import '../../services/settings_service.dart';
+import '../../utils/platform_detector.dart';
+import '../../widgets/focusable_media_card.dart';
+import '../../widgets/media_grid_delegate.dart';
+import '../../widgets/settings_builder.dart';
+import '../libraries/state_messages.dart';
+import '../../i18n/strings.g.dart';
+
+/// Screen that displays the user's watchlist items grouped by media kind.
+///
+/// Each non-empty group (movies, shows, seasons, episodes) renders as a
+/// labelled section with a horizontal grid of [FocusableMediaCard] widgets.
+/// The empty state shows an [EmptyStateWidget] with a contextual message.
+/// A clear-all button in the action bar triggers a confirmation dialog,
+/// after which all items are removed via [WatchlistProvider.clearAll].
+class WatchlistScreen extends StatefulWidget {
+  const WatchlistScreen({super.key});
+
+  @override
+  State<WatchlistScreen> createState() => _WatchlistScreenState();
+}
+
+class _WatchlistScreenState extends State<WatchlistScreen> {
+  /// Converts a persisted [WatchlistItem] into a [MediaItem] so it can be fed
+  /// to [FocusableMediaCard] (which delegates to [MediaCard] — both expect an
+  /// `Object` that is either a [MediaItem] or [MediaPlaylist]).
+  static MediaItem _toMediaItem(WatchlistItem item) {
+    return MediaItem(
+      id: item.ratingKey,
+      backend: MediaBackend.plex,
+      kind: MediaKind.fromString(item.kind),
+      title: item.title,
+      thumbPath: item.thumbPath,
+      artPath: item.backdropPath,
+      year: item.year,
+      index: item.index,
+      serverId: item.serverId,
+      parentTitle: item.parentTitle,
+    );
+  }
+
+  Future<void> _showClearAllDialog(BuildContext context) async {
+    final t = Translations.of(context);
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.watchlist.clearAll),
+        content: Text(t.watchlist.clearAllConfirm),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(t.common.cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(t.common.clear),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      await context.read<WatchlistProvider>().clearAll();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(t.watchlist.clearAllConfirm)),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Translations.of(context);
+    final provider = context.watch<WatchlistProvider>();
+
+    final movies = provider.movies;
+    final shows = provider.shows;
+    final seasons = provider.seasons;
+    final episodes = provider.episodes;
+
+    final hasAnyItems =
+        movies.isNotEmpty || shows.isNotEmpty || seasons.isNotEmpty || episodes.isNotEmpty;
+
+    // Empty state — no items in any group.
+    if (!hasAnyItems) {
+      return Scaffold(
+        body: EmptyStateWidget(
+          message: t.watchlist.emptyTitle,
+          subtitle: t.watchlist.emptySubtitle,
+          icon: Symbols.bookmark_rounded,
+          iconSize: 80,
+        ),
+      );
+    }
+
+    final groups = <_WatchlistGroup>[
+      if (movies.isNotEmpty) _WatchlistGroup(label: t.watchlist.movies, items: movies),
+      if (shows.isNotEmpty) _WatchlistGroup(label: t.watchlist.shows, items: shows),
+      if (seasons.isNotEmpty) _WatchlistGroup(label: t.watchlist.seasons, items: seasons),
+      if (episodes.isNotEmpty) _WatchlistGroup(label: t.watchlist.episodes, items: episodes),
+    ];
+
+    return Scaffold(
+      body: SettingsBuilder(
+        prefs: const [SettingsService.libraryDensity],
+        builder: (context) {
+          final density = SettingsService.instance.read(SettingsService.libraryDensity);
+
+          return CustomScrollView(
+            primary: false,
+            slivers: [
+              // Clear-all action bar at the top.
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton.icon(
+                        onPressed: () => _showClearAllDialog(context),
+                        icon: const Icon(Symbols.delete_forever_rounded, size: 18),
+                        label: Text(t.watchlist.clearAll),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              // One section per non-empty group.
+              for (final group in groups)
+                _WatchlistGroupSection(
+                  label: group.label,
+                  items: group.items,
+                  density: density,
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Lightweight model for a labelled group of watchlist items.
+class _WatchlistGroup {
+  final String label;
+  final List<WatchlistItem> items;
+  const _WatchlistGroup({required this.label, required this.items});
+}
+
+/// Renders a single section: a header label followed by a horizontally
+/// scrollable grid of [FocusableMediaCard] items.
+class _WatchlistGroupSection extends StatelessWidget {
+  final String label;
+  final List<WatchlistItem> items;
+  final int density;
+
+  const _WatchlistGroupSection({
+    required this.label,
+    required this.items,
+    required this.density,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fullCardLayout = PlatformDetector.isTV() &&
+        SettingsService.instance.read(SettingsService.tvFullCardLayout);
+
+    return SliverMainAxisGroup(slivers: [
+      // Section header.
+      SliverToBoxAdapter(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ),
+      ),
+      // Grid of items.
+      SliverLayoutBuilder(
+        builder: (context, constraints) {
+          return SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            sliver: SliverGrid(
+              gridDelegate: MediaGridDelegate.createDelegate(
+                context: context,
+                density: density,
+                fullBleedImage: fullCardLayout,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                (context, index) {
+                  final item = items[index];
+                  return FocusableMediaCard(
+                    item: _WatchlistScreenState._toMediaItem(item),
+                    isOffline: true,
+                    fullBleedImage: fullCardLayout,
+                  );
+                },
+                childCount: items.length,
+              ),
+            ),
+          );
+        },
+      ),
+    ]);
+  }
+}

--- a/lib/widgets/side_navigation_rail.dart
+++ b/lib/widgets/side_navigation_rail.dart
@@ -234,6 +234,7 @@ class SideNavigationRailState extends State<SideNavigationRail> with MountedSetS
   static const _kLibraries = 'libraries';
   static const _kSearch = 'search';
   static const _kDownloads = 'downloads';
+  static const _kWatchlist = 'watchlist';
   static const _kSettings = 'settings';
   static const _kReconnect = 'reconnect';
   static const _kFullscreen = 'fullscreen';
@@ -253,6 +254,8 @@ class SideNavigationRailState extends State<SideNavigationRail> with MountedSetS
   bool get _interactionExpanded => _isHovered || _isTouchExpanded;
 
   bool get _showDownloads => !PlatformDetector.isAppleTV();
+
+  bool get _showWatchlist => !PlatformDetector.isAppleTV();
 
   /// macOS has the system green button; mobile/TV have no OS fullscreen toggle.
   bool get _showFullscreenToggle => Platform.isWindows || Platform.isLinux;
@@ -379,6 +382,8 @@ class SideNavigationRailState extends State<SideNavigationRail> with MountedSetS
         return _kSearch;
       case NavigationTabId.downloads:
         return _showDownloads ? _kDownloads : null;
+      case NavigationTabId.watchlist:
+        return _showWatchlist ? _kWatchlist : null;
       case NavigationTabId.settings:
         return _kSettings;
       case NavigationTabId.liveTv:
@@ -419,6 +424,7 @@ class SideNavigationRailState extends State<SideNavigationRail> with MountedSetS
       _kLibraries,
       _kSearch,
       if (_showDownloads) _kDownloads,
+      if (_showWatchlist) _kWatchlist,
       _kSettings,
       _kReconnect,
       if (hasHiddenLibraries) _kHiddenLibraries,
@@ -507,6 +513,7 @@ class SideNavigationRailState extends State<SideNavigationRail> with MountedSetS
         _kSearch,
       ],
       if (_showDownloads) _kDownloads,
+      if (_showWatchlist) _kWatchlist,
       _kSettings,
       if (_showFullscreenToggle) _kFullscreen,
     ];
@@ -765,6 +772,20 @@ class SideNavigationRailState extends State<SideNavigationRail> with MountedSetS
                                       isFocused: _focusTracker.isFocused(_kDownloads),
                                       onTap: () => widget.onDestinationSelected(NavigationTabId.downloads),
                                       focusNode: _focusTracker.get(_kDownloads),
+                                      isCollapsed: isCollapsed,
+                                    ),
+                                    const SizedBox(height: 8),
+                                  ],
+                                  // Watchlist (hidden on Apple TV)
+                                  if (_showWatchlist) ...[
+                                    _buildNavItem(
+                                      icon: Symbols.bookmark_rounded,
+                                      selectedIcon: Symbols.bookmark_rounded,
+                                      label: Translations.of(context).navigation.watchlist,
+                                      isSelected: widget.selectedTab == NavigationTabId.watchlist,
+                                      isFocused: _focusTracker.isFocused(_kWatchlist),
+                                      onTap: () => widget.onDestinationSelected(NavigationTabId.watchlist),
+                                      focusNode: _focusTracker.get(_kWatchlist),
                                       isCollapsed: isCollapsed,
                                     ),
                                     const SizedBox(height: 8),

--- a/test/database/app_database_test.dart
+++ b/test/database/app_database_test.dart
@@ -40,8 +40,8 @@ class _AppDatabaseTestSuite {
     // ============================================================
 
     group('schema', () {
-      test('schemaVersion is 16', () {
-        expect(db.schemaVersion, 16);
+      test('schemaVersion is 17', () {
+        expect(db.schemaVersion, 17);
       });
 
       test('all tables are accessible and start empty', () async {

--- a/test/database/watchlist_operations_test.dart
+++ b/test/database/watchlist_operations_test.dart
@@ -1,0 +1,410 @@
+import 'dart:async';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/database/app_database.dart';
+import 'package:plezy/database/watchlist_operations.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  // ============================================================
+  // toggleBookmark
+  // ============================================================
+
+  group('toggleBookmark', () {
+    test('inserts a row on first toggle', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+        year: 2024,
+      );
+
+      final rows = await db.select(db.watchlistItems).get();
+      expect(rows, hasLength(1));
+      final r = rows.first;
+      expect(r.profileId, 'profile-a');
+      expect(r.globalKey, 'srv:100');
+      expect(r.serverId, 'srv');
+      expect(r.ratingKey, '100');
+      expect(r.kind, 'movie');
+      expect(r.title, 'Test Movie');
+      expect(r.year, 2024);
+      expect(r.thumbPath, isNull);
+      expect(r.backdropPath, isNull);
+      expect(r.index, isNull);
+      expect(r.parentTitle, isNull);
+      expect(r.clientScopeId, isNull);
+      expect(r.addedAt, isNotNull);
+    });
+
+    test('re-toggle removes the row', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+      expect(await db.select(db.watchlistItems).get(), hasLength(1));
+
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+      expect(await db.select(db.watchlistItems).get(), isEmpty);
+    });
+
+    test('re-toggling after remove inserts again', () async {
+      // First toggle → insert
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+      // Second toggle → remove
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+      // Third toggle → insert again
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Re-added Movie',
+      );
+
+      final rows = await db.select(db.watchlistItems).get();
+      expect(rows, hasLength(1));
+      expect(rows.first.title, 'Re-added Movie');
+    });
+
+    test('stores optional display metadata', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: 'ep1',
+        globalKey: 'srv:ep1',
+        kind: 'episode',
+        title: 'Pilot',
+        thumbPath: '/thumb/pilot.jpg',
+        backdropPath: '/backdrop/pilot.jpg',
+        year: 2023,
+        index: 1,
+        parentTitle: 'My Show',
+        clientScopeId: 'srv/user-a',
+      );
+
+      final row = (await db.select(db.watchlistItems).get()).single;
+      expect(row.kind, 'episode');
+      expect(row.thumbPath, '/thumb/pilot.jpg');
+      expect(row.backdropPath, '/backdrop/pilot.jpg');
+      expect(row.index, 1);
+      expect(row.parentTitle, 'My Show');
+      expect(row.clientScopeId, 'srv/user-a');
+    });
+  });
+
+  // ============================================================
+  // isBookmarked
+  // ============================================================
+
+  group('isBookmarked', () {
+    test('returns false when no row exists', () async {
+      expect(await db.isBookmarked('profile-a', 'srv:100'), isFalse);
+    });
+
+    test('returns true after toggleBookmark, false after second toggle', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+      expect(await db.isBookmarked('profile-a', 'srv:100'), isTrue);
+
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+      expect(await db.isBookmarked('profile-a', 'srv:100'), isFalse);
+    });
+  });
+
+  // ============================================================
+  // profile isolation
+  // ============================================================
+
+  group('profile isolation', () {
+    test('add to profile A, query B via select returns empty', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'A Movie',
+      );
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '200',
+        globalKey: 'srv:200',
+        kind: 'show',
+        title: 'A Show',
+      );
+
+      // Profile A has 2 items
+      final aRows = await (db.select(db.watchlistItems)
+            ..where((t) => t.profileId.equals('profile-a')))
+          .get();
+      expect(aRows, hasLength(2));
+
+      // Profile B has 0 items — same server items, different profile
+      final bRows = await (db.select(db.watchlistItems)
+            ..where((t) => t.profileId.equals('profile-b')))
+          .get();
+      expect(bRows, isEmpty);
+    });
+
+    test('same globalKey on different profiles are independent bookmarks', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'A sees this',
+      );
+      await db.toggleBookmark(
+        profileId: 'profile-b',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'B sees this',
+      );
+
+      final aRows = await (db.select(db.watchlistItems)
+            ..where((t) => t.profileId.equals('profile-a')))
+          .get();
+      expect(aRows, hasLength(1));
+      expect(aRows.first.title, 'A sees this');
+
+      final bRows = await (db.select(db.watchlistItems)
+            ..where((t) => t.profileId.equals('profile-b')))
+          .get();
+      expect(bRows, hasLength(1));
+      expect(bRows.first.title, 'B sees this');
+    });
+  });
+
+  // ============================================================
+  // clearAll
+  // ============================================================
+
+  group('clearAll', () {
+    test('deletes only the given profile rows', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '1',
+        globalKey: 'srv:1',
+        kind: 'movie',
+        title: 'A1',
+      );
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '2',
+        globalKey: 'srv:2',
+        kind: 'show',
+        title: 'A2',
+      );
+      await db.toggleBookmark(
+        profileId: 'profile-b',
+        serverId: 'srv',
+        ratingKey: '3',
+        globalKey: 'srv:3',
+        kind: 'movie',
+        title: 'B1',
+      );
+
+      await db.clearAll('profile-a');
+
+      // Profile A rows gone
+      expect(
+        await (db.select(db.watchlistItems)..where((t) => t.profileId.equals('profile-a'))).get(),
+        isEmpty,
+      );
+      // Profile B rows still present
+      final bRows = await (db.select(db.watchlistItems)
+            ..where((t) => t.profileId.equals('profile-b')))
+          .get();
+      expect(bRows, hasLength(1));
+      expect(bRows.first.title, 'B1');
+    });
+
+    test('clearAll with empty profile is a no-op', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '1',
+        globalKey: 'srv:1',
+        kind: 'movie',
+        title: 'A1',
+      );
+
+      await db.clearAll('profile-z-empty');
+      expect(await db.select(db.watchlistItems).get(), hasLength(1));
+    });
+  });
+
+  // ============================================================
+  // watchWatchlist
+  // ============================================================
+
+  group('watchWatchlist', () {
+    test('stream emits current items on subscribe', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+
+      final stream = db.watchWatchlist('profile-a');
+      final items = await stream.first;
+      expect(items, hasLength(1));
+      expect(items.first.title, 'Test Movie');
+    });
+
+    test('stream emits on insert', () async {
+      final stream = db.watchWatchlist('profile-a');
+
+      // Start listening, check initial state is empty
+      final emitted = <List<WatchlistItem>>[];
+      final sub = stream.listen((items) {
+        emitted.add(items);
+      });
+
+      // Give it a moment to emit the initial empty list
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      // Insert an item
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+
+      // Give the stream time to emit
+      await Future.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
+
+      // Should have at least the initial empty + the insert emission
+      expect(emitted.length, greaterThanOrEqualTo(2));
+      // The last emission should contain our inserted item
+      final lastEmission = emitted.last;
+      expect(lastEmission.map((i) => i.title), contains('Test Movie'));
+    });
+
+    test('stream emits empty when all items removed', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+
+      final stream = db.watchWatchlist('profile-a');
+      final emitted = <List<WatchlistItem>>[];
+      final sub = stream.listen(emitted.add);
+
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'Test Movie',
+      );
+
+      await Future.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
+
+      final lastEmission = emitted.last;
+      expect(lastEmission, isEmpty);
+    });
+
+    test('stream only emits for the watched profile', () async {
+      final stream = db.watchWatchlist('profile-a');
+      final emitted = <List<WatchlistItem>>[];
+      final sub = stream.listen(emitted.add);
+
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      // Insert into profile-b — should NOT trigger emission
+      await db.toggleBookmark(
+        profileId: 'profile-b',
+        serverId: 'srv',
+        ratingKey: '100',
+        globalKey: 'srv:100',
+        kind: 'movie',
+        title: 'B Movie',
+      );
+
+      await Future.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
+
+      // The only emission should be the initial one (empty or not)
+      // Profile B insertion should not appear in profile A's stream
+      for (final items in emitted) {
+        expect(items.where((i) => i.profileId == 'profile-b'), isEmpty);
+      }
+    });
+  });
+}

--- a/test/navigation/navigation_tabs_test.dart
+++ b/test/navigation/navigation_tabs_test.dart
@@ -2,6 +2,56 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:plezy/navigation/navigation_tabs.dart';
 
 void main() {
+  group('NavigationTabId enum', () {
+    test('contains watchlist between downloads and settings', () {
+      expect(NavigationTabId.values.indexOf(NavigationTabId.watchlist),
+          NavigationTabId.values.indexOf(NavigationTabId.downloads) + 1);
+      expect(
+          NavigationTabId.values.indexOf(NavigationTabId.watchlist),
+          NavigationTabId.values.indexOf(NavigationTabId.settings) - 1,
+      );
+    });
+  });
+
+  group('allNavigationTabs', () {
+    test('includes watchlist with onlineOnly: false', () {
+      final watchlistTab = allNavigationTabs.where((t) => t.id == NavigationTabId.watchlist);
+      expect(watchlistTab, hasLength(1));
+      expect(watchlistTab.first.onlineOnly, isFalse);
+    });
+
+    test('watchlist is positioned between downloads and settings', () {
+      final ids = allNavigationTabs.map((t) => t.id).toList();
+      final watchlistIdx = ids.indexOf(NavigationTabId.watchlist);
+      final downloadsIdx = ids.indexOf(NavigationTabId.downloads);
+      final settingsIdx = ids.indexOf(NavigationTabId.settings);
+      expect(watchlistIdx, greaterThan(downloadsIdx));
+      expect(watchlistIdx, lessThan(settingsIdx));
+    });
+  });
+
+  group('NavigationTab.getVisibleTabs', () {
+    test('includes watchlist when online', () {
+      final tabs = NavigationTab.getVisibleTabs(isOffline: false, hasLiveTv: false);
+      expect(tabs.any((t) => t.id == NavigationTabId.watchlist), isTrue);
+    });
+
+    test('includes watchlist when offline (onlineOnly: false)', () {
+      final tabs = NavigationTab.getVisibleTabs(isOffline: true, hasLiveTv: false);
+      expect(tabs.any((t) => t.id == NavigationTabId.watchlist), isTrue);
+    });
+  });
+
+  group('NavigationTab.indexFor', () {
+    test('returns correct index for watchlist', () {
+      final idx = NavigationTab.indexFor(NavigationTabId.watchlist,
+          isOffline: false, hasLiveTv: false);
+      expect(idx, isNonNegative);
+      final tabs = NavigationTab.getVisibleTabs(isOffline: false, hasLiveTv: false);
+      expect(tabs[idx].id, NavigationTabId.watchlist);
+    });
+  });
+
   group('NavigationTab.resolveDefaultTab', () {
     test('offline prefers Downloads when available', () {
       expect(

--- a/test/navigation/watchlist_navigation_test.dart
+++ b/test/navigation/watchlist_navigation_test.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/navigation/navigation_tabs.dart';
+import 'package:plezy/providers/hidden_libraries_provider.dart';
+import 'package:plezy/providers/libraries_provider.dart';
+import 'package:plezy/providers/multi_server_provider.dart';
+import 'package:plezy/services/data_aggregation_service.dart';
+import 'package:plezy/services/multi_server_manager.dart';
+import 'package:plezy/services/settings_service.dart';
+import 'package:plezy/theme/mono_tokens.dart';
+import 'package:plezy/utils/platform_detector.dart';
+import 'package:plezy/widgets/side_navigation_rail.dart';
+import 'package:provider/provider.dart';
+
+import '../test_helpers/prefs.dart';
+
+const _testTokens = MonoTokens(
+  radiusSm: 8,
+  radiusMd: 12,
+  space: 8,
+  fast: Duration(milliseconds: 1),
+  normal: Duration(milliseconds: 1),
+  slow: Duration(milliseconds: 1),
+  bg: Colors.black,
+  surface: Colors.black,
+  outline: Colors.white24,
+  text: Colors.white,
+  textMuted: Colors.white70,
+  splashFactory: NoSplash.splashFactory,
+);
+
+Future<void> _press(WidgetTester tester, LogicalKeyboardKey key) async {
+  await tester.sendKeyEvent(key);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pumpBasicRail(
+  WidgetTester tester, {
+  GlobalKey<SideNavigationRailState>? sideNavKey,
+  NavigationTabId selectedTab = NavigationTabId.discover,
+  bool isSidebarFocused = false,
+  bool alwaysExpanded = false,
+}) async {
+  await SettingsService.getInstance();
+
+  final librariesProvider = LibrariesProvider();
+  addTearDown(librariesProvider.dispose);
+
+  final hiddenLibrariesProvider = HiddenLibrariesProvider();
+  await hiddenLibrariesProvider.ensureInitialized();
+  addTearDown(hiddenLibrariesProvider.dispose);
+
+  final manager = MultiServerManager();
+  final aggregation = DataAggregationService(manager);
+  final multiServerProvider = MultiServerProvider(manager, aggregation);
+  addTearDown(multiServerProvider.dispose);
+
+  await tester.pumpWidget(
+    TranslationProvider(
+      child: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<LibrariesProvider>.value(value: librariesProvider),
+          ChangeNotifierProvider<HiddenLibrariesProvider>.value(value: hiddenLibrariesProvider),
+          ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(extensions: const [_testTokens]),
+          home: Scaffold(
+            body: SideNavigationRail(
+              key: sideNavKey,
+              selectedTab: selectedTab,
+              isSidebarFocused: isSidebarFocused,
+              alwaysExpanded: alwaysExpanded,
+              onDestinationSelected: (_) {},
+              onLibrarySelected: (_) {},
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    TvDetectionService.debugSetAppleTVOverride(null);
+    TvDetectionService.setForceTVSync(false);
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  });
+
+  group('NavigationTab.getVisibleTabs', () {
+    test('includes watchlist when online', () {
+      final tabs = NavigationTab.getVisibleTabs(isOffline: false, hasLiveTv: false);
+      expect(tabs.any((t) => t.id == NavigationTabId.watchlist), isTrue);
+    });
+
+    test('includes watchlist when offline (onlineOnly: false)', () {
+      final tabs = NavigationTab.getVisibleTabs(isOffline: true, hasLiveTv: false);
+      expect(tabs.any((t) => t.id == NavigationTabId.watchlist), isTrue);
+    });
+
+    test('watchlist has icon Symbols.bookmark_rounded and onlineOnly: false', () {
+      final watchlistTab = allNavigationTabs.firstWhere((t) => t.id == NavigationTabId.watchlist);
+      expect(watchlistTab.onlineOnly, isFalse);
+    });
+  });
+
+  group('SideNavigationRail watchlist item', () {
+    testWidgets('renders watchlist nav item between downloads and settings', (tester) async {
+      await _pumpBasicRail(tester, alwaysExpanded: true);
+
+      // The rail is alwaysExpanded so labels should be visible.
+      // Find all NavigationRailItem widgets and verify their labels.
+      final navItems = tester.widgetList<NavigationRailItem>(find.byType(NavigationRailItem));
+      final labels = navItems.map((item) {
+        final textWidget = (item.label is Text) ? item.label as Text : null;
+        return textWidget?.data;
+      }).whereType<String>().toList();
+
+      // Watchlist should appear in the label list.
+      expect(labels, contains('Watchlist'));
+
+      // Watchlist should be after Downloads and before Settings.
+      final watchlistIdx = labels.indexOf('Watchlist');
+      final downloadsIdx = labels.indexOf('Downloads');
+      final settingsIdx = labels.indexOf('Settings');
+      expect(watchlistIdx, greaterThan(downloadsIdx));
+      expect(watchlistIdx, lessThan(settingsIdx));
+    });
+
+    testWidgets('watchlist nav item is selected when selectedTab is watchlist', (tester) async {
+      await _pumpBasicRail(tester, selectedTab: NavigationTabId.watchlist, alwaysExpanded: true);
+
+      // The watchlist label should have bold styling (FontWeight.w600) when selected.
+      final navItems = tester.widgetList<NavigationRailItem>(find.byType(NavigationRailItem));
+      NavigationRailItem? watchlistItem;
+      for (final item in navItems) {
+        if (item.label is Text) {
+          final text = item.label as Text;
+          if (text.data == 'Watchlist') {
+            watchlistItem = item;
+            break;
+          }
+        }
+      }
+      expect(watchlistItem, isNotNull);
+      expect(watchlistItem!.isSelected, isTrue);
+    });
+
+    testWidgets('watchlist nav item is hidden on Apple TV', (tester) async {
+      TvDetectionService.debugSetAppleTVOverride(true);
+      addTearDown(() => TvDetectionService.debugSetAppleTVOverride(null));
+      await SettingsService.getInstance();
+
+      final librariesProvider = LibrariesProvider();
+      addTearDown(librariesProvider.dispose);
+
+      final hiddenLibrariesProvider = HiddenLibrariesProvider();
+      await hiddenLibrariesProvider.ensureInitialized();
+      addTearDown(hiddenLibrariesProvider.dispose);
+
+      final manager = MultiServerManager();
+      final aggregation = DataAggregationService(manager);
+      final multiServerProvider = MultiServerProvider(manager, aggregation);
+      addTearDown(multiServerProvider.dispose);
+
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: MultiProvider(
+            providers: [
+              ChangeNotifierProvider<LibrariesProvider>.value(value: librariesProvider),
+              ChangeNotifierProvider<HiddenLibrariesProvider>.value(value: hiddenLibrariesProvider),
+              ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ],
+            child: MaterialApp(
+              theme: ThemeData(extensions: const [_testTokens]),
+              home: Scaffold(
+                body: SideNavigationRail(
+                  selectedTab: NavigationTabId.discover,
+                  isSidebarFocused: true,
+                  alwaysExpanded: true,
+                  onDestinationSelected: (_) {},
+                  onLibrarySelected: (_) {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // On Apple TV, neither Downloads nor Watchlist labels should appear.
+      final allText = find.byType(Text);
+      final labels = tester.widgetList<Text>(allText).map((t) => t.data).whereType<String>().toList();
+      expect(labels, isNot(contains('Watchlist')));
+      expect(labels, isNot(contains('Downloads')));
+    });
+  });
+
+  group('SideNavigationRail watchlist focus keys', () {
+    testWidgets('watchlist focus key resolves when selectedTab is watchlist', (tester) async {
+      final sideNavKey = GlobalKey<SideNavigationRailState>();
+      await _pumpBasicRail(
+        tester,
+        sideNavKey: sideNavKey,
+        selectedTab: NavigationTabId.watchlist,
+        isSidebarFocused: true,
+        alwaysExpanded: true,
+      );
+
+      // Focus the active item — should be the watchlist item.
+      sideNavKey.currentState!.focusActiveItem();
+      await tester.pumpAndSettle();
+
+      // The focused NavigationRailItem should be the watchlist one.
+      final focusedItem = find.descendant(
+        of: find.byType(SideNavigationRail),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is NavigationRailItem && widget.focusNode.hasFocus,
+        ),
+      );
+      expect(focusedItem, findsOneWidget);
+
+      final focusedWidget = tester.widget<NavigationRailItem>(focusedItem);
+      final label = (focusedWidget.label as Text).data;
+      expect(label, 'Watchlist');
+    });
+
+    testWidgets('D-pad down from downloads navigates to watchlist, then settings', (tester) async {
+      final sideNavKey = GlobalKey<SideNavigationRailState>();
+      await _pumpBasicRail(
+        tester,
+        sideNavKey: sideNavKey,
+        selectedTab: NavigationTabId.downloads,
+        isSidebarFocused: true,
+        alwaysExpanded: true,
+      );
+
+      // Focus the active item (downloads).
+      sideNavKey.currentState!.focusActiveItem();
+      await tester.pumpAndSettle();
+
+      // Press down once — should move to watchlist.
+      await _press(tester, LogicalKeyboardKey.arrowDown);
+
+      var focusedItem = find.descendant(
+        of: find.byType(SideNavigationRail),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is NavigationRailItem && widget.focusNode.hasFocus,
+        ),
+      );
+      expect(focusedItem, findsOneWidget);
+      var focusedWidget = tester.widget<NavigationRailItem>(focusedItem);
+      expect((focusedWidget.label as Text).data, 'Watchlist');
+
+      // Press down again — should move to settings.
+      await _press(tester, LogicalKeyboardKey.arrowDown);
+
+      focusedItem = find.descendant(
+        of: find.byType(SideNavigationRail),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is NavigationRailItem && widget.focusNode.hasFocus,
+        ),
+      );
+      expect(focusedItem, findsOneWidget);
+      focusedWidget = tester.widget<NavigationRailItem>(focusedItem);
+      expect((focusedWidget.label as Text).data, 'Settings');
+    });
+  });
+}

--- a/test/providers/watchlist_provider_test.dart
+++ b/test/providers/watchlist_provider_test.dart
@@ -1,0 +1,364 @@
+import 'dart:async';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/database/app_database.dart';
+import 'package:plezy/database/watchlist_operations.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
+import 'package:plezy/providers/watchlist_provider.dart';
+
+MediaItem _makeMediaItem({
+  required String id,
+  required MediaKind kind,
+  String serverId = 'srv',
+  String title = 'Test Title',
+  String? thumbPath,
+  int? year,
+  int? index,
+  String? parentTitle,
+}) {
+  return MediaItem(
+    id: id,
+    backend: MediaBackend.plex,
+    kind: kind,
+    serverId: serverId,
+    title: title,
+    thumbPath: thumbPath,
+    year: year,
+    index: index,
+    parentTitle: parentTitle,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late WatchlistProvider provider;
+  StreamSubscription<void>? _listenSub;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    provider = WatchlistProvider(database: db);
+    // Attach a listener so we can verify safeNotifyListeners fires
+    provider.addListener(() {});
+  });
+
+  tearDown(() async {
+    _listenSub?.cancel();
+    await db.close();
+    if (!provider.isDisposed) {
+      provider.dispose();
+    }
+  });
+
+  // ============================================================
+  // toggleBookmark
+  // ============================================================
+
+  group('toggleBookmark', () {
+    test('delegates insert to database and updates _items map', () async {
+      provider.setActiveProfileId('profile-a');
+      // Allow stream subscription to settle
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final movie = _makeMediaItem(id: '100', kind: MediaKind.movie, serverId: 'srv', title: 'Star Wars', year: 1977);
+
+      await provider.toggleBookmark(movie);
+
+      // After toggle, the item should be bookmarked
+      expect(provider.isBookmarked(movie.globalKey), isTrue);
+      expect(provider.items, contains(movie.globalKey));
+      expect(provider.items[movie.globalKey]!.title, 'Star Wars');
+    });
+
+    test('delegates delete on re-toggle and removes from _items', () async {
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final movie = _makeMediaItem(id: '100', kind: MediaKind.movie, serverId: 'srv', title: 'Star Wars', year: 1977);
+
+      await provider.toggleBookmark(movie);
+      expect(provider.isBookmarked(movie.globalKey), isTrue);
+
+      // Re-toggle removes
+      await provider.toggleBookmark(movie);
+      expect(provider.isBookmarked(movie.globalKey), isFalse);
+      expect(provider.items, isNot(contains(movie.globalKey)));
+    });
+
+    test('maps all MediaItem fields to DB columns', () async {
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final episode = MediaItem(
+        id: '200',
+        backend: MediaBackend.plex,
+        kind: MediaKind.episode,
+        serverId: 'srv',
+        title: 'Pilot',
+        thumbPath: '/thumb/200',
+        year: 2024,
+        index: 1,
+        parentTitle: 'Best Show',
+      );
+
+      await provider.toggleBookmark(episode);
+
+      final item = provider.items[episode.globalKey]!;
+      expect(item.profileId, 'profile-a');
+      expect(item.globalKey, 'srv:200');
+      expect(item.serverId, 'srv');
+      expect(item.ratingKey, '200');
+      expect(item.kind, 'episode');
+      expect(item.title, 'Pilot');
+      expect(item.thumbPath, '/thumb/200');
+      expect(item.year, 2024);
+      expect(item.index, 1);
+      expect(item.parentTitle, 'Best Show');
+    });
+
+    test('preserves profile isolation (profile A items not in profile B)', () async {
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final movieForA = _makeMediaItem(id: '101', kind: MediaKind.movie, serverId: 'srv', title: 'Avatar');
+      await provider.toggleBookmark(movieForA);
+      expect(provider.isBookmarked(movieForA.globalKey), isTrue);
+
+      // Switch profile
+      provider.setActiveProfileId('profile-b');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Profile B has no items
+      expect(provider.items, isEmpty);
+      expect(provider.isBookmarked(movieForA.globalKey), isFalse);
+    });
+  });
+
+  // ============================================================
+  // clearAll
+  // ============================================================
+
+  group('clearAll', () {
+    test('delegates to database and empties _items map', () async {
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      await provider.toggleBookmark(_makeMediaItem(id: '300', kind: MediaKind.movie, serverId: 'srv', title: 'M1'));
+      await provider.toggleBookmark(_makeMediaItem(id: '301', kind: MediaKind.show, serverId: 'srv', title: 'S1'));
+      expect(provider.items.length, 2);
+
+      await provider.clearAll();
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // _items should be empty after stream re-emits
+      expect(provider.items, isEmpty);
+    });
+  });
+
+  // ============================================================
+  // isBookmarked
+  // ============================================================
+
+  group('isBookmarked', () {
+    test('returns true when item is in _items', () async {
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      final movie = _makeMediaItem(id: '400', kind: MediaKind.movie, serverId: 'srv', title: 'Test');
+      expect(provider.isBookmarked(movie.globalKey), isFalse);
+
+      await provider.toggleBookmark(movie);
+      expect(provider.isBookmarked(movie.globalKey), isTrue);
+    });
+
+    test('returns false for unknown globalKey', () async {
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(provider.isBookmarked('srv:nonexistent'), isFalse);
+    });
+  });
+
+  // ============================================================
+  // setActiveProfileId
+  // ============================================================
+
+  group('setActiveProfileId', () {
+    test('populates _items from watchWatchlist stream', () async {
+      // Seed the database directly
+      await db.toggleBookmark(
+        profileId: 'profile-x',
+        serverId: 'srv',
+        ratingKey: '500',
+        globalKey: 'srv:500',
+        kind: 'movie',
+        title: 'Inception',
+        year: 2010,
+      );
+
+      provider.setActiveProfileId('profile-x');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(provider.items, isNotEmpty);
+      expect(provider.items['srv:500']!.title, 'Inception');
+    });
+
+    test('cancels old subscription and starts new one on profile change', () async {
+      // Seed profile-a
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '501',
+        globalKey: 'srv:501',
+        kind: 'movie',
+        title: 'Movie A',
+      );
+      // Seed profile-b
+      await db.toggleBookmark(
+        profileId: 'profile-b',
+        serverId: 'srv',
+        ratingKey: '502',
+        globalKey: 'srv:502',
+        kind: 'show',
+        title: 'Show B',
+      );
+
+      // Start with profile-a
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(provider.items.length, 1);
+      expect(provider.items['srv:501']!.title, 'Movie A');
+      expect(provider.isBookmarked('srv:502'), isFalse);
+
+      // Switch to profile-b
+      provider.setActiveProfileId('profile-b');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(provider.items.length, 1);
+      expect(provider.items['srv:502']!.title, 'Show B');
+      expect(provider.isBookmarked('srv:501'), isFalse);
+    });
+
+    test('cancels subscription when profileId is null', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-a',
+        serverId: 'srv',
+        ratingKey: '503',
+        globalKey: 'srv:503',
+        kind: 'movie',
+        title: 'Movie C',
+      );
+
+      provider.setActiveProfileId('profile-a');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(provider.items, isNotEmpty);
+
+      provider.setActiveProfileId(null);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Items should be cleared when no active profile
+      expect(provider.items, isEmpty);
+    });
+
+    test('no-ops when same profileId is set', () async {
+      await db.toggleBookmark(
+        profileId: 'profile-x',
+        serverId: 'srv',
+        ratingKey: '504',
+        globalKey: 'srv:504',
+        kind: 'movie',
+        title: 'Same Profile',
+      );
+
+      provider.setActiveProfileId('profile-x');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(provider.items.length, 1);
+
+      // Setting the same profile again should not reset state
+      provider.setActiveProfileId('profile-x');
+      expect(provider.items.length, 1);
+    });
+  });
+
+  // ============================================================
+  // items by kind getters
+  // ============================================================
+
+  group('filtered kind getters', () {
+    setUp(() async {
+      provider.setActiveProfileId('profile-k');
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      await provider.toggleBookmark(_makeMediaItem(id: 'm1', kind: MediaKind.movie, title: 'Movie 1'));
+      await provider.toggleBookmark(_makeMediaItem(id: 'm2', kind: MediaKind.movie, title: 'Movie 2'));
+      await provider.toggleBookmark(_makeMediaItem(id: 's1', kind: MediaKind.show, title: 'Show 1'));
+      await provider.toggleBookmark(
+        _makeMediaItem(id: 'se1', kind: MediaKind.season, title: 'Season 1', index: 1),
+      );
+      await provider.toggleBookmark(
+        _makeMediaItem(id: 'e1', kind: MediaKind.episode, title: 'Episode 1', index: 1),
+      );
+    });
+
+    test('movies returns only movie kind items', () {
+      final movies = provider.movies;
+      expect(movies.length, 2);
+      expect(movies.every((i) => i.kind == 'movie'), isTrue);
+    });
+
+    test('shows returns only show kind items', () {
+      final shows = provider.shows;
+      expect(shows.length, 1);
+      expect(shows.single.kind, 'show');
+    });
+
+    test('seasons returns only season kind items', () {
+      final seasons = provider.seasons;
+      expect(seasons.length, 1);
+      expect(seasons.single.kind, 'season');
+    });
+
+    test('episodes returns only episode kind items', () {
+      final episodes = provider.episodes;
+      expect(episodes.length, 1);
+      expect(episodes.single.kind, 'episode');
+    });
+
+    test('bookmarkedKeys matches items keys', () {
+      expect(provider.bookmarkedKeys, provider.items.keys.toSet());
+    });
+  });
+
+  // ============================================================
+  // dispose
+  // ============================================================
+
+  group('dispose', () {
+    test('cancels stream subscription on dispose', () async {
+      provider.setActiveProfileId('profile-d');
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(provider.items, isEmpty);
+
+      // Dispose should not throw
+      provider.dispose();
+      expect(provider.isDisposed, isTrue);
+    });
+  });
+
+  // ============================================================
+  // safeNotifyListeners
+  // ============================================================
+
+  group('safeNotifyListeners', () {
+    test('does not throw when called after dispose', () async {
+      provider.dispose();
+      // safeNotifyListeners should return false without throwing
+      final result = provider.safeNotifyListeners();
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/screens/media_detail/watchlist_action_button_test.dart
+++ b/test/screens/media_detail/watchlist_action_button_test.dart
@@ -1,0 +1,328 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:plezy/database/app_database.dart';
+import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/media/ids.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
+import 'package:plezy/media/media_server_client.dart';
+import 'package:plezy/media/server_capabilities.dart';
+import 'package:plezy/providers/download_provider.dart';
+import 'package:plezy/providers/multi_server_provider.dart';
+import 'package:plezy/providers/watch_state_store.dart';
+import 'package:plezy/providers/watchlist_provider.dart';
+import 'package:plezy/screens/media_detail_screen.dart';
+import 'package:plezy/services/data_aggregation_service.dart';
+import 'package:plezy/services/download_manager_service.dart';
+import 'package:plezy/services/download_storage_service.dart';
+import 'package:plezy/services/jellyfin_api_cache.dart';
+import 'package:plezy/services/multi_server_manager.dart';
+import 'package:plezy/services/plex_api_cache.dart';
+import 'package:plezy/services/settings_service.dart';
+import 'package:plezy/theme/mono_theme.dart';
+import 'package:plezy/utils/platform_detector.dart';
+import 'package:provider/provider.dart';
+
+import '../../test_helpers/prefs.dart';
+import '../../test_helpers/profile_navigation.dart';
+
+/// Minimal fake [MediaServerClient] that returns a single movie item.
+class _FakeMovieClient implements MediaServerClient {
+  final MediaItem _movie;
+
+  _FakeMovieClient(this._movie);
+
+  @override
+  ServerId get serverId => ServerId(_movie.serverId!);
+
+  @override
+  String? get serverName => 'TestServer';
+
+  @override
+  MediaBackend get backend => _movie.backend;
+
+  @override
+  ServerCapabilities get capabilities => ServerCapabilities.plex;
+
+  @override
+  Future<({MediaItem? item, MediaItem? onDeckEpisode})> fetchItemWithOnDeck(
+    String id,
+  ) async {
+    return (item: _movie, onDeckEpisode: null);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const serverId = 'srv-1';
+  const movieId = 'movie-1';
+  const profileId = 'profile-test';
+
+  MediaItem movie() => MediaItem(
+    id: movieId,
+    backend: MediaBackend.plex,
+    kind: MediaKind.movie,
+    serverId: serverId,
+    title: 'Test Movie',
+  );
+
+  // ── Full integration: pump with full provider tree (phone mode) ──
+
+  testWidgets('bookmark toggle renders, flips icon, and responds to tap', (tester) async {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    TvDetectionService.debugSetAppleTVOverride(false);
+    await SettingsService.getInstance();
+    LocaleSettings.setLocaleSync(AppLocale.en);
+    tester.view.physicalSize = const Size(1100, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      TvDetectionService.debugSetAppleTVOverride(null);
+    });
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    PlexApiCache.initialize(db);
+    JellyfinApiCache.initialize(db);
+
+    final watchlistProvider = WatchlistProvider(database: db);
+    watchlistProvider.setActiveProfileId(profileId);
+
+    final downloadManager = DownloadManagerService(
+      database: db,
+      storageService: DownloadStorageService.instance,
+      clientResolver: (serverId, {clientScopeId}) => null,
+    );
+    downloadManager.recoveryFuture = Future<void>.value();
+    final downloadProvider =
+        DownloadProvider.forTesting(downloadManager: downloadManager, database: db);
+    await downloadProvider.ensureInitialized();
+
+    final manager = MultiServerManager();
+    manager.debugRegisterClientForTesting(_FakeMovieClient(movie()));
+
+    final multiServerProvider = MultiServerProvider(manager, DataAggregationService(manager));
+    final watchStateOverlay = WatchStateStore();
+
+    addTearDown(() async {
+      watchStateOverlay.dispose();
+      if (!watchlistProvider.isDisposed) watchlistProvider.dispose();
+      downloadProvider.dispose();
+      multiServerProvider.dispose();
+      await db.close();
+    });
+
+    final metadata = movie();
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ChangeNotifierProvider<WatchlistProvider>.value(value: watchlistProvider),
+            ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
+            ChangeNotifierProvider<WatchStateStore>.value(value: watchStateOverlay),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(
+              child: MediaDetailScreen(metadata: metadata),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // TEST 1 — bookmark button renders
+    expect(find.byIcon(Symbols.bookmark), findsOneWidget);
+
+    // TEST 2 — icon flips to filled when bookmarked
+    await watchlistProvider.toggleBookmark(metadata);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.byIcon(Symbols.bookmark_rounded), findsOneWidget);
+    expect(find.byIcon(Symbols.bookmark), findsNothing);
+
+    // TEST 3 — icon flips back to outlined when unbookmarked
+    await watchlistProvider.toggleBookmark(metadata);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.byIcon(Symbols.bookmark), findsOneWidget);
+    expect(find.byIcon(Symbols.bookmark_rounded), findsNothing);
+
+    // TEST 4 — tap adds to watchlist + shows snackbar
+    await tester.tap(find.byIcon(Symbols.bookmark));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(watchlistProvider.isBookmarked(metadata.globalKey), isTrue);
+    expect(find.text('Added to watchlist'), findsOneWidget);
+  });
+
+  testWidgets('tap removes from watchlist and shows removal snackbar', (tester) async {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    TvDetectionService.debugSetAppleTVOverride(false);
+    await SettingsService.getInstance();
+    LocaleSettings.setLocaleSync(AppLocale.en);
+    tester.view.physicalSize = const Size(1100, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      TvDetectionService.debugSetAppleTVOverride(null);
+    });
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    PlexApiCache.initialize(db);
+    JellyfinApiCache.initialize(db);
+
+    final watchlistProvider = WatchlistProvider(database: db);
+    watchlistProvider.setActiveProfileId(profileId);
+
+    final downloadManager = DownloadManagerService(
+      database: db,
+      storageService: DownloadStorageService.instance,
+      clientResolver: (serverId, {clientScopeId}) => null,
+    );
+    downloadManager.recoveryFuture = Future<void>.value();
+    final downloadProvider =
+        DownloadProvider.forTesting(downloadManager: downloadManager, database: db);
+    await downloadProvider.ensureInitialized();
+
+    final manager = MultiServerManager();
+    manager.debugRegisterClientForTesting(_FakeMovieClient(movie()));
+
+    final multiServerProvider = MultiServerProvider(manager, DataAggregationService(manager));
+    final watchStateOverlay = WatchStateStore();
+
+    addTearDown(() async {
+      watchStateOverlay.dispose();
+      if (!watchlistProvider.isDisposed) watchlistProvider.dispose();
+      downloadProvider.dispose();
+      multiServerProvider.dispose();
+      await db.close();
+    });
+
+    final metadata = movie();
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ChangeNotifierProvider<WatchlistProvider>.value(value: watchlistProvider),
+            ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
+            ChangeNotifierProvider<WatchStateStore>.value(value: watchStateOverlay),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(
+              child: MediaDetailScreen(metadata: metadata),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Bookmark first so we can test removal
+    await watchlistProvider.toggleBookmark(metadata);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // Tap the filled bookmark icon to remove
+    await tester.tap(find.byIcon(Symbols.bookmark_rounded));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(watchlistProvider.isBookmarked(metadata.globalKey), isFalse);
+    expect(find.text('Removed from watchlist'), findsOneWidget);
+  });
+
+  testWidgets('bookmark toggle is always visible (not gated by offline)', (tester) async {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    TvDetectionService.debugSetAppleTVOverride(false);
+    await SettingsService.getInstance();
+    LocaleSettings.setLocaleSync(AppLocale.en);
+    tester.view.physicalSize = const Size(1100, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+      TvDetectionService.debugSetAppleTVOverride(null);
+    });
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    PlexApiCache.initialize(db);
+    JellyfinApiCache.initialize(db);
+
+    final watchlistProvider = WatchlistProvider(database: db);
+    watchlistProvider.setActiveProfileId(profileId);
+
+    final downloadManager = DownloadManagerService(
+      database: db,
+      storageService: DownloadStorageService.instance,
+      clientResolver: (serverId, {clientScopeId}) => null,
+    );
+    downloadManager.recoveryFuture = Future<void>.value();
+    final downloadProvider =
+        DownloadProvider.forTesting(downloadManager: downloadManager, database: db);
+    await downloadProvider.ensureInitialized();
+
+    final manager = MultiServerManager();
+    manager.debugRegisterClientForTesting(_FakeMovieClient(movie()));
+
+    final multiServerProvider = MultiServerProvider(manager, DataAggregationService(manager));
+    final watchStateOverlay = WatchStateStore();
+
+    addTearDown(() async {
+      watchStateOverlay.dispose();
+      if (!watchlistProvider.isDisposed) watchlistProvider.dispose();
+      downloadProvider.dispose();
+      multiServerProvider.dispose();
+      await db.close();
+    });
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ChangeNotifierProvider<WatchlistProvider>.value(value: watchlistProvider),
+            ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
+            ChangeNotifierProvider<WatchStateStore>.value(value: watchStateOverlay),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(
+              child: MediaDetailScreen(metadata: movie()),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Bookmark icon should be visible regardless of connectivity
+    expect(find.byIcon(Symbols.bookmark), findsOneWidget);
+  });
+}

--- a/test/screens/watchlist/watchlist_screen_test.dart
+++ b/test/screens/watchlist/watchlist_screen_test.dart
@@ -1,0 +1,315 @@
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/database/app_database.dart';
+import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
+import 'package:plezy/providers/download_provider.dart';
+import 'package:plezy/providers/watchlist_provider.dart';
+import 'package:plezy/screens/watchlist/watchlist_screen.dart';
+import 'package:plezy/services/download_manager_service.dart';
+import 'package:plezy/services/download_storage_service.dart';
+import 'package:plezy/services/settings_service.dart';
+import 'package:plezy/theme/mono_theme.dart';
+import 'package:provider/provider.dart';
+
+import '../../test_helpers/prefs.dart';
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppDatabase db;
+  late WatchlistProvider watchlistProvider;
+  late DownloadProvider downloadProvider;
+
+  const profileId = 'profile-test';
+
+  setUp(() async {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    await SettingsService.getInstance();
+
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    watchlistProvider = WatchlistProvider(database: db);
+    watchlistProvider.setActiveProfileId(profileId);
+
+    final downloadManager = DownloadManagerService(
+      database: db,
+      storageService: DownloadStorageService.instance,
+      clientResolver: (serverId, {clientScopeId}) => null,
+    );
+    downloadProvider =
+        DownloadProvider.forTesting(downloadManager: downloadManager, database: db);
+    await downloadProvider.ensureInitialized();
+
+    // Let the stream subscription settle
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  });
+
+  tearDown(() async {
+    if (!watchlistProvider.isDisposed) {
+      watchlistProvider.dispose();
+    }
+    downloadProvider.dispose();
+    await db.close();
+  });
+
+  // Helper: insert a watchlist item via the provider (optimistic local update).
+  Future<void> insertItem({
+    required String ratingKey,
+    required String serverId,
+    required String kind,
+    required String title,
+    String? thumbPath,
+    int? year,
+    int? index,
+    String? parentTitle,
+  }) async {
+    await watchlistProvider.toggleBookmark(
+      MediaItem(
+        id: ratingKey,
+        backend: MediaBackend.plex,
+        kind: MediaKind.fromString(kind),
+        serverId: serverId,
+        title: title,
+        thumbPath: thumbPath,
+        year: year,
+        index: index,
+        parentTitle: parentTitle,
+      ),
+    );
+  }
+
+  Widget buildTestApp() {
+    return TranslationProvider(
+      child: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<WatchlistProvider>.value(value: watchlistProvider),
+          ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
+        ],
+        child: MaterialApp(
+          theme: monoTheme(dark: true),
+          home: const WatchlistScreen(),
+        ),
+      ),
+    );
+  }
+
+  // ============================================================
+  // Empty state
+  // ============================================================
+
+  group('empty state', () {
+    testWidgets('shows empty title and subtitle when no items', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+
+      // The empty state widget should show the watchlist empty message
+      expect(find.text('Your watchlist is empty'), findsOneWidget);
+      // The subtitle should also be visible
+      expect(
+        find.text('Bookmark movies and shows to find them here later.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('does not show clear-all button when empty', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+
+      expect(find.text('Clear All'), findsNothing);
+    });
+  });
+
+  // ============================================================
+  // Non-empty state with grouped content
+  // ============================================================
+
+  group('non-empty state', () {
+    setUp(() async {
+      // Insert one item per kind so all sections fit in the default viewport.
+      await insertItem(
+        ratingKey: 'm1',
+        serverId: 'srv',
+        kind: 'movie',
+        title: 'Inception',
+        year: 2010,
+      );
+      await insertItem(
+        ratingKey: 'm2',
+        serverId: 'srv',
+        kind: 'movie',
+        title: 'The Matrix',
+        year: 1999,
+      );
+      await insertItem(
+        ratingKey: 's1',
+        serverId: 'srv',
+        kind: 'show',
+        title: 'Breaking Bad',
+        year: 2008,
+      );
+      await insertItem(
+        ratingKey: 'se1',
+        serverId: 'srv',
+        kind: 'season',
+        title: 'Season 1',
+        parentTitle: 'Breaking Bad',
+        index: 1,
+      );
+      await insertItem(
+        ratingKey: 'ep1',
+        serverId: 'srv',
+        kind: 'episode',
+        title: 'Pilot',
+        parentTitle: 'Breaking Bad',
+        index: 1,
+      );
+      // Provider optimistically updates _items on toggleBookmark,
+      // so items are immediately available.
+    });
+
+    testWidgets('shows section headers for each non-empty group',
+        (tester) async {
+      // Use a tall viewport so all sliver sections are laid out.
+      tester.view.physicalSize = const Size(800, 3000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+      });
+
+      await tester.pumpWidget(buildTestApp());
+      // SliverLayoutBuilder needs multiple frames to resolve layout.
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Each non-empty kind should have a section header
+      expect(find.text('Movies'), findsOneWidget);
+      expect(find.text('Shows'), findsOneWidget);
+      expect(find.text('Seasons'), findsOneWidget);
+      expect(find.text('Episodes'), findsOneWidget);
+    });
+
+    testWidgets('shows FocusableMediaCard items inside each group',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 3000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+      });
+
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // The item titles should appear on the MediaCard widgets.
+      // Note: "Breaking Bad" appears as the show title AND as parentTitle
+      // on season/episode cards, so we use findsWidgets (at least one).
+      expect(find.text('Inception'), findsOneWidget);
+      expect(find.text('The Matrix'), findsOneWidget);
+      expect(find.text('Breaking Bad'), findsWidgets);
+      expect(find.text('Season 1'), findsOneWidget);
+      expect(find.text('Pilot'), findsOneWidget);
+    });
+
+    testWidgets('does not show empty state when items exist', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+
+      expect(find.text('Your watchlist is empty'), findsNothing);
+    });
+
+    testWidgets('groups are rendered in order: movies, shows, seasons, episodes',
+        (tester) async {
+      tester.view.physicalSize = const Size(800, 3000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.physicalSize = const Size(800, 600);
+        tester.view.devicePixelRatio = 1.0;
+      });
+
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Find the positions of each section header
+      final moviesHeader = tester.getTopLeft(find.text('Movies'));
+      final showsHeader = tester.getTopLeft(find.text('Shows'));
+      final seasonsHeader = tester.getTopLeft(find.text('Seasons'));
+      final episodesHeader = tester.getTopLeft(find.text('Episodes'));
+
+      expect(moviesHeader.dy, lessThan(showsHeader.dy));
+      expect(showsHeader.dy, lessThan(seasonsHeader.dy));
+      expect(seasonsHeader.dy, lessThan(episodesHeader.dy));
+    });
+  });
+
+  // ============================================================
+  // Clear-all dialog
+  // ============================================================
+
+  group('clear-all', () {
+    setUp(() async {
+      await insertItem(
+        ratingKey: 'm1',
+        serverId: 'srv',
+        kind: 'movie',
+        title: 'Inception',
+        year: 2010,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+
+    testWidgets('shows clear-all button when items exist', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+
+      expect(find.text('Clear All'), findsOneWidget);
+    });
+
+    testWidgets('clear-all dialog confirms and clears items', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+
+      // Tap the clear-all button
+      await tester.tap(find.text('Clear All'));
+      await tester.pump();
+
+      // AlertDialog should appear
+      expect(find.text('Clear All'), findsWidgets);
+      // Confirm button should be present
+      expect(find.text('Clear'), findsOneWidget);
+
+      // Tap Confirm to clear
+      await tester.tap(find.text('Clear'));
+      await tester.pump();
+
+      // After clear, should show empty state
+      expect(find.text('Your watchlist is empty'), findsOneWidget);
+    });
+
+    testWidgets('cancel on clear-all dialog keeps items', (tester) async {
+      await tester.pumpWidget(buildTestApp());
+      await tester.pump();
+
+      // Tap the clear-all button
+      await tester.tap(find.text('Clear All'));
+      await tester.pump();
+
+      // Tap Cancel to dismiss
+      await tester.tap(find.text('Cancel'));
+      await tester.pump();
+
+      // Items should still be present — empty state not shown
+      expect(find.text('Your watchlist is empty'), findsNothing);
+      expect(find.text('Inception'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a client-side Watchlist feature — a local bookmark system for movies, shows, seasons, and episodes. Profile-scoped, offline-capable, and purely additive (no existing behavior changes).

## What's included

- **Drift table** WatchlistItems with composite PK (profileId, globalKey) — schema v16→v17 migration
- **WatchlistProvider** — ChangeNotifierProxyProvider with stream-based reactive state
- **WatchlistScreen** — grouped grid by kind (Movies/TV Shows/Seasons/Episodes), empty state, clear-all with confirmation
- **Bookmark toggle** — FocusableAction in media detail screen action buttons
- **Navigation integration** — bottom nav tab, side rail entry, companion remote via next/prev
- **i18n** — full key set across 16 locales

## Changes

- 15 conventional commits across 5 layered PR slices
- 4 new source files, 8 modified source files
- 5 new test files (63 new tests)
- 2543 total tests passing, zero regressions

## Test plan

- `flutter test` — 2543/2543 passing
- `flutter analyze` — clean on all changed files
- APK built and tested on Android device — watchlist works end-to-end

## Notes

Port of the toffbrawny/plezy watchlist implementation, adapted and modernized for current upstream codebase (~2300 commits ahead of the original fork).