### PR TITLE
fix(tv): don't leave the on-screen keyboard stuck on companion-remote search

### DIFF
--- a/lib/focus/focusable_text_field.dart
+++ b/lib/focus/focusable_text_field.dart
@@ -26,6 +26,30 @@ enum TvKeyboardAutoOpenBehavior {
   never,
 }
 
+/// Imperative handle to the TV on-screen keyboard of a [FocusableTextField] /
+/// [FocusableTextFormField]. Pass the same instance to the field's
+/// `tvKeyboardController`; the field's host attaches itself on mount.
+///
+/// Only meaningful on TV. On other platforms the OSK never exists, so every
+/// method is an effective no-op.
+class TvKeyboardController {
+  _FocusableTextInputHostState? _host;
+
+  void _attach(_FocusableTextInputHostState host) => _host = host;
+  void _detach(_FocusableTextInputHostState host) {
+    if (identical(_host, host)) _host = null;
+  }
+
+  /// Dismiss the OSK if it is open (and prevent it from auto-reopening while
+  /// the field keeps focus). No-op when nothing is open.
+  void closeKeyboard() => _host?._dismissTvKeyboard();
+
+  /// Focus the field but do NOT open the OSK for this focus entry. Used as a
+  /// fallback landing spot (e.g. a remote search that returned no results) so
+  /// the remote isn't stranded on an off-screen element.
+  void focusInputWithoutKeyboard() => _host?._focusWithoutKeyboard();
+}
+
 String _describeTextInputKey(KeyEvent event) {
   return 'type=${event.runtimeType} logical=${event.logicalKey.keyLabel}/${event.logicalKey.keyId} '
       'physical=${event.physicalKey.usbHidUsage} deviceType=${event.deviceType} character=${event.character}';
@@ -527,6 +551,7 @@ abstract class _FocusableTextInputBase extends StatelessWidget {
   final bool enabled;
   final bool enableTvKeyboard;
   final TvKeyboardAutoOpenBehavior tvKeyboardAutoOpenBehavior;
+  final TvKeyboardController? tvKeyboardController;
   final bool obscureText;
   final bool autocorrect;
   final bool enableSuggestions;
@@ -560,6 +585,7 @@ abstract class _FocusableTextInputBase extends StatelessWidget {
     this.enabled = true,
     this.enableTvKeyboard = true,
     this.tvKeyboardAutoOpenBehavior = TvKeyboardAutoOpenBehavior.onFocus,
+    this.tvKeyboardController,
     this.obscureText = false,
     this.autocorrect = true,
     this.enableSuggestions = true,
@@ -659,8 +685,18 @@ class _FocusableTextInputHostState extends State<_FocusableTextInputHost> {
       widget.input.focusNode ?? (_ownedFocusNode ??= FocusNode(debugLabel: 'FocusableTextInput'));
 
   @override
+  void initState() {
+    super.initState();
+    widget.input.tvKeyboardController?._attach(this);
+  }
+
+  @override
   void didUpdateWidget(_FocusableTextInputHost oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.input.tvKeyboardController, widget.input.tvKeyboardController)) {
+      oldWidget.input.tvKeyboardController?._detach(this);
+      widget.input.tvKeyboardController?._attach(this);
+    }
     if (oldWidget.input.focusNode != widget.input.focusNode) {
       // An open keyboard dialog intentionally survives rebuilds and focusNode
       // swaps; it is closed only when this host unmounts — see dispose.
@@ -675,6 +711,7 @@ class _FocusableTextInputHostState extends State<_FocusableTextInputHost> {
 
   @override
   void dispose() {
+    widget.input.tvKeyboardController?._detach(this);
     _restoreInstalledHandler();
     // The keyboard is a navigator route — it must not outlive the field that
     // opened it (e.g. a form section swapped out while the keyboard is up).
@@ -818,6 +855,28 @@ class _FocusableTextInputHostState extends State<_FocusableTextInputHost> {
     );
   }
 
+  /// Dismiss an open OSK imperatively (e.g. a companion-remote search that must
+  /// show results instead of the keyboard). Suppresses auto-reopen so a field
+  /// that regains focus when the dialog route pops does not relaunch it.
+  void _dismissTvKeyboard() {
+    // No-op when nothing is up: setting the suppress flag here (with no
+    // compensating unfocus to clear it) would block a later legitimate
+    // auto-open when the user deliberately focuses the field.
+    if (!_tvKeyboardOpen && !_tvKeyboardOpenScheduled) return;
+    _tvKeyboardOpenScheduled = false;
+    _suppressTvKeyboardAutoOpen = true;
+    _tvKeyboardHandle?.close();
+  }
+
+  /// Focus the field without opening the OSK for this focus entry. Suppress is
+  /// set BEFORE requestFocus so the resulting focus-change sync already sees it;
+  /// the flag persists for this focus and resets on the next unfocus.
+  void _focusWithoutKeyboard() {
+    _suppressTvKeyboardAutoOpen = true;
+    _tvKeyboardOpenScheduled = false;
+    (_installedFocusNode ?? _effectiveFocusNode).requestFocus();
+  }
+
   void _setNativeTextInputFocused(bool focused) {
     if (_reportedNativeTextInputFocused == focused) {
       _logTvTextInput('Host.setNativeTextInputFocused no-op focused=$focused');
@@ -907,6 +966,7 @@ class FocusableTextField extends _FocusableTextInputBase {
     super.enabled,
     super.enableTvKeyboard,
     super.tvKeyboardAutoOpenBehavior,
+    super.tvKeyboardController,
     super.obscureText,
     super.autocorrect,
     super.enableSuggestions,
@@ -983,6 +1043,7 @@ class FocusableTextFormField extends _FocusableTextInputBase {
     super.enabled,
     super.enableTvKeyboard,
     super.tvKeyboardAutoOpenBehavior,
+    super.tvKeyboardController,
     super.obscureText,
     super.autocorrect,
     super.enableSuggestions,

--- a/lib/mixins/refreshable.dart
+++ b/lib/mixins/refreshable.dart
@@ -13,6 +13,12 @@ mixin FocusableTab {
 mixin SearchInputFocusable {
   void focusSearchInput();
   void setSearchQuery(String query);
+
+  /// Apply a complete query submitted from outside the field (e.g. the Plezy
+  /// companion remote): run the search and land focus on the results without
+  /// leaving the TV on-screen keyboard open. Distinct from [setSearchQuery],
+  /// which only sets the text and lets the field stay focused for typing.
+  void submitSearchQuery(String query);
 }
 
 mixin LibraryLoadable {

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -791,11 +791,15 @@ class _MainScreenState extends State<MainScreen>
     receiver.onTabSettings = () => _selectTab(NavigationTabId.settings);
     receiver.onHome = () => _selectTab(NavigationTabId.discover);
     receiver.onSearchAction = (query) {
-      _selectTab(NavigationTabId.search);
-      if (query != null && query.isNotEmpty) {
+      final trimmed = query?.trim() ?? '';
+      final hasQuery = trimmed.isNotEmpty;
+      // With a query, don't focus the input (which would auto-open the TV
+      // keyboard); submitSearchQuery runs the search and focuses results.
+      _selectTab(NavigationTabId.search, focusSearchInput: !hasQuery);
+      if (hasQuery) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (_searchKey.currentState case final SearchInputFocusable searchable) {
-            searchable.setSearchQuery(query);
+            searchable.submitSearchQuery(trimmed);
           }
         });
       }
@@ -1387,7 +1391,7 @@ class _MainScreenState extends State<MainScreen>
     }
   }
 
-  void _selectTab(NavigationTabId tab) {
+  void _selectTab(NavigationTabId tab, {bool focusSearchInput = true}) {
     // Guard: ignore if tab isn't available in current mode
     if (!_getVisibleTabs(_isOffline).any((t) => t.id == tab)) return;
 
@@ -1418,7 +1422,10 @@ class _MainScreenState extends State<MainScreen>
       // Back-to-home keeps the sidebar focused (chain: content → sidebar →
       // home → exit); stealing focus here left _isSidebarFocused stuck true
       // while real focus sat on a content card (#1411).
-      if (!_isSidebarFocused) {
+      // A companion-remote search (focusSearchInput: false) must NOT focus the
+      // search input, since focusing it auto-opens the on-screen keyboard; the
+      // query submit focuses results instead.
+      if (!_isSidebarFocused && !(tab == NavigationTabId.search && !focusSearchInput)) {
         if (newState case final FocusableTab focusable) {
           focusable.focusActiveTabIfReady();
         }
@@ -1430,8 +1437,10 @@ class _MainScreenState extends State<MainScreen>
       _onDiscoverBecameVisible();
     }
 
-    // Focus search input after rebuild so IndexedStack has made it visible
-    if (tab == NavigationTabId.search) {
+    // Focus search input after rebuild so IndexedStack has made it visible.
+    // Skipped for a companion-remote search (focusSearchInput: false), whose
+    // submit runs the search and focuses results without opening the keyboard.
+    if (tab == NavigationTabId.search && focusSearchInput) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (_searchKey.currentState case final SearchInputFocusable searchable) {
           searchable.focusSearchInput();

--- a/lib/screens/search_screen.dart
+++ b/lib/screens/search_screen.dart
@@ -46,6 +46,11 @@ class _SearchScreenState extends State<SearchScreen>
   late final Debounce _searchDebounce;
   String _lastSearchedQuery = '';
   String? _focusResultsForQuery;
+  final _tvKeyboardController = TvKeyboardController();
+  // True while a companion-remote submit is awaiting results; drives the
+  // no-results focus fallback so the remote isn't stranded (see
+  // [_maybeFocusResultsAfterSubmit]).
+  bool _remoteSubmitPending = false;
 
   @override
   void initState() {
@@ -72,6 +77,7 @@ class _SearchScreenState extends State<SearchScreen>
     if (query.trim().isEmpty) {
       _searchDebounce.cancel();
       _focusResultsForQuery = null;
+      _remoteSubmitPending = false;
       setStateIfMounted(() {
         _searchResults = [];
         _hasSearched = false;
@@ -124,6 +130,7 @@ class _SearchScreenState extends State<SearchScreen>
       }
     } catch (e) {
       _focusResultsForQuery = null;
+      _remoteSubmitPending = false;
       if (mounted) {
         setStateIfMounted(() {
           _isSearching = false;
@@ -156,8 +163,16 @@ class _SearchScreenState extends State<SearchScreen>
   void _maybeFocusResultsAfterSubmit(String query, List<MediaItem> results) {
     if (_focusResultsForQuery == null || _focusResultsForQuery != query.trim()) return;
     _focusResultsForQuery = null;
-    if (results.isEmpty) return;
+    final focusInputWhenEmpty = _remoteSubmitPending;
+    _remoteSubmitPending = false;
     if (_searchController.text.trim() != query.trim()) return; // user kept editing
+    if (results.isEmpty) {
+      // A remote submit with no matches: land focus back on the (visible,
+      // query-filled) input without reopening the OSK, so the remote isn't
+      // stranded on the now-hidden previous tab.
+      if (focusInputWhenEmpty) _tvKeyboardController.focusInputWithoutKeyboard();
+      return;
+    }
     FocusUtils.requestFocusAfterBuild(this, _firstResultFocusNode);
   }
 
@@ -182,11 +197,49 @@ class _SearchScreenState extends State<SearchScreen>
     _searchFocusNode.requestFocus();
   }
 
-  /// Set the search query externally (e.g. from companion remote)
+  /// Set the search query text only (debounced search runs via the controller
+  /// listener; the field stays focused). For a completed remote submit use
+  /// [submitSearchQuery], which also focuses results and closes the OSK.
   @override
   void setSearchQuery(String query) {
     if (!mounted) return;
     _searchController.text = query;
+  }
+
+  /// Apply a complete query submitted from the Plezy companion remote: set the
+  /// text, dismiss any open on-screen keyboard, run the search now, and focus
+  /// the results when they land — never opening or re-opening the OSK (the user
+  /// already typed the query on their phone).
+  @override
+  void submitSearchQuery(String query) {
+    if (!mounted) return;
+    final trimmed = query.trim();
+    _searchController.text = trimmed;
+
+    // Focusing the field would auto-open the OSK; a remote search must not.
+    _tvKeyboardController.closeKeyboard();
+
+    if (trimmed.isEmpty) {
+      _focusResultsForQuery = null;
+      _remoteSubmitPending = false;
+      return;
+    }
+
+    // Results already match this exact query → jump straight to them.
+    if (_searchResults.isNotEmpty && !_isSearching && trimmed == _lastSearchedQuery.trim()) {
+      _remoteSubmitPending = false;
+      FocusUtils.requestFocusAfterBuild(this, _firstResultFocusNode);
+      return;
+    }
+
+    // Otherwise run now; results (or the empty-state fallback) take focus when
+    // the search lands, via _maybeFocusResultsAfterSubmit.
+    _focusResultsForQuery = trimmed;
+    _remoteSubmitPending = true;
+    if (_searchDebounce.isPending || !_isSearching) {
+      _searchDebounce.cancel();
+      _performSearch(trimmed);
+    }
   }
 
   // Public method to fully reload all content (for profile switches)
@@ -197,6 +250,7 @@ class _SearchScreenState extends State<SearchScreen>
     // Clear search results and search text for new profile
     _searchController.clear();
     _focusResultsForQuery = null;
+    _remoteSubmitPending = false;
     setStateIfMounted(() {
       _searchResults.clear();
       _isSearching = false;
@@ -262,6 +316,7 @@ class _SearchScreenState extends State<SearchScreen>
                 child: FocusableTextField(
                   controller: _searchController,
                   focusNode: _searchFocusNode,
+                  tvKeyboardController: _tvKeyboardController,
                   textInputAction: TextInputAction.search,
                   onNavigateLeft: _navigateToSidebar,
                   onNavigateDown: _searchResults.isNotEmpty && !_isSearching

--- a/test/mixins/refreshable_test.dart
+++ b/test/mixins/refreshable_test.dart
@@ -17,6 +17,7 @@ class _RefreshProbeState extends State<_RefreshProbe>
   int focusActiveTabCalls = 0;
   int focusSearchInputCalls = 0;
   String? lastSearchQuery;
+  String? lastSubmittedQuery;
   String? lastLibraryKey;
 
   @override
@@ -39,6 +40,9 @@ class _RefreshProbeState extends State<_RefreshProbe>
 
   @override
   void setSearchQuery(String query) => lastSearchQuery = query;
+
+  @override
+  void submitSearchQuery(String query) => lastSubmittedQuery = query;
 
   @override
   void loadLibraryByKey(String libraryGlobalKey) => lastLibraryKey = libraryGlobalKey;
@@ -182,6 +186,16 @@ void main() {
 
       state.setSearchQuery('');
       expect(state.lastSearchQuery, '');
+    });
+
+    testWidgets('submitSearchQuery() forwards the query argument', (tester) async {
+      late _RefreshProbeState state;
+      await tester.pumpWidget(_RefreshProbe(onState: (s) => state = s));
+
+      if (state case final SearchInputFocusable s) {
+        s.submitSearchQuery('movie');
+      }
+      expect(state.lastSubmittedQuery, 'movie');
     });
   });
 

--- a/test/screens/search_screen_test.dart
+++ b/test/screens/search_screen_test.dart
@@ -105,9 +105,59 @@ void main() {
     expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsNothing);
     expect(FocusManager.instance.primaryFocus?.debugLabel, 'SearchFirstResult');
   });
+
+  testWidgets('companion-remote submitSearchQuery dismisses an open OSK and focuses results', (tester) async {
+    final (client, key) = await _pumpTvSearchScreen(tester);
+    await tester.pumpAndSettle();
+    // The search screen autofocuses its input on TV, so the OSK is already up —
+    // this is exactly the "keyboard already open when the remote search
+    // arrives" flow (a common way to hit the stuck-keyboard bug).
+    expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsOneWidget);
+
+    (key.currentState! as SearchInputFocusable).submitSearchQuery('movie');
+    await tester.pumpAndSettle();
+
+    expect(client.queries, ['movie']);
+    expect(find.text('Movie 1'), findsOneWidget);
+    // The OSK is dismissed (and does not auto-reopen), focus lands on results.
+    expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsNothing);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'SearchFirstResult');
+
+    // Stays closed on subsequent frames.
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('companion-remote submitSearchQuery with no results focuses the input without the OSK', (tester) async {
+    final (client, key) = await _pumpTvSearchScreen(tester, items: []);
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsOneWidget);
+
+    (key.currentState! as SearchInputFocusable).submitSearchQuery('zzz');
+    await tester.pumpAndSettle();
+
+    expect(client.queries, ['zzz']);
+    // No results: the OSK is dismissed and the input is refocused WITHOUT
+    // reopening the keyboard, so the remote isn't stranded.
+    expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsNothing);
+    expect(FocusManager.instance.primaryFocus?.debugLabel, 'SearchInput');
+
+    // Does not auto-reopen while the input keeps focus.
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('tv_virtual_keyboard_panel')), findsNothing);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
 }
 
-Future<(_FakeMediaServerClient, GlobalKey<State<SearchScreen>>)> _pumpTvSearchScreen(WidgetTester tester) async {
+Future<(_FakeMediaServerClient, GlobalKey<State<SearchScreen>>)> _pumpTvSearchScreen(
+  WidgetTester tester, {
+  List<MediaItem>? items,
+}) async {
   TvDetectionService.debugSetAppleTVOverride(null);
   await TvDetectionService.getInstance(forceTv: true);
   TvDetectionService.setForceTVSync(true);
@@ -119,16 +169,18 @@ Future<(_FakeMediaServerClient, GlobalKey<State<SearchScreen>>)> _pumpTvSearchSc
   });
 
   final client = _FakeMediaServerClient(
-    items: [
-      MediaItem(
-        id: 'movie_1',
-        backend: MediaBackend.plex,
-        kind: MediaKind.movie,
-        title: 'Movie 1',
-        serverId: 'server_1',
-        serverName: 'Server',
-      ),
-    ],
+    items:
+        items ??
+        [
+          MediaItem(
+            id: 'movie_1',
+            backend: MediaBackend.plex,
+            kind: MediaKind.movie,
+            title: 'Movie 1',
+            serverId: 'server_1',
+            serverName: 'Server',
+          ),
+        ],
   );
   final manager = MultiServerManager()..debugRegisterClientForTesting(client);
   final provider = MultiServerProvider(manager, DataAggregationService(manager));


### PR DESCRIPTION
AI Used for commit. Also unable to test due to no dev account or mac.

## Summary

Searching from the **Plezy companion remote** left the custom TV on-screen keyboard (OSK) stuck on screen, covering the search results. This PR makes a remote-submitted query behave like a *submit* (run the search, focus the results) instead of *focus-to-type*, so the OSK is never left open.

## The bug

On TV, when you triggered a search from the phone companion remote:

1. The remote routed the app to the **Search** tab, which focuses the search field.
2. Focusing the field **auto-opens** the custom TV OSK (that's the intended behavior when a user navigates to search to type).
3. The query text was then injected into the field — but nothing ever dismissed the keyboard.

The OSK just sat there over the results. Its normal dismissal paths don't apply to a remote search: blur is intentionally a no-op (so the keyboard survives rebuilds/focus swaps), and the remote never sends a `Done`/`Back` key. The user already typed the query on their phone, so the OSK shouldn't have opened at all.

## Root cause

A remote search reused the same code path as "user tapped the Search tab to type": route to Search → focus input (→ auto-open OSK) → set text. That path has no step that closes the keyboard, because for interactive typing you *want* it open. There was no way to say "I have a complete query already — just run it and show results."

## The fix

Treat a query-bearing remote search as a submit, distinct from focus-to-type:

- **`SearchInputFocusable.submitSearchQuery(query)`** — new mixin method (`lib/mixins/refreshable.dart`). `SearchScreen` implements it to set the text, dismiss any open OSK, run the search immediately, and land focus on the first result when results arrive — never opening or re-opening the OSK. `setSearchQuery` keeps its old "just set text, stay focused for typing" semantics.
- **`main_screen.dart`** — the companion-remote `onSearchAction` now calls `submitSearchQuery` and routes to the Search tab with `focusSearchInput: false` for a query-bearing search, so `_selectTab` no longer focuses the input (which is what auto-opened the OSK). An empty remote search still focuses the input as before.
- **`TvKeyboardController`** — new optional, additive imperative handle on `FocusableTextField` / `FocusableTextFormField` (`lib/focus/focusable_text_field.dart`). It exposes `closeKeyboard()` (dismiss an already-open OSK and suppress auto-reopen while the field keeps focus) and `focusInputWithoutKeyboard()` (focus the field without opening the OSK). `closeKeyboard()` is needed because the phone's "Search tab" button opens the keyboard *before* the query is sent.
- **Empty-results fallback** — a remote submit that returns no matches focuses the (visible, query-filled) input *without* reopening the OSK, so the remote isn't stranded on the now-hidden previous tab.

The `FocusableTextField` change is purely additive — an optional nullable `tvKeyboardController` that defaults to `null` — so every other text field in the app is unchanged.

## Testing

Per `CONTRIBUTING.md`:

- `dart format` — no changes on the touched files.
- `flutter analyze` on the changed files — **No issues found**.
- `flutter test` on `test/mixins/refreshable_test.dart` and `test/screens/search_screen_test.dart` — **16/16 passing**.

New/updated tests cover: `submitSearchQuery` forwarding through the mixin, the TV-OSK search key moving focus to the first result, a companion-remote submit dismissing an open OSK and focusing results, and a no-results remote submit focusing the input without the OSK.

## Notes

- Only touches Dart source + tests; no native, dependency, or generated-file changes.
- No user-facing string changes, so no `slang` regeneration needed.
