### PR TITLE
fix(macos): apply volume changes immediately with AVFoundation

### DIFF
--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -410,7 +410,7 @@ class PlayerNative extends PlayerBase {
     }
     final logicalVolume = _macOSLogicalVolume;
     if (_usesMacOSOutputVolume && logicalVolume != null) {
-      await _applyMacOSVolume(logicalVolume);
+      await _applyMacOSVolumeOrFallback(logicalVolume);
     }
     await setProperty('pause', 'no');
   }
@@ -563,20 +563,31 @@ class PlayerNative extends PlayerBase {
 
   Future<void> _applyMacOSVolume(double logicalVolume, {bool resetSoftwareVolume = false}) async {
     if (logicalVolume <= 100.0) {
-      if (resetSoftwareVolume) {
-        await setProperty('volume', '100.0');
-        if (disposed || logicalVolume != _macOSLogicalVolume) return;
-      }
-
       final normalized = logicalVolume / 100.0;
       final outputVolume = normalized * normalized * normalized * 100.0;
       await setProperty('ao-volume', outputVolume.toString());
+      if (resetSoftwareVolume && !disposed && logicalVolume == _macOSLogicalVolume) {
+        await setProperty('volume', '100.0');
+      }
       return;
     }
 
     await setProperty('ao-volume', '100.0');
     if (disposed || logicalVolume != _macOSLogicalVolume) return;
     await setProperty('volume', logicalVolume.toString());
+  }
+
+  Future<void> _applyMacOSVolumeOrFallback(double logicalVolume, {bool resetSoftwareVolume = false}) async {
+    try {
+      await _applyMacOSVolume(logicalVolume, resetSoftwareVolume: resetSoftwareVolume);
+    } on PlatformException catch (error) {
+      if (error.code != 'SET_PROPERTY_FAILED') rethrow;
+      // ao-volume only exists while mpv has an active audio output. Keep the
+      // software-volume fallback until audio-out-params retries this after
+      // the AVFoundation renderer becomes ready.
+      if (disposed || logicalVolume != _macOSLogicalVolume) return;
+      await setProperty('volume', logicalVolume.toString());
+    }
   }
 
   @override
@@ -591,7 +602,7 @@ class PlayerNative extends PlayerBase {
         return;
       }
       if (name == 'audio-out-params') {
-        unawaited(_applyMacOSVolume(_macOSLogicalVolume!));
+        if (value != null) unawaited(_refreshMacOSOutputVolume());
         return;
       }
     }
