### PR TITLE
fix(companion): stop remote desyncing and hanging on reconnect

### DIFF
--- a/lib/providers/companion_remote_provider.dart
+++ b/lib/providers/companion_remote_provider.dart
@@ -40,6 +40,12 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
   int _reconnectAttempts = 0;
   bool _intentionalDisconnect = false;
 
+  // Explicit liveness flag for the client reconnect loop. Replaces abusing
+  // `_session.status` as the flag — the peer service clobbers status with
+  // disconnected/connecting/error events during a reconnect attempt, which
+  // would otherwise kill the loop after one try.
+  bool _isReconnecting = false;
+
   // Reconnection context (only hostAddresses and hostClientId are connection-specific)
   List<String>? _lastHostAddresses;
   String? _lastHostClientId;
@@ -421,6 +427,7 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
     return _serializeLifecycle(() async {
       _reconnectTimer?.cancel();
       _reconnectAttempts = 0;
+      _isReconnecting = false;
       _lastHostAddresses = null;
       _lastHostClientId = null;
       _lastAuthContextId = null;
@@ -662,6 +669,10 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
         safeNotifyListeners();
         appLogger.d('CompanionRemote: Host waiting for client to reconnect');
       } else {
+        // A failed attempt's channel-close onDone can fire here again while the
+        // loop is already running — don't double-schedule and burn attempts.
+        if (_isReconnecting) return;
+        _isReconnecting = true;
         _session = _session?.copyWith(status: RemoteSessionStatus.reconnecting);
         safeNotifyListeners();
         _scheduleReconnect();
@@ -670,12 +681,19 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
 
     _errorSubscription = _peerService!.onError.listen((error) {
       appLogger.e('CompanionRemote: Error: ${error.message}');
+      // A join failure during a reconnect attempt emits an error event; don't
+      // let it clobber the reconnecting status and kill the loop.
+      if (_isReconnecting) return;
       _session = _session?.copyWith(status: RemoteSessionStatus.error, errorMessage: error.message);
       safeNotifyListeners();
     });
 
     _statusSubscription = _peerService!.onConnectionStateChanged.listen((status) {
       appLogger.d('CompanionRemote: Status changed: $status');
+      // While reconnecting, the peer service emits disconnected/connecting/error
+      // that would overwrite `reconnecting`; ignore all but the connected event
+      // (which _attemptReconnect applies itself on success).
+      if (_isReconnecting && status != RemoteSessionStatus.connected) return;
       _session = _session?.copyWith(status: status);
       safeNotifyListeners();
     });
@@ -731,6 +749,7 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
   void _scheduleReconnect() {
     if (_reconnectAttempts >= _maxReconnectAttempts) {
       appLogger.w('CompanionRemote: Max reconnect attempts reached');
+      _isReconnecting = false;
       _session = _session?.copyWith(
         status: RemoteSessionStatus.error,
         errorMessage: t.companionRemote.errors.connectionLostAfterAttempts(attempts: _maxReconnectAttempts),
@@ -748,9 +767,47 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
     _reconnectTimer = Timer(delay, _attemptReconnect);
   }
 
+  /// Listen for LAN beacons and return the host whose clientId matches, or
+  /// null if it doesn't appear within [timeout]. Hosts beacon every 3s over
+  /// lossy UDP broadcast, so 7s covers two beacon windows plus margin — a
+  /// single dropped datagram won't waste a reconnect attempt. Uses its own
+  /// [LanDiscoveryService] instance so its teardown can't kill a
+  /// concurrently-mounted discovery screen listening on the shared service.
+  Future<DiscoveredHost?> _rediscoverHost(String clientId, {Duration timeout = const Duration(seconds: 7)}) async {
+    final discovery = LanDiscoveryService();
+
+    final completer = Completer<DiscoveredHost?>();
+    final timer = Timer(timeout, () {
+      if (!completer.isCompleted) {
+        appLogger.w('CompanionRemote: Rediscovery timed out for host $clientId');
+        completer.complete(null);
+      }
+    });
+
+    final sub = discovery.startListeningForContexts(_authContexts).listen((hosts) {
+      if (completer.isCompleted) return;
+      for (final host in hosts) {
+        if (host.clientId == clientId) {
+          appLogger.d('CompanionRemote: Rediscovered host $clientId at ${host.addresses}');
+          completer.complete(host);
+          return;
+        }
+      }
+    });
+
+    try {
+      return await completer.future;
+    } finally {
+      timer.cancel();
+      await sub.cancel();
+      discovery.dispose();
+    }
+  }
+
   Future<void> _attemptReconnect() async {
     if (_lastHostAddresses == null || !isCryptoReady) {
       appLogger.w('CompanionRemote: No stored context for reconnect');
+      _isReconnecting = false;
       _session = _session?.copyWith(
         status: RemoteSessionStatus.error,
         errorMessage: t.companionRemote.errors.connectionLost,
@@ -761,6 +818,15 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
 
     try {
       appLogger.d('CompanionRemote: Attempting reconnect...');
+
+      DiscoveredHost? fresh;
+      if (_lastHostClientId != null && _lastHostClientId!.isNotEmpty) {
+        fresh = await _rediscoverHost(_lastHostClientId!);
+      }
+
+      // The user may have tapped Cancel while we were waiting on discovery.
+      if (!_isReconnecting) return;
+
       _cleanupSubscriptions();
       try {
         await _peerService?.disconnect();
@@ -770,24 +836,52 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
       }
 
       final authContextId = _authContextForId(_lastAuthContextId)?.id;
-      await _peerService!.joinSessionWithContexts(
-        _deviceName,
-        _platform,
-        _lastHostAddresses!.first,
-        _authContexts,
-        authContextId: authContextId,
-        expectedHostClientId: _lastHostClientId ?? '',
-      );
+      if (fresh != null) {
+        final winner = await _peerService!.joinSessionRacingWithContexts(
+          _deviceName,
+          _platform,
+          fresh.addresses,
+          _authContexts,
+          authContextId: authContextId,
+          expectedHostClientId: _lastHostClientId ?? '',
+        );
+        _lastHostAddresses = [winner];
+      } else {
+        await _peerService!.joinSessionWithContexts(
+          _deviceName,
+          _platform,
+          _lastHostAddresses!.first,
+          _authContexts,
+          authContextId: authContextId,
+          expectedHostClientId: _lastHostClientId ?? '',
+        );
+      }
+
+      // Cancel could have landed while the join was in flight — don't resurrect
+      // a session the user tore down. Drop the freshly-joined connection. Cancel
+      // the subscriptions BEFORE disconnecting: cancelReconnect() doesn't set
+      // _intentionalDisconnect, so a stray onDeviceDisconnected from this
+      // disconnect would otherwise flip _isReconnecting back on and schedule a
+      // spurious reconnect.
+      if (!_isReconnecting) {
+        _cleanupSubscriptions();
+        final ps = _peerService;
+        _peerService = null;
+        await ps?.disconnect();
+        return;
+      }
+
       _lastAuthContextId = _peerService!.selectedAuthContextId ?? authContextId;
       _lastHostClientId = _peerService!.selectedHostClientId ?? _lastHostClientId;
 
+      _isReconnecting = false;
       _session = _session?.copyWith(status: RemoteSessionStatus.connected, errorMessage: null);
       _reconnectAttempts = 0;
       safeNotifyListeners();
       appLogger.d('CompanionRemote: Reconnected successfully');
     } catch (e) {
       appLogger.e('CompanionRemote: Reconnect failed', error: e);
-      if (_session?.status == RemoteSessionStatus.reconnecting) {
+      if (_isReconnecting) {
         _scheduleReconnect();
       }
     }
@@ -796,12 +890,14 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
   void retryReconnectNow() {
     _reconnectTimer?.cancel();
     _reconnectAttempts = 0;
+    _isReconnecting = true;
     _attemptReconnect();
   }
 
   void cancelReconnect() {
     _reconnectTimer?.cancel();
     _reconnectAttempts = 0;
+    _isReconnecting = false;
     _session = _session?.copyWith(status: RemoteSessionStatus.disconnected, connectedDevice: null);
     safeNotifyListeners();
   }
@@ -810,6 +906,7 @@ class CompanionRemoteProvider with ChangeNotifier, DisposableChangeNotifierMixin
     _intentionalDisconnect = true;
     _reconnectTimer?.cancel();
     _reconnectAttempts = 0;
+    _isReconnecting = false;
 
     // Don't stop the host server when leaving — only stop discovery listening
     if (_peerService != null && !isHost) {

--- a/lib/services/companion_remote/companion_remote_peer_service.dart
+++ b/lib/services/companion_remote/companion_remote_peer_service.dart
@@ -469,6 +469,20 @@ class CompanionRemotePeerService with KeepaliveMixin {
       throw const RemotePeerError(type: RemotePeerErrorType.authFailed, message: 'No auth contexts available');
     }
 
+    // Start every join from clean handshake state. A join that failed fast now
+    // leaves `_channel` null (see _teardownChannel), so the internal disconnect()
+    // below is skipped — reset the session scalars here so stale state from a
+    // prior attempt can't misroute this connection's plaintext handshake into
+    // the encrypted branch. Mirrors what disconnect() clears.
+    _isAuthenticated = false;
+    _sessionEncKey = null;
+    _sendCounter = 0;
+    _recvCounter = 0;
+    _selectedAuthContextId = null;
+    _selectedHostClientId = null;
+    _sendChain = null;
+    _recvChain = Future.value();
+
     if (_channel != null) {
       await disconnect();
     }
@@ -486,7 +500,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
 
       _connectionStateController.add(RemoteSessionStatus.connecting);
 
-      _channel = IOWebSocketChannel.connect(Uri.parse(url));
+      _channel = IOWebSocketChannel.connect(Uri.parse(url), connectTimeout: const Duration(seconds: 5));
       await _channel!.ready;
 
       List<int>? hostNonce;
@@ -548,6 +562,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
                     ),
                   );
                 }
+                unawaited(_teardownChannel());
               }
             } else {
               // Pre-auth: plaintext handshake
@@ -595,7 +610,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
                       const RemotePeerError(type: RemotePeerErrorType.authFailed, message: 'No shared identity'),
                     );
                   }
-                  unawaited(_channel?.sink.close(4003, 'Authentication failed'));
+                  unawaited(_teardownChannel(4003, 'Authentication failed'));
                   return;
                 }
 
@@ -609,7 +624,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
                       const RemotePeerError(type: RemotePeerErrorType.authFailed, message: 'Host identity mismatch'),
                     );
                   }
