### PR TITLE
MacOS Video Optimisations for Older Machines

### DIFF
--- a/lib/mpv/player/player.dart
+++ b/lib/mpv/player/player.dart
@@ -348,8 +348,7 @@ abstract class Player {
   /// - true: Use ExoPlayer (default, better hardware support)
   /// - false: Use MPV (more features, ASS subtitle rendering)
   ///
-  /// [rendererConfig] is an optional map of renderer properties (vo, gpuApi,
-  /// gpuContext) passed to the native layer at initialization time (macOS only).
+  /// [rendererConfig] overrides mpv renderer properties (macOS only).
   factory Player({bool? useExoPlayer, Map<String, String>? rendererConfig}) {
     if (Platform.isAndroid) {
       // Default to ExoPlayer on Android, with MPV as fallback

--- a/lib/mpv/player/player.dart
+++ b/lib/mpv/player/player.dart
@@ -347,7 +347,10 @@ abstract class Player {
   /// On Android, pass [useExoPlayer] to override the default:
   /// - true: Use ExoPlayer (default, better hardware support)
   /// - false: Use MPV (more features, ASS subtitle rendering)
-  factory Player({bool? useExoPlayer}) {
+  ///
+  /// [rendererConfig] is an optional map of renderer properties (vo, gpuApi,
+  /// gpuContext) passed to the native layer at initialization time (macOS only).
+  factory Player({bool? useExoPlayer, Map<String, String>? rendererConfig}) {
     if (Platform.isAndroid) {
       // Default to ExoPlayer on Android, with MPV as fallback
       // The caller should pass useExoPlayer based on SettingsService.getUseExoPlayer()
@@ -358,7 +361,7 @@ abstract class Player {
       return PlayerNative(); // MPV fallback
     }
     if (Platform.isMacOS || Platform.isIOS) {
-      return PlayerNative();
+      return PlayerNative(rendererConfig: rendererConfig);
     }
     if (Platform.isWindows) {
       return PlayerWindows();

--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -13,6 +13,12 @@ class PlayerNative extends PlayerBase {
   String _dvConversionMode = 'auto';
   String _dvConversionLog = 'no';
 
+  /// Optional renderer configuration passed to the native layer during init.
+  /// Keys: 'vo', 'gpuApi', 'gpuContext'. macOS only.
+  final Map<String, String>? rendererConfig;
+
+  PlayerNative({this.rendererConfig});
+
   @override
   int? get textureId => _textureIdValue;
 
@@ -122,7 +128,7 @@ class PlayerNative extends PlayerBase {
 
   Future<void> _doInitialize() async {
     try {
-      final result = await invoke<Object>('initialize');
+      final result = await invoke<Object>('initialize', rendererConfig);
       final bool ok;
       if (result is int) {
         // Linux: initialize returns the texture ID

--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -13,8 +13,7 @@ class PlayerNative extends PlayerBase {
   String _dvConversionMode = 'auto';
   String _dvConversionLog = 'no';
 
-  /// Optional renderer configuration passed to the native layer during init.
-  /// Keys: 'vo', 'gpuApi', 'gpuContext'. macOS only.
+  /// macOS renderer overrides: 'vo', 'gpuApi', 'gpuContext'.
   final Map<String, String>? rendererConfig;
 
   PlayerNative({this.rendererConfig});

--- a/lib/screens/settings/playback_settings_screen.dart
+++ b/lib/screens/settings/playback_settings_screen.dart
@@ -53,6 +53,7 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
         if (Platform.isAndroid) _playerBackendSelector(),
         if (PlatformDetector.supportsExternalPlayers()) _externalPlayerTile(),
         _hardwareDecodingTile(),
+        if (Platform.isMacOS) _macosVideoOutputTile(),
         if (PlatformDetector.supportsPictureInPicture()) _autoPipTile(),
         if (Platform.isAndroid) _matchContentFrameRateTile(),
         if (Platform.isWindows) _matchRefreshRateTile(),
@@ -245,6 +246,18 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
     icon: Symbols.hardware_rounded,
     title: t.settings.hardwareDecoding,
     subtitle: t.settings.hardwareDecodingDescription,
+  );
+
+  Widget _macosVideoOutputTile() => SettingSelectionTile<MacosVideoOutput, MacosVideoOutput>(
+    pref: SettingsService.macosVideoOutput,
+    icon: Symbols.display_settings_rounded,
+    title: 'Renderer Pipeline',
+    subtitleBuilder: (mode) => '${mode.displayLabel} · ${mode.description}',
+    options: MacosVideoOutput.values
+        .map((m) => DialogOption(value: m, title: '${m.displayLabel}\n${m.description}'))
+        .toList(),
+    decode: (m) => m,
+    encode: (m) => m,
   );
 
   Widget _autoPipTile() => SettingSwitchTile(

--- a/lib/screens/settings/playback_settings_screen.dart
+++ b/lib/screens/settings/playback_settings_screen.dart
@@ -54,6 +54,7 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
         if (PlatformDetector.supportsExternalPlayers()) _externalPlayerTile(),
         _hardwareDecodingTile(),
         if (Platform.isMacOS) _macosVideoOutputTile(),
+        if (Platform.isMacOS) _useSkiaRendererTile(),
         if (PlatformDetector.supportsPictureInPicture()) _autoPipTile(),
         if (Platform.isAndroid) _matchContentFrameRateTile(),
         if (Platform.isWindows) _matchRefreshRateTile(),
@@ -258,6 +259,13 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
         .toList(),
     decode: (m) => m,
     encode: (m) => m,
+  );
+
+  Widget _useSkiaRendererTile() => SettingSwitchTile(
+    pref: SettingsService.useSkiaRenderer,
+    icon: Symbols.brush_rounded,
+    title: 'Use Skia Renderer',
+    subtitle: 'Use Skia instead of Impeller (Metal). May reduce idle CPU/GPU usage. Requires app restart.',
   );
 
   Widget _autoPipTile() => SettingSwitchTile(

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -651,7 +651,16 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
       }
 
       initPhase = 'creating player';
-      final currentPlayer = Player(useExoPlayer: useExoPlayer);
+      Map<String, String>? rendererConfig;
+      if (Platform.isMacOS) {
+        final macosVo = settingsService.read(SettingsService.macosVideoOutput);
+        rendererConfig = {
+          'vo': macosVo.voValue,
+          'gpuApi': macosVo.gpuApiValue,
+          'gpuContext': macosVo.gpuContextValue,
+        };
+      }
+      final currentPlayer = Player(useExoPlayer: useExoPlayer, rendererConfig: rendererConfig);
       player = currentPlayer;
       _playerBackendLabel = currentPlayer.playerType;
       if (Platform.isAndroid && useExoPlayer) {

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -19,6 +19,14 @@ import '../navigation/navigation_tabs.dart';
 import '../utils/platform_detector.dart';
 import 'trackers/tracker_constants.dart';
 
+/// Called when the Skia/Impeller toggle changes. Updates the native Info.plist
+/// so the renderer switch takes effect on the next app launch.
+void _updateImpellerPlist(bool useSkia) {
+  if (!Platform.isMacOS) return;
+  const channel = MethodChannel('com.plezy/window_utils');
+  channel.invokeMethod('setImpellerEnabled', {'enabled': !useSkia});
+}
+
 enum ThemeMode { system, light, dark, oled }
 
 /// Library density is now an int 1–5 (1 = most compact, 5 = most comfortable).
@@ -382,6 +390,7 @@ class SettingsService extends BaseSharedPreferencesService {
     values: MacosVideoOutput.values,
     defaultValue: MacosVideoOutput.gpuNext,
   );
+  static const useSkiaRenderer = BoolPref('use_skia_renderer', onWrite: _updateImpellerPlist);
   static const enableHDR = BoolPref('enable_hdr', defaultValue: true);
   static const preferredVideoCodec = StringPref('preferred_video_codec', defaultValue: 'auto');
   static const preferredAudioCodec = StringPref('preferred_audio_codec', defaultValue: 'auto');

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -19,8 +19,7 @@ import '../navigation/navigation_tabs.dart';
 import '../utils/platform_detector.dart';
 import 'trackers/tracker_constants.dart';
 
-/// Called when the Skia/Impeller toggle changes. Updates the native Info.plist
-/// so the renderer switch takes effect on the next app launch.
+/// Updates the app bundle's Info.plist to toggle Impeller on next launch.
 void _updateImpellerPlist(bool useSkia) {
   if (!Platform.isMacOS) return;
   const channel = MethodChannel('com.plezy/window_utils');

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -66,6 +66,50 @@ extension SubtitleRenderScale on SubtitleRenderResolution {
 
 enum DvConversionModePreference { auto, disabled, dv81, hevcStrip }
 
+/// macOS video output (VO) backend. Affects rendering pipeline performance.
+enum MacosVideoOutput {
+  /// gpu-next with Vulkan via MoltenVK (default, best HDR support, heaviest).
+  gpuNext,
+
+  /// gpu with Vulkan via MoltenVK (simpler renderer, less shader overhead).
+  gpu,
+
+  /// gpu with OpenGL (avoids MoltenVK entirely, lightest GPU usage).
+  gpuOpenGL,
+}
+
+extension MacosVideoOutputConfig on MacosVideoOutput {
+  String get voValue => switch (this) {
+    MacosVideoOutput.gpuNext => 'gpu-next',
+    MacosVideoOutput.gpu => 'gpu',
+    MacosVideoOutput.gpuOpenGL => 'gpu',
+  };
+
+  String get gpuApiValue => switch (this) {
+    MacosVideoOutput.gpuNext => 'vulkan',
+    MacosVideoOutput.gpu => 'vulkan',
+    MacosVideoOutput.gpuOpenGL => 'opengl',
+  };
+
+  String get gpuContextValue => switch (this) {
+    MacosVideoOutput.gpuNext => 'moltenvk',
+    MacosVideoOutput.gpu => 'moltenvk',
+    MacosVideoOutput.gpuOpenGL => 'cocoa',
+  };
+
+  String get displayLabel => switch (this) {
+    MacosVideoOutput.gpuNext => 'gpu-next + Vulkan (Default)',
+    MacosVideoOutput.gpu => 'gpu + Vulkan',
+    MacosVideoOutput.gpuOpenGL => 'gpu + OpenGL',
+  };
+
+  String get description => switch (this) {
+    MacosVideoOutput.gpuNext => 'Best quality, HDR tone-mapping. Heaviest on CPU/GPU.',
+    MacosVideoOutput.gpu => 'Simpler shaders, still uses MoltenVK. Moderate load.',
+    MacosVideoOutput.gpuOpenGL => 'No MoltenVK overhead. Lightest, but no HDR.',
+  };
+}
+
 extension DvConversionModePreferenceNativeValue on DvConversionModePreference {
   String get nativeValue => switch (this) {
     DvConversionModePreference.auto => 'auto',
@@ -333,6 +377,11 @@ class SettingsService extends BaseSharedPreferencesService {
   static const enableDebugLogging = BoolPref('enable_debug_logging', onWrite: setLoggerLevel);
   static const crashReporting = BoolPref('crash_reporting', defaultValue: true);
   static const enableHardwareDecoding = BoolPref('enable_hardware_decoding', defaultValue: true);
+  static const macosVideoOutput = EnumPref<MacosVideoOutput>(
+    'macos_video_output',
+    values: MacosVideoOutput.values,
+    defaultValue: MacosVideoOutput.gpuNext,
+  );
   static const enableHDR = BoolPref('enable_hdr', defaultValue: true);
   static const preferredVideoCodec = StringPref('preferred_video_codec', defaultValue: 'auto');
   static const preferredAudioCodec = StringPref('preferred_audio_codec', defaultValue: 'auto');

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -3,6 +3,12 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
+    // Sync the Info.plist with the Skia renderer preference before the Flutter
+    // engine reads FLTEnableImpeller. UserDefaults keys written by
+    // SharedPreferences are prefixed with "flutter.".
+    let useSkia = UserDefaults.standard.bool(forKey: "flutter.use_skia_renderer")
+    WindowUtilsPlugin.updateImpellerPlist(enabled: !useSkia)
+
     let flutterViewController = FlutterViewController()
 
     // Keep the window itself opaque so WindowServer does not have to blend the

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -3,9 +3,7 @@ import FlutterMacOS
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
-    // Sync the Info.plist with the Skia renderer preference before the Flutter
-    // engine reads FLTEnableImpeller. UserDefaults keys written by
-    // SharedPreferences are prefixed with "flutter.".
+    // Sync Impeller/Skia plist setting before Flutter engine starts.
     let useSkia = UserDefaults.standard.bool(forKey: "flutter.use_skia_renderer")
     WindowUtilsPlugin.updateImpellerPlist(enabled: !useSkia)
 

--- a/macos/Runner/MpvPlayer/MpvPlayerPlugin.swift
+++ b/macos/Runner/MpvPlayer/MpvPlayerPlugin.swift
@@ -76,7 +76,7 @@ class MpvPlayerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, MpvPluginS
   func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "initialize":
-      handleInitialize(result: result)
+      handleInitialize(call: call, result: result)
 
     case "dispose":
       handleDispose(result: result)
@@ -219,7 +219,12 @@ class MpvPlayerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, MpvPluginS
 
   // MARK: - Platform-Specific Method Handlers
 
-  private func handleInitialize(result: @escaping FlutterResult) {
+  private func handleInitialize(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    let args = call.arguments as? [String: Any]
+    let vo = args?["vo"] as? String
+    let gpuApi = args?["gpuApi"] as? String
+    let gpuContext = args?["gpuContext"] as? String
+
     DispatchQueue.main.async { [weak self] in
       guard let self = self else {
         result(FlutterError(code: "ERROR", message: "Plugin deallocated", details: nil))
@@ -245,6 +250,9 @@ class MpvPlayerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, MpvPluginS
       // Create and initialize player core
       let core = MpvPlayerCore()
       core.delegate = self
+      core.rendererOverrideVo = vo
+      core.rendererOverrideGpuApi = gpuApi
+      core.rendererOverrideGpuContext = gpuContext
 
       guard core.initialize(in: window) else {
         print("[MpvPlayerPlugin] Failed to initialize MPV")

--- a/macos/Runner/WindowUtilsPlugin.swift
+++ b/macos/Runner/WindowUtilsPlugin.swift
@@ -269,8 +269,7 @@ class WindowUtilsPlugin: NSObject, FlutterPlugin {
     }
   }
 
-  /// Updates FLTEnableImpeller in the app bundle's Info.plist on disk.
-  /// Takes effect on the next app launch.
+  /// Updates FLTEnableImpeller in the app bundle's Info.plist. Takes effect on next launch.
   static func updateImpellerPlist(enabled: Bool) {
     let plistURL = Bundle.main.bundleURL.appendingPathComponent("Contents/Info.plist")
     guard let dict = NSMutableDictionary(contentsOf: plistURL) else { return }

--- a/macos/Runner/WindowUtilsPlugin.swift
+++ b/macos/Runner/WindowUtilsPlugin.swift
@@ -163,6 +163,12 @@ class WindowUtilsPlugin: NSObject, FlutterPlugin {
     case "isFullscreen":
       result(window.styleMask.contains(.fullScreen))
 
+    case "setImpellerEnabled":
+      let args = call.arguments as? [String: Any]
+      let enabled = args?["enabled"] as? Bool ?? true
+      Self.updateImpellerPlist(enabled: enabled)
+      result(nil)
+
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -261,5 +267,18 @@ class WindowUtilsPlugin: NSObject, FlutterPlugin {
       button.translatesAutoresizingMaskIntoConstraints = true
       superview.layoutSubtreeIfNeeded()
     }
+  }
+
+  /// Updates FLTEnableImpeller in the app bundle's Info.plist on disk.
+  /// Takes effect on the next app launch.
+  static func updateImpellerPlist(enabled: Bool) {
+    let plistURL = Bundle.main.bundleURL.appendingPathComponent("Contents/Info.plist")
+    guard let dict = NSMutableDictionary(contentsOf: plistURL) else { return }
+    if enabled {
+      dict.removeObject(forKey: "FLTEnableImpeller")
+    } else {
+      dict["FLTEnableImpeller"] = false
+    }
+    dict.write(to: plistURL, atomically: true)
   }
 }

--- a/shared/apple/MpvPlayer/MpvPlayerCoreBase.swift
+++ b/shared/apple/MpvPlayer/MpvPlayerCoreBase.swift
@@ -83,8 +83,7 @@ struct ServerDisplayCriteria {
 class MpvPlayerCoreBase: NSObject {
   weak var delegate: MpvPlayerDelegate?
 
-  /// Renderer overrides set from Dart settings (macOS only).
-  /// When nil, defaults are used (gpu-next + vulkan + moltenvk).
+  /// Renderer overrides from Dart settings (macOS). Nil = defaults.
   var rendererOverrideVo: String?
   var rendererOverrideGpuApi: String?
   var rendererOverrideGpuContext: String?
@@ -760,7 +759,6 @@ class MpvPlayerCoreBase: NSObject {
       let vo = rendererOverrideVo ?? "gpu-next"
       let gpuApi = rendererOverrideGpuApi ?? "vulkan"
       let gpuContext = rendererOverrideGpuContext ?? "moltenvk"
-      print("[MpvPlayerCore] Renderer config: vo=\(vo), gpu-api=\(gpuApi), gpu-context=\(gpuContext)")
       checkError(mpv_set_option_string(mpv, "vo", vo))
       checkError(mpv_set_option_string(mpv, "gpu-api", gpuApi))
       checkError(mpv_set_option_string(mpv, "gpu-context", gpuContext))

--- a/shared/apple/MpvPlayer/MpvPlayerCoreBase.swift
+++ b/shared/apple/MpvPlayer/MpvPlayerCoreBase.swift
@@ -83,6 +83,12 @@ struct ServerDisplayCriteria {
 class MpvPlayerCoreBase: NSObject {
   weak var delegate: MpvPlayerDelegate?
 
+  /// Renderer overrides set from Dart settings (macOS only).
+  /// When nil, defaults are used (gpu-next + vulkan + moltenvk).
+  var rendererOverrideVo: String?
+  var rendererOverrideGpuApi: String?
+  var rendererOverrideGpuContext: String?
+
   #if os(macOS)
     var metalLayer: MpvMetalLayer?
   #else
@@ -751,9 +757,13 @@ class MpvPlayerCoreBase: NSObject {
   private func applySharedMpvOptions() {
     guard let mpv else { return }
     #if os(macOS)
-      checkError(mpv_set_option_string(mpv, "vo", "gpu-next"))
-      checkError(mpv_set_option_string(mpv, "gpu-api", "vulkan"))
-      checkError(mpv_set_option_string(mpv, "gpu-context", "moltenvk"))
+      let vo = rendererOverrideVo ?? "gpu-next"
+      let gpuApi = rendererOverrideGpuApi ?? "vulkan"
+      let gpuContext = rendererOverrideGpuContext ?? "moltenvk"
+      print("[MpvPlayerCore] Renderer config: vo=\(vo), gpu-api=\(gpuApi), gpu-context=\(gpuContext)")
+      checkError(mpv_set_option_string(mpv, "vo", vo))
+      checkError(mpv_set_option_string(mpv, "gpu-api", gpuApi))
+      checkError(mpv_set_option_string(mpv, "gpu-context", gpuContext))
       checkError(mpv_set_option_string(mpv, "hwdec", "videotoolbox"))
     #else
       checkError(mpv_set_option_string(mpv, "vo", "avfoundation"))


### PR DESCRIPTION
Adds two macOS-only settings under Settings > Video Playback to reduce CPU/GPU load and fan noise on older Macs:

## Renderer Pipeline

Lets users switch the mpv video output backend between:
- **gpu-next + Vulkan** (default) -- best HDR/tone-mapping, heaviest
- **gpu + Vulkan** -- simpler shaders, still uses MoltenVK
- **gpu + OpenGL** -- bypasses MoltenVK entirely, lightest

Takes effect on the next video played.

## Flutter Renderer (Impeller/Skia)

Toggle to use Skia instead of Impeller (Metal) for Flutter's UI rendering. This can significantly reduce idle GPU usage on machines where Impeller's Metal backend runs hot.

Modifies the app bundle's `FLTEnableImpeller` Info.plist key. Requires app restart.

## Notes

- Both settings are macOS-only
- The Impeller toggle only works on unsigned/dev builds (modifies Info.plist on disk)
- Renderer pipeline properties are set at mpv init time and can't change mid-playback