@@ -612,9 +623,19 @@ class PlayerNative extends PlayerBase {
   Future<void> _restoreMacOSVolume(bool play, Object? token) async {
     final logicalVolume = _macOSLogicalVolume;
     if (logicalVolume == null) return;
-    await _applyMacOSVolume(logicalVolume);
+    await _applyMacOSVolumeOrFallback(logicalVolume, resetSoftwareVolume: true);
     if (token == null || !identical(token, _macOSVolumeRestoreToken)) return;
     if (play && !disposed) await setProperty('pause', 'no');
+  }
+
+  Future<void> _refreshMacOSOutputVolume() async {
+    final logicalVolume = _macOSLogicalVolume;
+    if (logicalVolume == null || disposed) return;
+    try {
+      await _applyMacOSVolumeOrFallback(logicalVolume, resetSoftwareVolume: true);
+    } catch (error, stackTrace) {
+      appLogger.w('MPV: failed to restore macOS output volume', error: error, stackTrace: stackTrace);
+    }
   }
 
   /// Gapless auto-advance detection: a `file-loaded` that open() didn't
@@ -706,8 +727,8 @@ class PlayerNative extends PlayerBase {
     if (_usesMacOSOutputVolume) {
       final resetSoftwareVolume = _macOSLogicalVolume == null || _macOSLogicalVolume! > 100.0;
       _macOSLogicalVolume = volume;
-      setVolumeState(volume);
-      await _applyMacOSVolume(volume, resetSoftwareVolume: resetSoftwareVolume);
+      await _applyMacOSVolumeOrFallback(volume, resetSoftwareVolume: resetSoftwareVolume);
+      if (!disposed && volume == _macOSLogicalVolume) setVolumeState(volume);
       return;
     }
     await setProperty('volume', volume.toString());

--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -42,6 +42,11 @@ class PlayerNative extends PlayerBase {
   String _dvConversionMode = 'auto';
   String _dvConversionLog = 'no';
 
+  // AVFoundation queues software-volume changes, but applies `ao-volume`
+  // immediately. Keep the logical value separate from mpv's software stage.
+  double? _macOSLogicalVolume;
+  bool? _macOSPlayAfterVolumeRestore;
+
   // Gapless-audio arming state (audioOnly). The native playlist is always
   // [current, next?]; these track whether entry 1 exists and what it plays.
   // _armedNextUri keeps the ORIGINAL media URI (the music service matches
@@ -59,6 +64,13 @@ class PlayerNative extends PlayerBase {
   /// Overrides the Linux-only video readiness handshake in host tests.
   @visibleForTesting
   static bool? debugUseLinuxVideoBootstrap;
+
+  /// Overrides macOS output-volume routing in host tests. Null uses the real
+  /// platform; audio-only players never use the video renderer path.
+  @visibleForTesting
+  static bool? debugMacOSOutputVolumeOverride;
+
+  bool get _usesMacOSOutputVolume => !audioOnly && (debugMacOSOutputVolumeOverride ?? Platform.isMacOS);
 
   // Set by open() and consumed by that load's file-loaded event, so it is
   // not mistaken for a gapless advance (see _handleAudioFileLoaded).
@@ -239,6 +251,9 @@ class PlayerNative extends PlayerBase {
       await observeProperty('demuxer-cache-state', _nodeFormat);
       await observeProperty('audio-device-list', _nodeFormat);
       await observeProperty('audio-device', 'string');
+      if (_usesMacOSOutputVolume) {
+        await observeProperty('audio-out-params', _nodeFormat);
+      }
 
       if (audioOnly) {
         // Debug aid only: raw playlist positions in the log trail. Gapless
@@ -348,8 +363,12 @@ class PlayerNative extends PlayerBase {
       await setProperty('start', 'none');
     }
 
-    // Prevents race condition that can freeze the video decoder on Android (issue #226).
-    if (!play) {
+    // Prevents a race that can freeze the Android decoder (issue #226). The
+    // macOS AVFoundation path also opens paused so its per-renderer volume can
+    // be restored before any queued audio becomes audible.
+    final gateMacOSOutputVolume = _usesMacOSOutputVolume && _macOSLogicalVolume != null;
+    if (gateMacOSOutputVolume) _macOSPlayAfterVolumeRestore = play;
+    if (!play || gateMacOSOutputVolume) {
       await setProperty('pause', 'yes');
     }
 
@@ -375,7 +394,7 @@ class PlayerNative extends PlayerBase {
     // file before resolving, so explicitly unpause for the replacement. Set
     // after loadfile so the paused old file never audibly unpauses
     // pre-replace.
-    if (play) {
+    if (play && !gateMacOSOutputVolume) {
       await setProperty('pause', 'no');
     }
   }
@@ -383,18 +402,30 @@ class PlayerNative extends PlayerBase {
   @override
   Future<void> play() async {
     if (_nativeCoreUnavailable) return;
+    if (_macOSPlayAfterVolumeRestore != null) {
+      _macOSPlayAfterVolumeRestore = true;
+      return;
+    }
+    final logicalVolume = _macOSLogicalVolume;
+    if (_usesMacOSOutputVolume && logicalVolume != null) {
+      await _applyMacOSVolume(logicalVolume);
+    }
     await setProperty('pause', 'no');
   }
 
   @override
   Future<void> pause() async {
     if (_nativeCoreUnavailable) return;
+    if (_macOSPlayAfterVolumeRestore != null) {
+      _macOSPlayAfterVolumeRestore = false;
+    }
     await setProperty('pause', 'yes');
   }
 
   @override
   Future<void> stop() async {
     if (_nativeCoreUnavailable) return;
+    _macOSPlayAfterVolumeRestore = null;
     // `stop` tears down the playlist without mpv opening the armed entry —
     // settle its content-fd claim first. No transition: playback is ending.
     await _clearArmedNext(adoptIfRolledIn: false);
@@ -527,6 +558,24 @@ class PlayerNative extends PlayerBase {
     }
   }
 
+  Future<void> _applyMacOSVolume(double logicalVolume, {bool resetSoftwareVolume = false}) async {
+    if (logicalVolume <= 100.0) {
+      if (resetSoftwareVolume) {
+        await setProperty('volume', '100.0');
+        if (disposed || logicalVolume != _macOSLogicalVolume) return;
+      }
+
+      final normalized = logicalVolume / 100.0;
+      final outputVolume = normalized * normalized * normalized * 100.0;
+      await setProperty('ao-volume', outputVolume.toString());
+      return;
+    }
+
+    await setProperty('ao-volume', '100.0');
+    if (disposed || logicalVolume != _macOSLogicalVolume) return;
+    await setProperty('volume', logicalVolume.toString());
+  }
+
   @override
   void handlePropertyChange(String name, dynamic value) {
     if (audioOnly && name == 'playlist-pos') {
@@ -534,13 +583,34 @@ class PlayerNative extends PlayerBase {
       appLogger.d('MPV-audio: playlist-pos=$value (armed=$_hasArmedNext)');
       return;
     }
+    if (_usesMacOSOutputVolume && _macOSLogicalVolume != null) {
+      if (name == 'volume') {
+        return;
+      }
+      if (name == 'audio-out-params') {
+        unawaited(_applyMacOSVolume(_macOSLogicalVolume!));
+        return;
+      }
+    }
     super.handlePropertyChange(name, value);
   }
 
   @override
   void handlePlayerEvent(String name, Map? data) {
     if (audioOnly && name == 'file-loaded') _handleAudioFileLoaded();
+    final playAfterRestore = _macOSPlayAfterVolumeRestore;
+    if (name == 'file-loaded' && playAfterRestore != null) {
+      _macOSPlayAfterVolumeRestore = null;
+      unawaited(_restoreMacOSVolume(playAfterRestore));
+    }
     super.handlePlayerEvent(name, data);
+  }
+
+  Future<void> _restoreMacOSVolume(bool play) async {
+    final logicalVolume = _macOSLogicalVolume;
+    if (logicalVolume == null) return;
+    await _applyMacOSVolume(logicalVolume);
+    if (play && !disposed) await setProperty('pause', 'no');
   }
 
   /// Gapless auto-advance detection: a `file-loaded` that open() didn't
@@ -628,7 +698,14 @@ class PlayerNative extends PlayerBase {
 
   @override
   Future<void> setVolume(double volume) async {
-    if (_nativeCoreUnavailable) return;
+    if (_nativeCoreUnavailable || disposed) return;
+    if (_usesMacOSOutputVolume) {
+      final resetSoftwareVolume = _macOSLogicalVolume == null || _macOSLogicalVolume! > 100.0;
+      _macOSLogicalVolume = volume;
+      setVolumeState(volume);
+      await _applyMacOSVolume(volume, resetSoftwareVolume: resetSoftwareVolume);
+      return;
+    }
     await setProperty('volume', volume.toString());
     if (!_nativeCoreUnavailable) setVolumeState(volume);
   }

--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -46,6 +46,7 @@ class PlayerNative extends PlayerBase {
   // immediately. Keep the logical value separate from mpv's software stage.
   double? _macOSLogicalVolume;
   bool? _macOSPlayAfterVolumeRestore;
+  Object? _macOSVolumeRestoreToken;
 
   // Gapless-audio arming state (audioOnly). The native playlist is always
   // [current, next?]; these track whether entry 1 exists and what it plays.
@@ -327,7 +328,8 @@ class PlayerNative extends PlayerBase {
     List<SubtitleTrack>? externalSubtitles,
     Duration? timelineDuration,
   }) async {
-    if (_nativeCoreUnavailable) return;
+    if (_nativeCoreUnavailable || disposed) return;
+    _macOSVolumeRestoreToken = Object();
     await _ensureInitialized();
     if (_nativeCoreUnavailable) return;
     // `loadfile replace` (below) clears the native playlist, dropping any
@@ -426,6 +428,7 @@ class PlayerNative extends PlayerBase {
   Future<void> stop() async {
     if (_nativeCoreUnavailable) return;
     _macOSPlayAfterVolumeRestore = null;
+    _macOSVolumeRestoreToken = null;
     // `stop` tears down the playlist without mpv opening the armed entry —
     // settle its content-fd claim first. No transition: playback is ending.
     await _clearArmedNext(adoptIfRolledIn: false);
@@ -601,15 +604,16 @@ class PlayerNative extends PlayerBase {
     final playAfterRestore = _macOSPlayAfterVolumeRestore;
     if (name == 'file-loaded' && playAfterRestore != null) {
       _macOSPlayAfterVolumeRestore = null;
-      unawaited(_restoreMacOSVolume(playAfterRestore));
+      unawaited(_restoreMacOSVolume(playAfterRestore, _macOSVolumeRestoreToken));
     }
     super.handlePlayerEvent(name, data);
   }
 
-  Future<void> _restoreMacOSVolume(bool play) async {
+  Future<void> _restoreMacOSVolume(bool play, Object? token) async {
     final logicalVolume = _macOSLogicalVolume;
     if (logicalVolume == null) return;
     await _applyMacOSVolume(logicalVolume);
+    if (token == null || !identical(token, _macOSVolumeRestoreToken)) return;
     if (play && !disposed) await setProperty('pause', 'no');
   }
 

--- a/test/mpv/player_open_test.dart
+++ b/test/mpv/player_open_test.dart
@@ -587,6 +587,46 @@ void main() {
       );
     });
 
+    test('MPV restores macOS output volume before playing', () async {
+      PlayerNative.debugMacOSOutputVolumeOverride = true;
+      final calls = <MethodCall>[];
+      try {
+        await withMockPlayerChannels(
+          methodChannelName: 'com.plezy/mpv_player',
+          eventChannelName: 'com.plezy/mpv_player/events',
+          methodHandler: (call) async {
+            calls.add(call);
+            return call.method == 'initialize' ? true : null;
+          },
+          testBody: () async {
+            final player = PlayerNative();
+            try {
+              await player.setVolume(50);
+              expect(_setPropertyValueIndex(calls, 'volume', '100.0'), greaterThanOrEqualTo(0));
+              expect(_setPropertyValueIndex(calls, 'ao-volume', '12.5'), greaterThanOrEqualTo(0));
+
+              calls.clear();
+              await player.open(Media('https://example.test/movie.mkv'));
+              final loadIndex = _loadfileCallIndex(calls);
+              expect(_setPropertyValueIndex(calls, 'pause', 'yes'), lessThan(loadIndex));
+              expect(_setPropertyValueIndex(calls, 'pause', 'no'), -1);
+
+              player.handlePlayerEvent('file-loaded', null);
+              await pumpEventQueue();
+              expect(
+                _setPropertyValueIndex(calls, 'ao-volume', '12.5'),
+                lessThan(_setPropertyValueIndex(calls, 'pause', 'no')),
+              );
+            } finally {
+              await player.dispose();
+            }
+          },
+        );
+      } finally {
+        PlayerNative.debugMacOSOutputVolumeOverride = null;
+      }
+    });
+
     test('MPV passes external subtitles through loadfile options', () async {
       final calls = <MethodCall>[];
 

--- a/test/mpv/player_open_test.dart
+++ b/test/mpv/player_open_test.dart
@@ -587,23 +587,27 @@ void main() {
       );
     });
 
-    test('MPV restores macOS output volume before playing', () async {
+    test('MPV defers macOS output volume until the audio output is active', () async {
       PlayerNative.debugMacOSOutputVolumeOverride = true;
       final calls = <MethodCall>[];
+      var audioOutputActive = false;
       try {
         await withMockPlayerChannels(
           methodChannelName: 'com.plezy/mpv_player',
           eventChannelName: 'com.plezy/mpv_player/events',
           methodHandler: (call) async {
             calls.add(call);
+            if (call.method == 'setProperty' && _setPropertyName(call) == 'ao-volume' && !audioOutputActive) {
+              throw PlatformException(code: 'SET_PROPERTY_FAILED');
+            }
             return call.method == 'initialize' ? true : null;
           },
           testBody: () async {
             final player = PlayerNative();
             try {
               await player.setVolume(50);
-              expect(_setPropertyValueIndex(calls, 'volume', '100.0'), greaterThanOrEqualTo(0));
-              expect(_setPropertyValueIndex(calls, 'ao-volume', '12.5'), greaterThanOrEqualTo(0));
+              expect(_setPropertyValueIndex(calls, 'volume', '50.0'), greaterThanOrEqualTo(0));
+              expect(_setPropertyCallIndex(calls, 'ao-volume'), greaterThanOrEqualTo(0));
 
               calls.clear();
               await player.open(Media('https://example.test/movie.mkv'));
@@ -613,9 +617,17 @@ void main() {
 
               player.handlePlayerEvent('file-loaded', null);
               await pumpEventQueue();
+              expect(_setPropertyValueIndex(calls, 'volume', '50.0'), greaterThan(loadIndex));
+              expect(_setPropertyValueIndex(calls, 'pause', 'no'), greaterThan(loadIndex));
+
+              calls.clear();
+              audioOutputActive = true;
+              player.handlePropertyChange('audio-out-params', const {'channels': 'stereo'});
+              await pumpEventQueue();
+              expect(_setPropertyValueIndex(calls, 'ao-volume', '12.5'), greaterThanOrEqualTo(0));
               expect(
                 _setPropertyValueIndex(calls, 'ao-volume', '12.5'),
-                lessThan(_setPropertyValueIndex(calls, 'pause', 'no')),
+                lessThan(_setPropertyValueIndex(calls, 'volume', '100.0')),
               );
             } finally {
               await player.dispose();


### PR DESCRIPTION
Fix issue that causes volume control to not apply changes immediately while the user is changing volume using the scroll wheel or volume slider.

## Changes
- Route macOS video volume from 0–100% through AVFoundation's `ao-volume`.