-                  unawaited(_channel?.sink.close(4003, 'Authentication failed'));
+                  unawaited(_teardownChannel(4003, 'Authentication failed'));
                   return;
                 }
 
@@ -659,6 +674,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
                   ),
                 );
                 _connectionStateController.add(RemoteSessionStatus.error);
+                unawaited(_teardownChannel());
               }
             }
           } catch (e) {
@@ -681,6 +697,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
           if (!completer.isCompleted) {
             completer.completeError(error);
           }
+          unawaited(_teardownChannel());
 
           _errorController.add(
             RemotePeerError(
@@ -698,6 +715,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
       if (!completer.isCompleted) {
         completer.completeError(e);
       }
+      unawaited(_teardownChannel());
 
       _errorController.add(
         RemotePeerError(type: RemotePeerErrorType.connectionFailed, message: 'Failed to connect: $e', originalError: e),
@@ -707,14 +725,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
     return completer.future.timeout(
       const Duration(seconds: 15),
       onTimeout: () async {
-        if (_channel != null) {
-          try {
-            await _channel!.sink.close();
-          } catch (e) {
-            appLogger.d('CompanionRemote: channel close on timeout failed', error: e);
-          }
-          _channel = null;
-        }
+        await _teardownChannel();
         throw RemotePeerError(type: RemotePeerErrorType.timeout, message: t.companionRemote.errors.joinTimedOut);
       },
     );
@@ -869,6 +880,9 @@ class CompanionRemotePeerService with KeepaliveMixin {
   // Serializes async sends to prevent counter interleaving
   Future<void>? _sendChain;
 
+  // Serializes async decrypts to prevent recv-counter interleaving
+  Future<void> _recvChain = Future.value();
+
   Future<List<int>> _encryptOutgoing(String plaintext) async {
     final encrypted = await RemoteAuthService.instance.encrypt(
       _sessionEncKey!,
@@ -886,7 +900,17 @@ class CompanionRemotePeerService with KeepaliveMixin {
     socket.add(encrypted);
   }
 
-  Future<String?> _decryptIncoming(dynamic data) async {
+  // Chain decrypts to prevent counter interleaving from concurrent async
+  // listen callbacks (Stream.listen does not backpressure async callbacks).
+  Future<String?> _decryptIncoming(dynamic data) {
+    final result = _recvChain.then((_) => _decryptIncomingSerial(data));
+    // Keep the chain alive; _decryptIncomingSerial never throws, but swallow
+    // defensively so one bad frame can't wedge the chain.
+    _recvChain = result.then((_) {}, onError: (_) {});
+    return result;
+  }
+
+  Future<String?> _decryptIncomingSerial(dynamic data) async {
     if (_sessionEncKey == null) return null;
     try {
       final auth = RemoteAuthService.instance;
@@ -974,6 +998,22 @@ class CompanionRemotePeerService with KeepaliveMixin {
     });
   }
 
+  /// Close and drop the client channel. Nulls the field *before* awaiting and
+  /// bounds the close so a dead socket whose close never completes can't wedge
+  /// every future connect attempt.
+  Future<void> _teardownChannel([int? closeCode, String? closeReason]) async {
+    final channel = _channel;
+    _channel = null;
+    if (channel == null) return;
+    try {
+      await channel.sink
+          .close(closeCode, closeReason)
+          .namedTimeout(const Duration(seconds: 2), operation: 'CompanionRemote channel close');
+    } catch (e) {
+      appLogger.d('CompanionRemote: channel close ignored', error: e);
+    }
+  }
+
   Future<void> disconnect() async {
     appLogger.d('CompanionRemote: Disconnecting');
 
@@ -981,21 +1021,17 @@ class CompanionRemotePeerService with KeepaliveMixin {
 
     if (_clientSocket != null) {
       try {
-        await _clientSocket!.close();
+        await _clientSocket!.close().namedTimeout(
+          const Duration(seconds: 2),
+          operation: 'CompanionRemote client socket close',
+        );
       } catch (e) {
         appLogger.d('CompanionRemote: client socket close ignored', error: e);
       }
       _clientSocket = null;
     }
 
-    if (_channel != null) {
-      try {
-        await _channel!.sink.close();
-      } catch (e) {
-        appLogger.d('CompanionRemote: channel close ignored', error: e);
-      }
-      _channel = null;
-    }
+    await _teardownChannel();
 
     if (_server != null) {
       await _server!.close();
@@ -1012,6 +1048,7 @@ class CompanionRemotePeerService with KeepaliveMixin {
     _recvCounter = 0;
     _isAuthenticated = false;
     _sendChain = null;
+    _recvChain = Future.value();
     _failedAuthAttempts.clear();
     _authLockouts.clear();
 

--- a/lib/widgets/companion_remote/discovery_view.dart
+++ b/lib/widgets/companion_remote/discovery_view.dart
@@ -153,7 +153,6 @@ class _DiscoveryViewState extends State<DiscoveryView> with ControllerDisposerMi
     });
 
     try {
-      _provider.stopDiscovery();
       await action();
     } catch (e) {
       appLogger.e('Failed to connect', error: e);

--- a/test/services/companion_remote_peer_service_connect_timeout_test.dart
+++ b/test/services/companion_remote_peer_service_connect_timeout_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/services/companion_remote/companion_remote_peer_service.dart';
+import 'package:plezy/services/companion_remote/remote_auth_context.dart';
+
+void main() {
+  RemoteAuthContext authContext() => const RemoteAuthContext(
+    id: 'test-context',
+    backend: 'legacy',
+    connectionId: '',
+    homeSecret: [1, 2, 3, 4],
+    discoveryKey: [],
+    clientIdentifier: 'test-client',
+    userUuid: 'test-user',
+    allowedUserUuids: ['test-user'],
+  );
+
+  group('CompanionRemotePeerService connect is time-bounded', () {
+    test('a dead endpoint that accepts but never speaks WS fails in well under 15s', () async {
+      // Accept the TCP connection but never upgrade to WebSocket and never send
+      // anything. Pre-fix, IOWebSocketChannel.connect() with no connectTimeout
+      // leaves `await _channel!.ready` hanging until the OS TCP timeout
+      // (~2 minutes); post-fix the 5s connectTimeout bounds it.
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final sub = server.listen((socket) {
+        // Accept and hold the connection open; never respond.
+      });
+      addTearDown(() async {
+        await sub.cancel();
+        await server.close();
+      });
+
+      final service = CompanionRemotePeerService();
+      addTearDown(() => service.dispose());
+
+      final address = '127.0.0.1:${server.port}';
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        service.joinSessionWithContexts('test', 'test', address, [authContext()]),
+        throwsA(isA<Object>()),
+      );
+
+      stopwatch.stop();
+      expect(
+        stopwatch.elapsed < const Duration(seconds: 10),
+        isTrue,
+        reason: 'connect should fail in ~5s via connectTimeout, not hang toward the ~2min OS TCP timeout '
+            '(took ${stopwatch.elapsed})',
+      );
+    });
+
+    test('a connection-refused address fails promptly', () async {
+      // Bind, note the port, then close it so nothing is listening — the OS
+      // should refuse the connection immediately (no need for connectTimeout
+      // to kick in here, but it must not regress into a slow path either).
+      final probe = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final port = probe.port;
+      await probe.close();
+
+      final service = CompanionRemotePeerService();
+      addTearDown(() => service.dispose());
+
+      final address = '127.0.0.1:$port';
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        service.joinSessionWithContexts('test', 'test', address, [authContext()]),
+        throwsA(isA<Object>()),
+      );
+
+      stopwatch.stop();
+      expect(
+        stopwatch.elapsed < const Duration(seconds: 10),
+        isTrue,
+        reason: 'connection-refused should fail promptly (took ${stopwatch.elapsed})',
+      );
+    });
+  });
+}

--- a/test/services/companion_remote_peer_service_disconnect_test.dart
+++ b/test/services/companion_remote_peer_service_disconnect_test.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/services/companion_remote/companion_remote_peer_service.dart';
+import 'package:plezy/services/companion_remote/remote_auth_context.dart';
+
+void main() {
+  group('CompanionRemotePeerService disconnect after fast connect failure', () {
+    late ServerSocket server;
+    late CompanionRemotePeerService service;
+    var accepted = 0;
+
+    setUp(() async {
+      accepted = 0;
+      // A server that immediately destroys every incoming connection. This makes
+      // the client's `_channel!.ready` throw before any WebSocket upgrade, so the
+      // join fails fast without entering the 15s timeout path (which would pull in
+      // i18n). We only care that a TCP socket was opened, hence the counter.
+      server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      server.listen((socket) {
+        accepted++;
+        socket.destroy();
+      });
+      service = CompanionRemotePeerService();
+    });
+
+    tearDown(() async {
+      await service.dispose();
+      await server.close();
+    });
+
+    RemoteAuthContext authContext() => const RemoteAuthContext(
+      id: 'test-context',
+      backend: 'legacy',
+      connectionId: '',
+      homeSecret: [1, 2, 3, 4],
+      discoveryKey: [],
+      clientIdentifier: 'test-client',
+      userUuid: 'test-user',
+      allowedUserUuids: ['test-user'],
+    );
+
+    test('disconnect completes quickly and a second connect opens a new socket', () async {
+      final address = '127.0.0.1:${server.port}';
+
+      // First attempt: fails fast because the host destroys the socket.
+      await expectLater(
+        service.joinSessionWithContexts('test', 'test', address, [authContext()]),
+        throwsA(isA<Object>()),
+      );
+
+      // Pre-fix, disconnect() awaits `_channel!.sink.close()` on a dead socket
+      // whose close never completes, hanging forever. Post-fix it is bounded.
+      await service.disconnect().timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => fail('disconnect() hung on a dead channel'),
+      );
+
+      // Second attempt must actually open a new TCP socket. Pre-fix the flow
+      // wedges inside joinSessionWithContexts' internal disconnect() and never
+      // reaches the connect, so `accepted` stays at 1.
+      await expectLater(
+        service.joinSessionWithContexts('test', 'test', address, [authContext()]),
+        throwsA(isA<Object>()),
+      );
+
+      expect(accepted, 2, reason: 'a second TCP socket should have been opened');
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Companion Remote (phone controlling playback on a desktop/TV host over the LAN) had three failure modes I kept hitting:

1. After the phone screen sleeps mid-movie, the LAN socket dies and the client gets booted. Reconnecting then spins forever and never recovers, so you have to kill the app.
2. Under normal use, sending a burst of commands (seek, pause, volume) would quietly kill the encrypted channel. The host dropped every command after that. The UI still showed "connected" (green dot), but nothing you pressed did anything.
3. If a connect attempt failed, the discovery list emptied itself, so the retry had nothing to connect to.

## Root causes

**The desync was the interesting one.** Each frame is encrypted with a monotonically increasing counter as the SecretBox nonce, so the receiver has to decrypt frames strictly in order. The receive path read `_recvCounter`, `await`ed the decrypt, then incremented it. The problem is that `Stream.listen` doesn't backpressure an `async` callback: it hands you the next frame without waiting for the previous callback's Future to complete. So two frames arriving close together both read the same counter across the `await`, and the channel desyncs. It never recovers either, because a failed decrypt doesn't increment. This is why an idle session (keepalive pings 5s apart, never racing) stayed fine while actually using the remote jammed it. The send path was already serialized through `_sendChain` for exactly this reason; the receive path just never got the same treatment.

The reconnect spinner had two causes. Reconnect trusted an in-memory cached `ip:port` and never re-discovered, so if the host's advertised address drifted while the phone slept, every attempt dialed a dead endpoint. And `IOWebSocketChannel.connect()` had no `connectTimeout`, so `await _channel!.ready` on a dead endpoint hung until the OS TCP timeout (~2 min) per attempt, on top of exponential backoff over the same dead address.

The discovery list emptied because the view called `stopDiscovery()` before awaiting the connect action.

## Changes

Added `_recvChain` to mirror the existing `_sendChain`, so `_decryptIncoming` chains each decrypt onto the previous one and the read/increment of `_recvCounter` can't interleave across an `await`. The chain gets reset at the same session boundaries as `_sendChain` (join and cleanup). This is purely about ordering local decrypt work; the wire format is unchanged.

On reconnect, re-discover the host instead of trusting the cache. New `_rediscoverHost(clientId, {timeout})` listens on the mDNS/UDP discovery stream, matches the beacon by `clientId`, and returns the fresh host, or `null` on timeout (it never throws). `_attemptReconnect` re-discovers first, races to the fresh address, and updates the cache; if discovery times out it falls back to the cached address. Manual `ip:port` sessions have no clientId, so they skip discovery. There's a cancellation guard so it bails if you tapped Cancel while discovery was running.

Gave `IOWebSocketChannel.connect()` a `connectTimeout`, so a dead endpoint fails in a few seconds and the existing catch path tears down and reports it instead of hanging.

Removed the premature `stopDiscovery()` so the host list survives a failed connect.

The branch also carries some earlier hardening in the same subsystem: `_teardownChannel` nulls the channel before a bounded close, `disconnect()` bounds both the socket and channel closes, a clean-state reset guards a fast-fail path that used to leave stale handshake state around, and the mid-join cancel path now cancels subscriptions before disconnecting the peer.

## Tests

- `companion_remote_peer_service_connect_timeout_test.dart`: a dead endpoint that accepts TCP but never speaks WebSocket fails well under 15s (proving the connect bound), and connection-refused fails promptly.
- `companion_remote_peer_service_disconnect_test.dart`: `disconnect()` on a dead channel completes quickly, and a subsequent connect opens a new socket (guards the teardown/close bounding).

## Verification

I verified this on a real phone against a macOS host, using the host-side decrypt counter as ground truth rather than trusting the UI.

The desync: before the fix, a burst of rapid taps made the host decrypt counter 6 twice and then jam at 7, followed by 21 straight MAC failures with every later command dropped. After the fix, the same 21-command burst decrypted with a clean monotonic counter (0 through 28) and zero failures, and the client got all its replies back.

Reconnect after sleep: I killed the host and forced its advertised port to drift. The phone reconnected on its own to the new address, and the reconnected session decrypted a full command burst (0 through 23) with zero failures. No spinner.

The discovery list survives a failed connect.

Worth flagging honestly: the two tests above guard the timeout and teardown paths, not the crypto fix. The evidence for the desync fix is the on-device counter traces, not a unit test.
