### PR TITLE
feat(discover): show series art for unwatched Continue Watching episodes

### DIFF
--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -147,6 +147,8 @@
     "visualEffectsReducedDescription": "Fewer animations and lower-resolution artwork",
     "hideSpoilers": "Hide Spoilers for Unwatched Episodes",
     "hideSpoilersDescription": "Blur thumbnails and descriptions for unwatched episodes",
+    "continueWatchingShowArt": "Show Artwork for Unwatched Episodes",
+    "continueWatchingShowArtDescription": "In Continue Watching, show the series artwork instead of a blurred thumbnail when Hide Spoilers is on",
     "playerBackend": "Player Backend",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 22481 (1405 per locale)
+/// Strings: 22483 (1405 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -555,6 +555,12 @@ class TranslationsSettingsEn {
 	/// en: 'Blur thumbnails and descriptions for unwatched episodes'
 	String get hideSpoilersDescription => 'Blur thumbnails and descriptions for unwatched episodes';
 
+	/// en: 'Show Artwork for Unwatched Episodes'
+	String get continueWatchingShowArt => 'Show Artwork for Unwatched Episodes';
+
+	/// en: 'In Continue Watching, show the series artwork instead of a blurred thumbnail when Hide Spoilers is on'
+	String get continueWatchingShowArtDescription => 'In Continue Watching, show the series artwork instead of a blurred thumbnail when Hide Spoilers is on';
+
 	/// en: 'Player Backend'
 	String get playerBackend => 'Player Backend';
 
