### PR TITLE
fix(player): make desktop chapter selector work

### DIFF
--- a/lib/widgets/video_controls/desktop_video_controls.dart
+++ b/lib/widgets/video_controls/desktop_video_controls.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
+import 'package:flutter/gestures.dart' show PointerScrollEvent;
 import 'package:flutter/material.dart';
 import 'package:plezy/widgets/app_icon.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -29,6 +30,7 @@ import 'widgets/video_controls_header.dart';
 import 'widgets/video_timeline_bar.dart';
 import 'widgets/volume_control.dart';
 import 'widgets/track_chapter_controls.dart';
+import 'video_control_button.dart';
 
 /// Desktop-specific video controls layout with top bar and bottom controls
 class DesktopVideoControls extends StatefulWidget {
@@ -307,6 +309,10 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
   void dismissContentStrip() {
     if (!_contentStripVisible) return;
     _onContentStripNavigateUp();
+  }
+
+  bool handleContentStripScroll(PointerScrollEvent event) {
+    return _contentStripVisible && (_contentStripKey.currentState?.handlePointerScroll(event) ?? false);
   }
 
   /// Handle left navigation from first track control - go to volume (or last button on TV)
@@ -607,13 +613,24 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
                     clipBehavior: Clip.none,
                     children: [
                       _buildBottomControlsContent(context, hasFrame: true),
-                      // Down arrow hint when strip content is available
                       if (widget.useDpadNavigation && _hasStripContent)
-                        const Positioned(
+                        Positioned(
                           left: 0,
                           right: 0,
-                          bottom: 12,
-                          child: AppIcon(Symbols.keyboard_arrow_down_rounded, color: Colors.white24, size: 24),
+                          bottom: 0,
+                          child: Center(
+                            child: SizedBox.square(
+                              key: const ValueKey('desktop_content_strip_open'),
+                              dimension: 48,
+                              child: VideoControlButton(
+                                icon: Symbols.keyboard_arrow_up_rounded,
+                                color: Colors.white24,
+                                tooltip: t.videoControls.chaptersButton,
+                                semanticLabel: t.videoControls.chaptersButton,
+                                onPressed: _showContentStrip,
+                              ),
+                            ),
+                          ),
                         ),
                     ],
                   ),
@@ -636,7 +653,22 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
                     child: Column(
                       mainAxisSize: .min,
                       children: [
-                        const AppIcon(Symbols.keyboard_arrow_up_rounded, color: Colors.white38, size: 20),
+                        SizedBox.square(
+                          key: const ValueKey('desktop_content_strip_close'),
+                          dimension: 48,
+                          child: DecoratedBox(
+                            decoration: BoxDecoration(
+                              color: Colors.black.withValues(alpha: 0.4),
+                              shape: BoxShape.circle,
+                            ),
+                            child: VideoControlButton(
+                              icon: Symbols.keyboard_arrow_down_rounded,
+                              color: Colors.white38,
+                              semanticLabel: t.common.close,
+                              onPressed: _onContentStripNavigateUp,
+                            ),
+                          ),
+                        ),
                         const SizedBox(height: 4),
                         ContentStrip(
                           key: _contentStripKey,
@@ -649,6 +681,7 @@ class DesktopVideoControlsState extends State<DesktopVideoControls> {
                           onSeekRequested: widget.onSeekRequested,
                           onSeekCompleted: widget.onSeekCompleted,
                           useFocusNavigation: true,
+                          showFocusNavigationLabel: PlatformDetector.isTV(),
                           onNavigateUp: _onContentStripNavigateUp,
                           onFocusActivity: widget.onFocusActivity,
                         ),

--- a/lib/widgets/video_controls/parts/playback_input.dart
+++ b/lib/widgets/video_controls/parts/playback_input.dart
@@ -541,6 +541,12 @@ extension _PlexVideoControlsPlaybackInputMethods on _PlexVideoControlsState {
     final isMobile = PlatformDetector.isMobile(context);
 
     if (!isMobile) {
+      if (widget.chromeController.contentStripVisible) {
+        _desktopControlsKey.currentState?.dismissContentStrip();
+        widget.chromeController.setContentStripVisible(false);
+        _restartHideTimerForCurrentPlaybackState();
+        return;
+      }
       final DateTime now = DateTime.now();
 
       // Always perform the single-click behavior immediately

--- a/lib/widgets/video_controls/parts/visibility.dart
+++ b/lib/widgets/video_controls/parts/visibility.dart
@@ -67,6 +67,10 @@ extension _PlexVideoControlsVisibilityMethods on _PlexVideoControlsState {
   void _restartHideTimerForCurrentPlaybackState() => widget.chromeController.restartAutoHideForCurrentPlaybackState();
 
   void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent && (_desktopControlsKey.currentState?.handleContentStripScroll(event) ?? false)) {
+      _cancelAutoSkipFromUserInteraction();
+      return;
+    }
     if (event is PointerScrollEvent && _keyboardService != null) {
       _cancelAutoSkipFromUserInteraction();
       final delta = event.scrollDelta.dy;

--- a/lib/widgets/video_controls/widgets/content_strip.dart
+++ b/lib/widgets/video_controls/widgets/content_strip.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show Stream, unawaited;
 import '../../../media/ids.dart';
 
+import 'package:flutter/gestures.dart' show PointerScrollEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -43,6 +44,9 @@ class ContentStrip extends StatefulWidget {
   /// When true, no tab bar is shown — pages are navigated via UP/DOWN.
   final bool useFocusNavigation;
 
+  /// Whether focus-navigation mode should show the current page label.
+  final bool showFocusNavigationLabel;
+
   /// Called when navigating UP from the top-most strip page (back to buttons).
   final VoidCallback? onNavigateUp;
 
@@ -60,6 +64,7 @@ class ContentStrip extends StatefulWidget {
     this.onSeekRequested,
     this.onSeekCompleted,
     this.useFocusNavigation = false,
+    this.showFocusNavigationLabel = true,
     this.onNavigateUp,
     this.onFocusActivity,
   });
@@ -196,6 +201,25 @@ class ContentStripState extends State<ContentStrip> {
         _lastAutoScrolledQueueIndex = null;
       }
     });
+  }
+
+  bool handlePointerScroll(PointerScrollEvent event) {
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.paintBounds.contains(renderObject.globalToLocal(event.position))) {
+      return false;
+    }
+
+    final controller = _activeTab == _StripTab.chapters ? _chapterScrollController : _queueScrollController;
+    if (!controller.hasClients) return true;
+
+    final delta = event.scrollDelta;
+    final horizontalDelta = delta.dx.abs() > delta.dy.abs() ? delta.dx : delta.dy;
+    if (horizontalDelta == 0) return true;
+
+    final position = controller.position;
+    controller.jumpTo((position.pixels + horizontalDelta).clamp(0.0, position.maxScrollExtent));
+    widget.onFocusActivity?.call();
+    return true;
   }
 
   KeyEventResult _handleFocusItemKeyEvent(KeyEvent event, int index, int totalItems, _StripTab page) {
@@ -335,8 +359,8 @@ class ContentStripState extends State<ContentStrip> {
           children: [
             // Tab bar only shown in touch mode when both tabs exist
             if (_hasBothTabs && !widget.useFocusNavigation) _buildTabBar(),
-            // In focus mode, show a small label for the current page
-            if (widget.useFocusNavigation)
+            // In focus mode, show a small label for the current page when requested.
+            if (widget.useFocusNavigation && widget.showFocusNavigationLabel)
               Padding(
                 padding: const EdgeInsets.only(bottom: 4),
                 child: Text(

--- a/test/widgets/video_controls_test.dart
+++ b/test/widgets/video_controls_test.dart
@@ -2,24 +2,34 @@ import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart' show PointerScrollEvent;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plezy/focus/key_event_utils.dart';
 import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/media/media_source_info.dart';
 import 'package:plezy/media/media_version.dart';
 import 'package:plezy/models/shader_preset.dart';
 import 'package:plezy/mpv/mpv.dart';
+import 'package:plezy/services/settings_service.dart';
 import 'package:plezy/theme/mono_tokens.dart';
+import 'package:plezy/watch_together/providers/watch_together_provider.dart';
+import 'package:plezy/widgets/video_controls/desktop_video_controls.dart';
 import 'package:plezy/widgets/video_controls/video_controls.dart';
 import 'package:plezy/widgets/video_controls/player_chrome_controller.dart';
+import 'package:plezy/widgets/video_controls/widgets/content_strip.dart';
 import 'package:plezy/widgets/video_controls/painters/buffer_range_painter.dart';
 import 'package:plezy/widgets/video_controls/widgets/mobile_skip_zones.dart';
 import 'package:plezy/widgets/video_controls/widgets/skip_marker_button.dart';
 import 'package:plezy/widgets/video_controls/widgets/sync_offset_control.dart';
 import 'package:plezy/widgets/video_controls/widgets/timeline_slider.dart';
 import 'package:plezy/widgets/video_controls/widgets/video_timeline_bar.dart';
+import 'package:provider/provider.dart';
 
+import '../test_helpers/prefs.dart';
 import '../test_helpers/watch_together_fakes.dart';
 
 const _testTokens = MonoTokens(
@@ -1250,6 +1260,98 @@ void main() {
       expect(slider.divisions, 1200);
       expect((slider.max - slider.min) / slider.divisions!, 100);
       expect(sliderTheme.data.tickMarkShape, same(SliderTickMarkShape.noTickMark));
+    });
+  });
+
+  group('DesktopVideoControls content strip', () {
+    setUp(() async {
+      LocaleSettings.setLocaleSync(AppLocale.en);
+      resetSharedPreferencesForTest();
+      SettingsService.resetForTesting();
+      await SettingsService.getInstance();
+    });
+
+    testWidgets('desktop chapter strip supports pointer interaction', (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(800, 600);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPhysicalSize);
+
+      final player = FakeSyncPlayer(duration: Duration.zero);
+      addTearDown(player.dispose);
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (_) => WatchTogetherProvider(),
+          child: MaterialApp(
+            theme: ThemeData(extensions: const [_testTokens]),
+            home: Scaffold(
+              body: DesktopVideoControls(
+                player: player,
+                metadata: MediaItem(
+                  id: 'video',
+                  backend: MediaBackend.plex,
+                  kind: MediaKind.movie,
+                  title: 'Test video',
+                ),
+                chapters: List.generate(
+                  12,
+                  (index) => MediaChapter(id: index, title: 'Chapter ${index + 1}', startTimeOffset: index * 60000),
+                ),
+                chaptersLoaded: true,
+                seekTimeSmall: 10,
+                onSeekToPreviousChapter: () {},
+                onSeekToNextChapter: () {},
+                onSeek: (_) {},
+                onSeekEnd: (_) {},
+                getReplayIcon: (_) => Icons.replay,
+                getForwardIcon: (_) => Icons.fast_forward,
+                onBack: () {},
+                useDpadNavigation: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final openToggle = find.byKey(const ValueKey('desktop_content_strip_open'));
+      await tester.tap(openToggle);
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(ContentStrip), findsOneWidget);
+      expect(find.text(t.videoControls.chapters), findsNothing);
+
+      final closeToggle = find.byKey(const ValueKey('desktop_content_strip_close'));
+      final closeButton = tester.widget<IconButton>(
+        find.descendant(of: closeToggle, matching: find.byType(IconButton)),
+      );
+      expect(closeButton.tooltip, isNull);
+      final closeBackground = tester.widget<DecoratedBox>(
+        find.descendant(of: closeToggle, matching: find.byType(DecoratedBox)).first,
+      );
+      expect((closeBackground.decoration as BoxDecoration).color, Colors.black.withValues(alpha: 0.4));
+
+      final scrollable = find.descendant(of: find.byType(ContentStrip), matching: find.byType(Scrollable)).first;
+      final position = tester.state<ScrollableState>(scrollable).position;
+      expect(position.maxScrollExtent, greaterThan(0));
+      expect(position.pixels, 0);
+
+      final scrollPosition = tester.getCenter(find.text('Chapter 3'));
+      final handled = tester
+          .state<DesktopVideoControlsState>(find.byType(DesktopVideoControls))
+          .handleContentStripScroll(PointerScrollEvent(position: scrollPosition, scrollDelta: const Offset(0, 160)));
+      await tester.pump();
+
+      expect(handled, isTrue);
+      expect(position.pixels, greaterThan(0));
+
+      await tester.tap(closeToggle);
+      await tester.pump();
+
+      expect(find.byType(ContentStrip), findsNothing);
+      expect(openToggle, findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Fix issue that prevents mouse users from opening and interacting with the chapter selector on desktop.

## Changes
- Open and close the existing chapter and queue strip using a clickable button
- Scroll the open strip with a mouse wheel or trackpad
- Close the strip when clicking the video


https://github.com/user-attachments/assets/ea801964-4f06-40f0-83cc-1f7517cfd898

