### PR TITLE
feat(player): show original bitrate in quality controls

### DIFF
--- a/lib/utils/quality_preset_labels.dart
+++ b/lib/utils/quality_preset_labels.dart
@@ -13,8 +13,13 @@ const int _audioBitrateEstimateKbps = 192;
 /// - [TranscodeQualityPreset.original] → "Original"
 /// - [TranscodeQualityPreset.p720_2mbps] → "720p 2 Mbps"
 /// - [TranscodeQualityPreset.p480_1_5mbps] → "480p 1.5 Mbps"
-String qualityPresetLabel(TranscodeQualityPreset preset) {
-  if (preset.isOriginal) return t.videoControls.qualityOriginal;
+String qualityPresetLabel(TranscodeQualityPreset preset, {int? sourceBitrateKbps}) {
+  if (preset.isOriginal) {
+    final bitrate = sourceBitrateKbps != null && sourceBitrateKbps > 0
+        ? ByteFormatter.formatBitrate(sourceBitrateKbps)
+        : null;
+    return [t.videoControls.qualityOriginal, ?bitrate].join(' ');
+  }
   final height = preset.resolutionHeight?.toString() ?? '';
   final bitrate = _formatBitrate(preset.videoBitrateKbps!);
   return t.videoControls.qualityPresetLabel(resolution: height, bitrate: bitrate);

--- a/lib/widgets/video_controls/sheets/version_quality_sheet.dart
+++ b/lib/widgets/video_controls/sheets/version_quality_sheet.dart
@@ -229,7 +229,7 @@ class _QualityColumnState extends State<_QualityColumn> {
 
               return _SelectionTile(
                 key: index == 0 ? _initialScroll.firstItemKey : null,
-                label: qualityPresetLabel(preset),
+                label: qualityPresetLabel(preset, sourceBitrateKbps: widget.sourceBitrateKbps),
                 trailingText: trailing,
                 isSelected: isSelected,
                 enabled: enabled,

--- a/lib/widgets/video_controls/sheets/version_quality_sheet.dart
+++ b/lib/widgets/video_controls/sheets/version_quality_sheet.dart
@@ -182,7 +182,7 @@ class _QualityColumn extends StatelessWidget {
 
         return _SelectionTile(
           key: scope.keyFor(index),
-          label: qualityPresetLabel(preset),
+          label: qualityPresetLabel(preset, sourceBitrateKbps: sourceBitrateKbps),
           trailingText: trailing,
           isSelected: isSelected,
           enabled: enabled,

--- a/lib/widgets/video_controls/sheets/video_settings_sheet.dart
+++ b/lib/widgets/video_controls/sheets/video_settings_sheet.dart
@@ -671,13 +671,14 @@ class _VideoSettingsSheetState extends State<VideoSettingsSheet> {
   }
 
   String _versionQualityValueText() {
+    final showVersions = _state.availableVersions.length > 1;
     final values = <String>[];
-    if (_state.availableVersions.length > 1) values.add(_selectedVersionLabel());
+    if (showVersions) values.add(_selectedVersionLabel());
     if (_state.serverSupportsTranscoding) {
       values.add(
         qualityPresetLabel(
           _state.selectedQualityPreset,
-          sourceBitrateKbps: _selectedSourceBitrateKbps(),
+          sourceBitrateKbps: showVersions ? null : _selectedSourceBitrateKbps(),
         ),
       );
     }

--- a/lib/widgets/video_controls/sheets/video_settings_sheet.dart
+++ b/lib/widgets/video_controls/sheets/video_settings_sheet.dart
@@ -425,13 +425,14 @@ class _VideoSettingsSheetState extends State<VideoSettingsSheet> {
   }
 
   String _versionQualityValueText() {
+    final showVersions = widget.availableVersions.length > 1;
     final values = <String>[];
-    if (widget.availableVersions.length > 1) values.add(_selectedVersionLabel());
+    if (showVersions) values.add(_selectedVersionLabel());
     if (widget.serverSupportsTranscoding) {
       values.add(
         qualityPresetLabel(
           widget.selectedQualityPreset,
-          sourceBitrateKbps: _selectedSourceBitrateKbps(),
+          sourceBitrateKbps: showVersions ? null : _selectedSourceBitrateKbps(),
         ),
       );
     }

--- a/lib/widgets/video_controls/sheets/video_settings_sheet.dart
+++ b/lib/widgets/video_controls/sheets/video_settings_sheet.dart
@@ -673,8 +673,24 @@ class _VideoSettingsSheetState extends State<VideoSettingsSheet> {
   String _versionQualityValueText() {
     final values = <String>[];
     if (_state.availableVersions.length > 1) values.add(_selectedVersionLabel());
-    if (_state.serverSupportsTranscoding) values.add(qualityPresetLabel(_state.selectedQualityPreset));
+    if (_state.serverSupportsTranscoding) {
+      values.add(
+        qualityPresetLabel(
+          _state.selectedQualityPreset,
+          sourceBitrateKbps: _selectedSourceBitrateKbps(),
+        ),
+      );
+    }
     return values.join(' / ');
+  }
+
+  int? _selectedSourceBitrateKbps() {
+    final index = _state.selectedMediaIndex;
+    if (index < 0 || index >= _state.availableVersions.length) {
+      return null;
+    }
+    final bitrate = _state.availableVersions[index].bitrate;
+    return bitrate != null && bitrate > 0 ? bitrate : null;
   }
 
   String _selectedVersionLabel() {

--- a/lib/widgets/video_controls/sheets/video_settings_sheet.dart
+++ b/lib/widgets/video_controls/sheets/video_settings_sheet.dart
@@ -427,8 +427,24 @@ class _VideoSettingsSheetState extends State<VideoSettingsSheet> {
   String _versionQualityValueText() {
     final values = <String>[];
     if (widget.availableVersions.length > 1) values.add(_selectedVersionLabel());
-    if (widget.serverSupportsTranscoding) values.add(qualityPresetLabel(widget.selectedQualityPreset));
+    if (widget.serverSupportsTranscoding) {
+      values.add(
+        qualityPresetLabel(
+          widget.selectedQualityPreset,
+          sourceBitrateKbps: _selectedSourceBitrateKbps(),
+        ),
+      );
+    }
     return values.join(' / ');
+  }
+
+  int? _selectedSourceBitrateKbps() {
+    final index = widget.selectedMediaIndex;
+    if (index < 0 || index >= widget.availableVersions.length) {
+      return null;
+    }
+    final bitrate = widget.availableVersions[index].bitrate;
+    return bitrate != null && bitrate > 0 ? bitrate : null;
   }
 
   String _selectedVersionLabel() {

--- a/test/utils/quality_preset_labels_test.dart
+++ b/test/utils/quality_preset_labels_test.dart
@@ -6,11 +6,14 @@ void main() {
   group('qualityPresetLabel', () {
     test('original returns "Original" (default English locale)', () {
       expect(qualityPresetLabel(TranscodeQualityPreset.original), 'Original');
+      expect(qualityPresetLabel(TranscodeQualityPreset.original, sourceBitrateKbps: 12400), 'Original 12.4 Mbps');
+      expect(qualityPresetLabel(TranscodeQualityPreset.original, sourceBitrateKbps: 0), 'Original');
     });
 
     test('integer-mbps preset renders without decimal', () {
       // 2000 kbps -> 2 Mbps (whole number)
       expect(qualityPresetLabel(TranscodeQualityPreset.p720_2mbps), '720p 2 Mbps');
+      expect(qualityPresetLabel(TranscodeQualityPreset.p720_2mbps, sourceBitrateKbps: 12400), '720p 2 Mbps');
     });
 
     test('fractional-mbps preset renders with one decimal', () {


### PR DESCRIPTION
## Changes
- Show the media's bitrate beside Original in the Quality Picker and Playback Settings menus.