@@ -5100,6 +5106,8 @@ extension on Translations {
 			'settings.visualEffectsReducedDescription' => 'Fewer animations and lower-resolution artwork',
 			'settings.hideSpoilers' => 'Hide Spoilers for Unwatched Episodes',
 			'settings.hideSpoilersDescription' => 'Blur thumbnails and descriptions for unwatched episodes',
+			'settings.continueWatchingShowArt' => 'Show Artwork for Unwatched Episodes',
+			'settings.continueWatchingShowArtDescription' => 'In Continue Watching, show the series artwork instead of a blurred thumbnail when Hide Spoilers is on',
 			'settings.playerBackend' => 'Player Backend',
 			'settings.exoPlayer' => 'ExoPlayer',
 			'settings.mpv' => 'mpv',
@@ -5473,10 +5481,10 @@ extension on Translations {
 			'messages.autoRemovedWatchedDownload' => ({required Object title}) => 'Auto-removed: ${title}',
 			'messages.removedFromContinueWatching' => 'Removed from Continue Watching',
 			'messages.errorLoading' => ({required Object error}) => 'Error: ${error}',
-			'messages.streamInterrupted' => 'The stream was interrupted. Press play or seek to retry.',
-			'messages.fileInfoNotAvailable' => 'File information not available',
 			_ => null,
 		} ?? switch (path) {
+			'messages.streamInterrupted' => 'The stream was interrupted. Press play or seek to retry.',
+			'messages.fileInfoNotAvailable' => 'File information not available',
 			'messages.errorLoadingFileInfo' => ({required Object error}) => 'Error loading file info: ${error}',
 			'messages.errorLoadingSeries' => 'Error loading series',
 			'messages.musicNotSupported' => 'Music playback is not yet supported',
@@ -5987,10 +5995,10 @@ extension on Translations {
 			'downloads.title' => 'Downloads',
 			'downloads.manage' => 'Manage',
 			'downloads.tvShows' => 'TV Shows',
-			'downloads.movies' => 'Movies',
-			'downloads.music' => 'Music',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.movies' => 'Movies',
+			'downloads.music' => 'Music',
 			'downloads.tracksQueued' => ({required Object count}) => '${count} tracks queued for download',
 			'downloads.noDownloads' => 'No downloads yet',
 			'downloads.noDownloadsDescription' => 'Downloaded content will appear here for offline viewing',

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -177,6 +177,12 @@ class AppearanceSettingsScreen extends StatelessWidget {
               title: t.settings.hideSpoilers,
               subtitle: t.settings.hideSpoilersDescription,
             ),
+            SettingSwitchTile(
+              pref: SettingsService.continueWatchingShowArt,
+              icon: Symbols.image_rounded,
+              title: t.settings.continueWatchingShowArt,
+              subtitle: t.settings.continueWatchingShowArtDescription,
+            ),
             _episodeActionSelector(),
             if (hasMultipleProfiles)
               SettingSwitchTile(

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -443,6 +443,7 @@ class SettingsService extends BaseSharedPreferencesService {
   static const showEpisodeNumberOnCards = BoolPref('show_episode_number_on_cards', defaultValue: true);
   static const showSeasonPostersOnTabs = BoolPref('show_season_posters_on_tabs');
   static const hideSpoilers = BoolPref('hide_spoilers');
+  static const continueWatchingShowArt = BoolPref('continue_watching_show_art');
   static const showNavBarLabels = BoolPref('show_nav_bar_labels', defaultValue: true);
   static const globalShaderPreset = StringPref('global_shader_preset', defaultValue: 'none');
   static const requireProfileSelectionOnOpen = BoolPref('require_profile_selection_on_open');
@@ -869,6 +870,7 @@ class SettingsService extends BaseSharedPreferencesService {
     showEpisodeNumberOnCards,
     showSeasonPostersOnTabs,
     hideSpoilers,
+    continueWatchingShowArt,
     showNavBarLabels,
     globalShaderPreset,
     requireProfileSelectionOnOpen,

--- a/lib/widgets/media_card.dart
+++ b/lib/widgets/media_card.dart
@@ -255,6 +255,7 @@ class MediaCardState extends State<MediaCard> with ContextMenuTapMixin<MediaCard
         SettingsService.episodePosterMode,
         SettingsService.showEpisodeNumberOnCards,
         SettingsService.hideSpoilers,
+        SettingsService.continueWatchingShowArt,
         SettingsService.showUnwatchedCount,
       ],
       builder: _buildContent,
@@ -290,6 +291,7 @@ class MediaCardState extends State<MediaCard> with ContextMenuTapMixin<MediaCard
             localPosterPath: localPosterPath,
             showServerName: widget.showServerName,
             episodePosterModeOverride: widget.episodePosterModeOverride,
+            isInContinueWatching: widget.isInContinueWatching,
           );
 
     // Catalog stand-ins (Explore tab) have no server-backed actions — every
@@ -373,6 +375,7 @@ class MediaCardState extends State<MediaCard> with ContextMenuTapMixin<MediaCard
                   episodePosterModeOverride: widget.episodePosterModeOverride,
                   knownWidth: width,
                   knownHeight: height,
+                  isInContinueWatching: widget.isInContinueWatching,
                 ),
                 if (item is MediaItem && _showsWatchedIndicator(item)) WatchedIndicator(item: item),
               ],
@@ -406,6 +409,7 @@ class MediaCardState extends State<MediaCard> with ContextMenuTapMixin<MediaCard
               episodePosterModeOverride: widget.episodePosterModeOverride,
               knownWidth: posterHeight != null ? posterWidth : null,
               knownHeight: posterHeight,
+              isInContinueWatching: widget.isInContinueWatching,
             ),
           ),
           if (item is MediaItem && _showsWatchedIndicator(item)) WatchedIndicator(item: item),
