### PR TITLE
fix: make crash reporting opt-in instead of opt-out (privacy concern)

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -331,7 +331,7 @@ class SettingsService extends BaseSharedPreferencesService {
   static const String defaultCreditsPattern = r'(?:^|\b)(?:outro|closing|credits?|ending)(?:\b|$)|^ed(?:\s?\d+)?$';
 
   static const enableDebugLogging = BoolPref('enable_debug_logging', onWrite: setLoggerLevel);
-  static const crashReporting = BoolPref('crash_reporting', defaultValue: true);
+  static const crashReporting = BoolPref('crash_reporting', defaultValue: false);
   static const enableHardwareDecoding = BoolPref('enable_hardware_decoding', defaultValue: true);
   static const enableHDR = BoolPref('enable_hdr', defaultValue: true);
   static const preferredVideoCodec = StringPref('preferred_video_codec', defaultValue: 'auto');

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -157,14 +157,14 @@ void main() {
       final settings = await SettingsService.getInstance();
       final crashReporting = settings.listenable(SettingsService.crashReporting);
 
-      expect(crashReporting.value, isTrue);
+      expect(crashReporting.value, isFalse);
 
-      await settings.prefs.setBool(SettingsService.crashReporting.key, false);
-      expect(crashReporting.value, isTrue);
+      await settings.prefs.setBool(SettingsService.crashReporting.key, true);
+      expect(crashReporting.value, isFalse);
 
       settings.refreshListenables();
 
-      expect(crashReporting.value, isFalse);
+      expect(crashReporting.value, isTrue);
     });
 
     test('resetAllSettings refreshes active dynamic tracker prefs', () async {


### PR DESCRIPTION
## Problem

Crash reporting (Sentry) is enabled by default when `ENABLE_SENTRY` is compiled in. The `crashReporting` `BoolPref` defaults to `true`, meaning crash data is sent to a remote server (`bugs.plezy.app`) **without explicit user consent**.

This is a privacy concern because:
- Users have no initial consent dialog — they must discover and disable it themselves in Settings > Advanced
- The DSN points to a self-hosted Sentry instance, which users may not expect or trust
- Crash reports may contain sensitive data (stack traces, device info, usage patterns)

## Two-layer control system (for context)

| Layer | Default | Mechanism |
|---|---|---|
| Compile-time (`ENABLE_SENTRY`) | `false` | `--dart-define` at build time |
| Runtime (`crashReporting`) | `true` → **`false` (this PR)** | `BoolPref` in SharedPreferences |

The runtime toggle in Settings already exists — this PR only changes the **default** from opt-out to opt-in. Users who want to contribute crash reports can still enable it explicitly.

## Changes

- `lib/services/settings_service.dart`: change `crashReporting` default from `true` to `false`
- `test/services/settings_service_test.dart`: update test to reflect new default and keep `refreshListenables` test meaningful

## UX behavior after fix

1. Fresh install → crash reporting is **off** by default
2. User goes to Settings > Advanced → toggles "Crash Reporting" **on** if they want to help
3. Existing users with the setting already stored are unaffected (SharedPreferences persists their choice)