### PR TITLE
ci(relay): publish versioned multi-arch container images

### DIFF
--- a/.github/workflows/check-relay-image.yml
+++ b/.github/workflows/check-relay-image.yml
@@ -1,0 +1,42 @@
+name: CI - Sanity Checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/check-relay-image.yml"
+      - "server/Dockerfile"
+      - "server/go.mod"
+      - "server/go.sum"
+      - "server/*.go"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/check-relay-image.yml"
+      - "server/Dockerfile"
+      - "server/go.mod"
+      - "server/go.sum"
+      - "server/*.go"
+
+jobs:
+  build:
+    name: Build relay image (amd64)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build relay image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha,scope=relay-amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           python3 scripts/test_check_workflow_security.py
           python3 scripts/test_run_maestro.py
           python3 scripts/check_update_packages_workflow.py
+          python3 scripts/check_publish_relay_image_workflow.py
           python3 scripts/test_pubspec_version.py
           python3 scripts/test_clean_translations.py
           python3 scripts/test_check_icon_consistency.py

--- a/.github/workflows/publish-relay-image.yml
+++ b/.github/workflows/publish-relay-image.yml
@@ -1,0 +1,201 @@
+name: Publish Relay Image
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  detect-server-changes:
+    name: Detect server changes since the previous release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      publish: ${{ steps.release.outputs.publish }}
+      version: ${{ steps.release.outputs.version }}
+      image: ${{ steps.release.outputs.image }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check whether this release changes the relay
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="$GITHUB_REF_NAME"
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          image="ghcr.io/$owner/plezy/relay-server"
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '$version' is not a release version; skipping relay image publication."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          previous_tag="$(
+            git for-each-ref \
+              --merged "$GITHUB_SHA^" \
+              --sort=-version:refname \
+              --format='%(refname:strip=2)' \
+              refs/tags | while IFS= read -r candidate; do
+                if [[ "$candidate" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                  printf '%s\n' "$candidate"
+                  break
+                fi
+              done
+          )"
+          if [[ -z "$previous_tag" ]]; then
+            echo "No previous release tag found; publishing the initial relay image."
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if git diff --quiet "$previous_tag" "$GITHUB_SHA" -- server/; then
+            echo "No server changes since $previous_tag; skipping relay image publication."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Server changes found since $previous_tag; publishing relay image."
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+
+  build-amd64:
+    name: Build relay image (amd64)
+    needs: detect-server-changes
+    if: needs.detect-server-changes.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build and push relay image by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          platforms: linux/amd64
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          outputs: type=image,name=${{ needs.detect-server-changes.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=relay-amd64
+          cache-to: type=gha,scope=relay-amd64,mode=max
+          provenance: false
+
+  build-arm64:
+    name: Build relay image (arm64)
+    needs: detect-server-changes
+    if: needs.detect-server-changes.outputs.publish == 'true'
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build and push relay image by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          platforms: linux/arm64
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          outputs: type=image,name=${{ needs.detect-server-changes.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=relay-arm64
+          cache-to: type=gha,scope=relay-arm64,mode=max
+          provenance: false
+
+  publish-manifest:
+    name: Publish relay manifest
+    needs: [detect-server-changes, build-amd64, build-arm64]
+    if: needs.detect-server-changes.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ needs.detect-server-changes.outputs.image }}
+          tags: |
+            type=raw,value=${{ needs.detect-server-changes.outputs.version }}
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=latest
+
+      - name: Create multi-architecture manifest
+        id: manifest
+        env:
+          IMAGE: ${{ needs.detect-server-changes.outputs.image }}
+          VERSION: ${{ needs.detect-server-changes.outputs.version }}
+          AMD64_DIGEST: ${{ needs.build-amd64.outputs.digest }}
+          ARM64_DIGEST: ${{ needs.build-arm64.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta.outputs.json }}')
+          docker buildx imagetools create $tags \
+            "$IMAGE@$AMD64_DIGEST" \
+            "$IMAGE@$ARM64_DIGEST"
+
+          digest="$(docker buildx imagetools inspect "$IMAGE:$VERSION" --format '{{.Manifest.Digest}}')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest relay image provenance
+        uses: actions/attest-build-provenance@78e6cbd37d0ac1a40113c04f2037dacf1ea3f12e # v4
+        with:
+          subject-name: ${{ needs.detect-server-changes.outputs.image }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Package managers:
 [^5]: Windows, Android, and tvOS.
 [^6]: Desktop only.
 
+## Relay Server
+
+Plezy's backend service coordinates Watch Together sessions and supports client logs, Discord artwork, and optional tracker sign-in flows. See the [Relay Server README](server/README.md) for Docker images, deployment, and development.
+
 ## Building from Source
 
 ### Prerequisites

--- a/scripts/check_publish_relay_image_workflow.py
+++ b/scripts/check_publish_relay_image_workflow.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Guard the release contract for the relay container image workflow."""
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/publish-relay-image.yml"
+CHECK_WORKFLOW = ROOT / ".github/workflows/check-relay-image.yml"
+text = WORKFLOW.read_text(encoding="utf-8")
+check_text = CHECK_WORKFLOW.read_text(encoding="utf-8")
+errors: list[str] = []
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        errors.append(message)
+
+
+require("  push:\n    tags:" in text, "relay image workflow must trigger on pushed tags")
+require("workflow_dispatch:" not in text, "relay image workflow must not allow manual publication")
+require("pull_request:" not in text, "relay image workflow must not run on pull requests")
+require("branches:" not in text, "relay image workflow must not trigger on branch pushes")
+require("fetch-depth: 0" in text, "relay image workflow must fetch release history")
+require("persist-credentials: false" in text, "relay image checkouts must discard credentials")
+require(
+    '^[0-9]+\\.[0-9]+\\.[0-9]+$' in text,
+    "relay image workflow must validate semantic release tags",
+)
+require(
+    'git for-each-ref' in text
+    and '--merged "$GITHUB_SHA^"' in text
+    and '--sort=-version:refname' in text,
+    "relay image workflow must resolve the previous semantic release tag",
+)
+require(
+    'git diff --quiet "$previous_tag" "$GITHUB_SHA" -- server/' in text,
+    "relay image workflow must publish only after server changes",
+)
+require(
+    'owner="${GITHUB_REPOSITORY_OWNER,,}"' in text,
+    "relay image workflow must lowercase the repository owner",
+)
+require(
+    'image="ghcr.io/$owner/plezy/relay-server"' in text,
+    "relay image workflow must publish under the repository owner namespace",
+)
+for permission in ("contents: read", "packages: write", "id-token: write", "attestations: write"):
+    require(permission in text, f"relay image workflow must grant {permission}")
+require("context: ./server" in text, "relay image workflow must build from the server context")
+require("file: ./server/Dockerfile" in text, "relay image workflow must use the server Dockerfile")
+require("platforms: linux/amd64" in text, "relay image workflow must build amd64 natively")
+require("platforms: linux/arm64" in text, "relay image workflow must build arm64 natively")
+require("runs-on: ubuntu-24.04-arm" in text, "relay image workflow must use a native arm64 runner")
+for cache_scope in ("relay-amd64", "relay-arm64"):
+    require(f"scope={cache_scope}" in text, f"relay image workflow must cache {cache_scope} independently")
+require("docker buildx imagetools create" in text, "relay image workflow must assemble a multi-architecture manifest")
+for tag in (
+    "type=raw,value=${{ needs.detect-server-changes.outputs.version }}",
+    "type=raw,value=sha-${{ github.sha }}",
+    "type=raw,value=latest",
+):
+    require(tag in text, f"relay image workflow must publish tag: {tag}")
+require("subject-digest: ${{ steps.manifest.outputs.digest }}" in text, "relay image workflow must attest the manifest digest")
+require("push-to-registry: true" in text, "relay image provenance must be published to GHCR")
+
+require(
+    "  pull_request:\n    branches: [main]\n    paths:" in check_text,
+    "relay image check must run for filtered pull requests to main",
+)
+require(
+    "  push:\n    branches: [main]\n    paths:" in check_text,
+    "relay image check must run for filtered pushes to main",
+)
+for path in (
+    ".github/workflows/check-relay-image.yml",
+    "server/Dockerfile",
+    "server/go.mod",
+    "server/go.sum",
+    "server/*.go",
+):
+    require(path in check_text, f"relay image check must include {path}")
+require("server/**" not in check_text, "relay image pull-request check must not rebuild for all server changes")
+require("push: false" in check_text, "relay image pull-request check must not publish")
+require("context: ./server" in check_text, "relay image pull-request check must use the server context")
+require("file: ./server/Dockerfile" in check_text, "relay image pull-request check must use the server Dockerfile")
+require("cache-from: type=gha,scope=relay-amd64" in check_text, "relay image pull-request check must reuse the amd64 cache")
+
+if errors:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    sys.exit(1)
+
+print("relay image workflow checks passed")

--- a/scripts/ci_checks.sh
+++ b/scripts/ci_checks.sh
@@ -86,6 +86,7 @@ if python3 scripts/check_build_workflow.py &&
    python3 scripts/check_workflow_security.py &&
    python3 scripts/test_check_workflow_security.py &&
    python3 scripts/check_update_packages_workflow.py &&
+   python3 scripts/check_publish_relay_image_workflow.py &&
    python3 scripts/test_pubspec_version.py &&
    python3 scripts/test_clean_translations.py &&
    python3 scripts/test_run_maestro.py &&

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,112 @@
+<h1>Plezy Relay</h1>
+
+A backend service for Plezy. It coordinates Watch Together sessions, receives client logs, stores Discord Rich Presence artwork, and handles optional MyAnimeList and AniList sign-in flows.
+
+## Download
+
+Pull the image from `ghcr.io/edde746/plezy/relay-server`. It supports `amd64` and `arm64`.
+
+## Features
+
+### Watch Together
+
+- WebSocket relay for synchronized playback
+- Health endpoint for load balancers and deployment checks
+- In-memory room coordination with persisted snapshots for restart recovery
+
+### Client Support
+
+- Client-log upload and retrieval
+- Temporary Discord Rich Presence poster storage
+- Built-in rate limits and connection limits
+
+### Integrations
+
+- Optional MyAnimeList OAuth with PKCE
+- Optional AniList OAuth proxy
+- OAuth sessions and tokens kept in memory and never written to disk
+
+## Deployment
+
+### Docker
+
+Run the versioned image with persistent state:
+
+```sh
+docker run --detach \
+  --name plezy-relay \
+  --publish 127.0.0.1:8080:8080 \
+  --volume plezy-relay-data:/data \
+  ghcr.io/edde746/plezy/relay-server:<version>
+```
+
+After the container starts, check that the relay is healthy:
+
+```sh
+curl http://127.0.0.1:8080/health
+```
+
+### Docker Compose
+
+Start the relay with Docker Compose:
+
+```sh
+cd server
+docker compose up --detach relay
+```
+
+- `docker compose up --detach relay` starts only the relay.
+- `docker compose up --detach` starts both the relay and Bugs.
+
+### Configuration
+
+| Setting | Purpose |
+| --- | --- |
+| `OAUTH_BASE_URL` | Public HTTPS base URL for OAuth callbacks. OAuth routes are disabled when unset. |
+| `MAL_CLIENT_ID` | Enables MyAnimeList OAuth. |
+| `ANILIST_CLIENT_ID` | Enables AniList OAuth. |
+| `ANILIST_CLIENT_SECRET` | Required for AniList token exchange. |
+| `-addr` | Listen address; default `:8080`. |
+| `-log-dir` | Log directory; default `/data/logs`. |
+| `-poster-dir` | Poster directory; default `/data/posters`. |
+| `-state-file` | Room snapshot path; default `/data/rooms.json`. |
+
+## Building from Source
+
+### Prerequisites
+
+- Go 1.22+
+- Docker, for container builds
+
+### Setup
+
+From the repository root:
+
+```sh
+docker build --tag plezy-relay ./server
+docker run --rm --publish 8080:8080 plezy-relay
+```
+
+### Code Generation
+
+The relay protocol is shared with the Flutter app. After changing `relay_protocol.json`, regenerate both protocol implementations:
+
+```sh
+scripts/codegen.sh
+```
+
+### Local Checks
+
+```sh
+cd server
+go test ./...
+```
+
+## License
+
+Plezy Relay is licensed under [GPL-3.0](../LICENSE).
+
+## Acknowledgments
+
+- Built with [Go](https://go.dev)
+- WebSocket support by [Gorilla WebSocket](https://github.com/gorilla/websocket)


### PR DESCRIPTION
## Summary

Adds a release-driven Docker image pipeline for the Plezy relay server.

- Adds a release-driven Docker image pipeline for the Plezy relay server.
- Publishes multi-architecture (`amd64`, `arm64`) images to:
  - `ghcr.io/<repository-owner>/plezy/relay-server:<version>`
  - `ghcr.io/<repository-owner>/plezy/relay-server:sha-<commit>`
  - `ghcr.io/<repository-owner>/plezy/relay-server:latest`
- Publishes only when a semantic Plezy release tag includes relevant relay build-input changes since the prior release.
- Builds amd64 and arm64 on native runners, caches layers per architecture, combines digests into a multi-architecture manifest, and publishes provenance.

## Release workflow
The relay Docker image is released alongside Plezy versions, but only when the relay itself is modified. The intended release workflow is as follows:
1. Create a plain semantic Plezy release tag, such as 2.10.0.
2. The workflow compares `server/` changes with the preceding release tag.
3. If the relevant files in the `server/` directory changed, it builds **amd64** and **arm64** images.
4. It publishes one multi-architecture image tagged with the release version, commit SHA, and latest.
5. If the `server/` directory did not have any meaningful changes, it skips the image build and leaves the existing image untouched.