@@ -475,6 +479,7 @@ class _MediaCardList extends StatelessWidget {
   final String? localPosterPath;
   final bool showServerName;
   final EpisodePosterMode? episodePosterModeOverride;
+  final bool isInContinueWatching;
 
   const _MediaCardList({
     required this.item,
@@ -489,6 +494,7 @@ class _MediaCardList extends StatelessWidget {
     this.localPosterPath,
     this.showServerName = false,
     this.episodePosterModeOverride,
+    this.isInContinueWatching = false,
   });
 
   CardShape _cardShape() {
@@ -671,6 +677,7 @@ class _MediaCardList extends StatelessWidget {
                         isOffline: isOffline,
                         localPosterPath: localPosterPath,
                         episodePosterModeOverride: episodePosterModeOverride,
+                        isInContinueWatching: isInContinueWatching,
                       ),
                     ),
                     if (item is MediaItem && _showsWatchedIndicator(item as MediaItem))
@@ -815,6 +822,11 @@ double _posterFocusRadius(BuildContext context, Object item) =>
 /// state to draw; tracks can show watched/resume state).
 bool _showsWatchedIndicator(MediaItem item) => item.kind != MediaKind.artist;
 
+/// Wraps [image] in the spoiler blur used for unwatched-episode thumbnails.
+Widget _blurredThumbnail(Widget image) => ClipRect(
+  child: ImageFiltered(imageFilter: ImageFilter.blur(sigmaX: 12, sigmaY: 12), child: image),
+);
+
 Widget _buildPosterImage(
   BuildContext context,
   Object item, {
@@ -824,6 +836,7 @@ Widget _buildPosterImage(
   EpisodePosterMode? episodePosterModeOverride,
   double? knownWidth,
   double? knownHeight,
+  bool isInContinueWatching = false,
 }) {
   String? posterUrl;
 
@@ -843,12 +856,25 @@ Widget _buildPosterImage(
     final EpisodePosterMode episodePosterMode =
         episodePosterModeOverride ?? SettingsService.instance.read(SettingsService.episodePosterMode);
     final hideSpoilers = SettingsService.instance.read(SettingsService.hideSpoilers);
-    final shouldBlur =
+    final wantsSpoilerHiding =
         hideSpoilers && item.shouldHideSpoiler && episodePosterMode == EpisodePosterMode.episodeThumbnail;
+    final spoilerSafeArtCandidate =
+        wantsSpoilerHiding &&
+            isInContinueWatching &&
+            SettingsService.instance.read(SettingsService.continueWatchingShowArt)
+        ? item.spoilerSafeArt
+        : null;
+    // Skip the show art if a previous attempt already failed to load, so the
+    // rebuild after a failure falls through to the blurred episode thumbnail
+    // instead of a broken image.
+    final spoilerSafeArtUrl = (spoilerSafeArtCandidate != null && !_hasFailedPosterUrl(spoilerSafeArtCandidate))
+        ? spoilerSafeArtCandidate
+        : null;
+    final shouldBlur = wantsSpoilerHiding && spoilerSafeArtUrl == null;
     final primaryPosterUrl = item.posterThumb(mode: episodePosterMode, mixedHubContext: mixedHubContext);
     final posterFallbackUrl = item.posterThumbFallback(mode: episodePosterMode, mixedHubContext: mixedHubContext);
     final useRememberedFallback = posterFallbackUrl != null && _hasFailedPosterUrl(primaryPosterUrl);
-    posterUrl = useRememberedFallback ? posterFallbackUrl : primaryPosterUrl;
+    posterUrl = spoilerSafeArtUrl ?? (useRememberedFallback ? posterFallbackUrl : primaryPosterUrl);
     final mediaClient = isOffline ? null : context.tryGetMediaClientWithFallback(serverIdOrNull(item.serverId));
     final fallbackIcon = _mediaPosterFallbackIcon(item);
 
@@ -869,9 +895,10 @@ Widget _buildPosterImage(
       );
     } else if (item.usesWideAspectRatio(episodePosterMode, mixedHubContext: mixedHubContext)) {
       // Use thumb image type for 16:9 content (episodes, or movies in mixed hubs)
-      image = OptimizedMediaImage.thumb(
+      final episodeThumbUrl = useRememberedFallback ? posterFallbackUrl : primaryPosterUrl;
+      OptimizedMediaImage buildEpisodeThumb() => OptimizedMediaImage.thumb(
         client: mediaClient,
-        imagePath: posterUrl,
+        imagePath: episodeThumbUrl,
         width: knownWidth ?? double.infinity,
         height: knownHeight ?? double.infinity,
         fit: BoxFit.cover,
@@ -879,6 +906,28 @@ Widget _buildPosterImage(
         fallbackIcon: fallbackIcon,
         localFilePath: localPosterPath,
       );
+      if (spoilerSafeArtUrl != null) {
+        // Continue Watching show-art swap. If the show art fails to load, fall
+        // back to the blurred episode thumbnail — a broken image is a worse
+        // spoiler outcome than the blur it replaced. Record the failure so the
+        // next rebuild skips the doomed load and blurs straight away.
+        image = OptimizedMediaImage.thumb(
+          client: mediaClient,
+          imagePath: spoilerSafeArtUrl,
+          width: knownWidth ?? double.infinity,
+          height: knownHeight ?? double.infinity,
+          fit: BoxFit.cover,
+          placeholder: _buildPosterLoadingPlaceholder,
+          fallbackIcon: fallbackIcon,
+          localFilePath: localPosterPath,
+          errorWidget: (_, _, _) {
+            _rememberFailedPosterUrl(spoilerSafeArtUrl);
+            return _blurredThumbnail(buildEpisodeThumb());
+          },
+        );
+      } else {
+        image = buildEpisodeThumb();
+      }
     } else {
       image = OptimizedMediaImage.poster(
         client: mediaClient,
@@ -907,9 +956,7 @@ Widget _buildPosterImage(
     }
 
     if (shouldBlur) {
-      return ClipRect(
-        child: ImageFiltered(imageFilter: ImageFilter.blur(sigmaX: 12, sigmaY: 12), child: image),
-      );
+      return _blurredThumbnail(image);
     }
     return image;
   }

--- a/test/widgets/media_card_continue_watching_art_test.dart
+++ b/test/widgets/media_card_continue_watching_art_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
+import 'package:plezy/services/settings_service.dart';
+import 'package:plezy/theme/mono_theme.dart';
+import 'package:plezy/widgets/media_card.dart';
+import 'package:plezy/widgets/optimized_media_image.dart';
+
+import '../test_helpers/prefs.dart';
+
+MediaItem _unwatchedEpisode({String? grandparentArtPath, String? artPath}) => MediaItem(
+  id: 'episode_1',
+  backend: MediaBackend.plex,
+  kind: MediaKind.episode,
+  title: 'Spoiler Episode',
+  grandparentTitle: 'Show',
+  parentIndex: 1,
+  index: 1,
+  thumbPath: 'https://example.invalid/thumb.jpg',
+  grandparentArtPath: grandparentArtPath,
+  artPath: artPath,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    await SettingsService.getInstance();
+    await SettingsService.instance.write(SettingsService.hideSpoilers, true);
+  });
+
+  testWidgets('toggle off keeps the blurred episode thumbnail', (tester) async {
+    await tester.pumpWidget(
+      _TestApp(
+        child: MediaCard(
+          item: _unwatchedEpisode(grandparentArtPath: 'https://example.invalid/art.jpg'),
+          width: 200,
+          height: 112,
+          forceGridMode: true,
+          isOffline: true,
+          isInContinueWatching: true,
+        ),
+      ),
+    );
+
+    expect(find.byType(ImageFiltered), findsOneWidget);
+    expect(
+      tester.widget<OptimizedMediaImage>(find.byType(OptimizedMediaImage)).imagePath,
+      'https://example.invalid/thumb.jpg',
+    );
+  });
+
+  testWidgets('toggle on swaps to unblurred show artwork', (tester) async {
+    await SettingsService.instance.write(SettingsService.continueWatchingShowArt, true);
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: MediaCard(
+          item: _unwatchedEpisode(grandparentArtPath: 'https://example.invalid/art.jpg'),
+          width: 200,
+          height: 112,
+          forceGridMode: true,
+          isOffline: true,
+          isInContinueWatching: true,
+        ),
+      ),
+    );
+
+    expect(find.byType(ImageFiltered), findsNothing);
+    expect(
+      tester.widget<OptimizedMediaImage>(find.byType(OptimizedMediaImage)).imagePath,
+      'https://example.invalid/art.jpg',
+    );
+  });
+
+  testWidgets('toggle on but no spoiler-safe art falls back to blur', (tester) async {
+    await SettingsService.instance.write(SettingsService.continueWatchingShowArt, true);
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: MediaCard(
+          item: _unwatchedEpisode(),
+          width: 200,
+          height: 112,
+          forceGridMode: true,
+          isOffline: true,
+          isInContinueWatching: true,
+        ),
+      ),
+    );
+
+    expect(find.byType(ImageFiltered), findsOneWidget);
+  });
+
+  testWidgets('toggle on but show art fails to load reverts to the blurred thumbnail', (tester) async {
+    await SettingsService.instance.write(SettingsService.continueWatchingShowArt, true);
+
+    // Unique art URL so recording its failure can't leak into other tests via
+    // the process-global failed-poster set.
+    const failingArt = 'https://example.invalid/art_fail.jpg';
+    final item = MediaItem(
+      id: 'episode_fail',
+      backend: MediaBackend.plex,
+      kind: MediaKind.episode,
+      title: 'Spoiler Episode',
+      grandparentTitle: 'Show',
+      parentIndex: 1,
+      index: 1,
+      thumbPath: 'https://example.invalid/thumb.jpg',
+      grandparentArtPath: failingArt,
+    );
+
+    Widget app() => _TestApp(
+      child: MediaCard(
+        item: item,
+        width: 200,
+        height: 112,
+        forceGridMode: true,
+        isOffline: true,
+        isInContinueWatching: true,
+      ),
+    );
+
+    await tester.pumpWidget(app());
+
+    // Show art is used and carries an error fallback so a failed load can
+    // revert to the blur.
+    final art = tester.widget<OptimizedMediaImage>(find.byType(OptimizedMediaImage));
+    expect(art.imagePath, failingArt);
+    expect(art.errorWidget, isNotNull);
+    expect(find.byType(ImageFiltered), findsNothing);
+
+    // Simulate the show art failing to load. The error callback records the
+    // failed URL (and renders the blurred thumbnail inline).
+    final context = tester.element(find.byType(OptimizedMediaImage));
+    art.errorWidget!(context, failingArt, 'load failed');
+
+    // On the next rebuild the failed URL is skipped, so the card falls through
+    // to the blurred episode thumbnail.
+    await tester.pumpWidget(app());
+    expect(find.byType(ImageFiltered), findsOneWidget);
+    expect(
+      tester.widget<OptimizedMediaImage>(find.byType(OptimizedMediaImage)).imagePath,
+      'https://example.invalid/thumb.jpg',
+    );
+  });
+
+  testWidgets('toggle on but not in Continue Watching keeps the blur', (tester) async {
+    await SettingsService.instance.write(SettingsService.continueWatchingShowArt, true);
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: MediaCard(
+          item: _unwatchedEpisode(grandparentArtPath: 'https://example.invalid/art.jpg'),
+          width: 200,
+          height: 112,
+          forceGridMode: true,
+          isOffline: true,
+        ),
+      ),
+    );
+
+    expect(find.byType(ImageFiltered), findsOneWidget);
+  });
+}
+
+class _TestApp extends StatelessWidget {
+  final Widget child;
+
+  const _TestApp({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: monoTheme(dark: true),
+      home: Scaffold(body: Center(child: child)),
+    );
+  }
+}


