### PR TITLE
feat(libraries): show item count in browse toolbar

### DIFF
--- a/lib/screens/libraries/tabs/library_browse_tab.dart
+++ b/lib/screens/libraries/tabs/library_browse_tab.dart
@@ -1671,8 +1671,13 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
   /// Whether the sort chip is visible
   bool get _isSortChipVisible => _sortOptions.isNotEmpty && _selectedGrouping != 'folders';
 
+  /// Whether the current browse result count is ready to display.
+  bool get _isItemCountVisible => !isLoading && errorMessage == null;
+
   /// Builds the chips bar widget
   Widget _buildChipsBar() {
+    final theme = Theme.of(context);
+    final itemCountText = totalSize.toString();
     VoidCallback? groupingNavigateRight;
     if (_isFiltersChipVisible) {
       groupingNavigateRight = () => _filtersChipFocusNode.requestFocus();
@@ -1681,7 +1686,7 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
     }
 
     return Container(
-      color: Theme.of(context).scaffoldBackgroundColor,
+      color: theme.scaffoldBackgroundColor,
       padding: const EdgeInsets.symmetric(horizontal: 16),
       alignment: .centerLeft,
       child: Row(
@@ -1699,7 +1704,7 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
             onNavigateRight: groupingNavigateRight,
             onBack: widget.onBack,
           ),
-          const SizedBox(width: 8),
+          if (_isFiltersChipVisible || _isSortChipVisible) const SizedBox(width: 8),
           // Filters chip
           if (_isFiltersChipVisible)
             FocusableFilterChip(
@@ -1730,6 +1735,19 @@ class _LibraryBrowseTabState extends BaseLibraryTabState<MediaItem, LibraryBrows
                   : () => _groupingChipFocusNode.requestFocus(),
               onBack: widget.onBack,
             ),
+          if (_isItemCountVisible) ...[
+            const SizedBox(width: 12),
+            Semantics(
+              key: const ValueKey('library_browse_item_count'),
+              label: t.libraries.content,
+              value: itemCountText,
+              excludeSemantics: true,
+              child: Text(
+                itemCountText,
+                style: theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ),
+          ],
         ],
       ),
     );


### PR DESCRIPTION
Display the current item count next to the Browse filter and sort controls.

## Changes
- Show the total count of items as plain digits on "Browse" tab of media library. (no localization needed, mimics Plex)
- Update the count when grouping or filters change, including folder view.
- Display the count on desktop and TV. Mobile is excluded because it uses the Library Options sheet instead of the inline Browse toolbar. (I would love for it to be implemented on mobile in the future)

## Screenshot
<img width="461" height="107" alt="CleanShot 2026-07-10 at 03 11 37" src="https://github.com/user-attachments/assets/0d84b041-1b26-42c6-8163-3a9b5e0599cd" />