### PR DESCRIPTION
## What

Adds an optional setting so unwatched episodes in the Continue Watching row show the series artwork instead of a blurred thumbnail.

## Why

With Hide Spoilers on, unwatched episodes get their thumbnails blurred so you don't spoil yourself. It works, but a row full of blur boxes looks bad on the home screen. The Plex app sidesteps this by just showing show-level art for those items, so there's no thumbnail to spoil and nothing to blur. This does the same thing.

The setting is off by default, so nothing changes unless you turn it on.

## How it works

When the toggle is on and Hide Spoilers is also on, an unwatched Continue Watching episode renders the show's landscape artwork (unblurred) in place of the blurred thumbnail. Everything else stays put: watched and in-progress episodes, movies, other hubs, and the episode list on the show page are untouched. If the show happens to have no artwork, it falls back to the old blurred thumbnail.

A note on why it's landscape art and not the portrait poster: the Continue Watching row is a fixed 16:9 row, so a portrait poster would get center-cropped into a useless strip. The rest of the codebase already handles spoiler-safe episode art the same way (mixed hubs, the Android TV shelf, the home hero), so this matches. If you specifically want portrait posters, that already exists under Episode Poster Mode → Series Poster.

The whole thing hangs off one existing chokepoint (`_buildPosterImage` in `media_card.dart`), so mobile, desktop, and TV all pick it up from a single change with no layout code moved.

If the show art itself fails to load, the card reverts to the old blurred thumbnail rather than showing a broken image — a broken image is a worse spoiler outcome than the blur it was replacing.

## Testing

New widget test covers five cases: toggle off keeps the blur, toggle on swaps to show art, toggle on with no art falls back to blur, toggle on but the art fails to load reverts to blur, and toggle on but not in Continue Watching keeps the blur. `flutter analyze` is clean on the touched files and the existing media card tests still pass.
