### PR TITLE
feat(jellyfin): add Next Up and full Favorites integration

### DIFF
--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -409,6 +409,11 @@
     "mediaDeletedSuccessfully": "Media item deleted successfully",
     "mediaFailedToDelete": "Failed to delete media item",
     "rate": "Rate",
+    "addToFavorites": "Add to Favorites",
+    "removeFromFavorites": "Remove from Favorites",
+    "addedToFavorites": "Added to Favorites",
+    "removedFromFavorites": "Removed from Favorites",
+    "favoritesUpdateFailed": "Couldn't update Favorites",
     "playFromBeginning": "Play from Beginning",
     "playVersion": "Play Version..."
   },

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 22851 (1428 per locale)
+/// Strings: 22856 (1428 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -1273,6 +1273,21 @@ class TranslationsMediaMenuEn {
 	/// en: 'Rate'
 	String get rate => 'Rate';
 
+	/// en: 'Add to Favorites'
+	String get addToFavorites => 'Add to Favorites';
+
+	/// en: 'Remove from Favorites'
+	String get removeFromFavorites => 'Remove from Favorites';
+
+	/// en: 'Added to Favorites'
+	String get addedToFavorites => 'Added to Favorites';
+
+	/// en: 'Removed from Favorites'
+	String get removedFromFavorites => 'Removed from Favorites';
+
+	/// en: 'Couldn't update Favorites'
+	String get favoritesUpdateFailed => 'Couldn\'t update Favorites';
+
 	/// en: 'Play from Beginning'
 	String get playFromBeginning => 'Play from Beginning';
 
@@ -5369,6 +5384,11 @@ extension on Translations {
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media item deleted successfully',
 			'mediaMenu.mediaFailedToDelete' => 'Failed to delete media item',
 			'mediaMenu.rate' => 'Rate',
+			'mediaMenu.addToFavorites' => 'Add to Favorites',
+			'mediaMenu.removeFromFavorites' => 'Remove from Favorites',
+			'mediaMenu.addedToFavorites' => 'Added to Favorites',
+			'mediaMenu.removedFromFavorites' => 'Removed from Favorites',
+			'mediaMenu.favoritesUpdateFailed' => 'Couldn\'t update Favorites',
 			'mediaMenu.playFromBeginning' => 'Play from Beginning',
 			'mediaMenu.playVersion' => 'Play Version...',
 			'rateSheet.title' => 'Rate',
@@ -5487,13 +5507,13 @@ extension on Translations {
 			'messages.markedAsWatchedOffline' => 'Marked as watched (will sync when online)',
 			'messages.markedAsUnwatchedOffline' => 'Marked as unwatched (will sync when online)',
 			'messages.autoRemovedWatchedDownload' => ({required Object title}) => 'Auto-removed: ${title}',
+			_ => null,
+		} ?? switch (path) {
 			'messages.autoRemovedWatchedDownloads' => ({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(n, one: 'Auto-removed ${n} watched download', other: 'Auto-removed ${n} watched downloads', ), 
 			'messages.removedFromContinueWatching' => 'Removed from Continue Watching',
 			'messages.errorLoading' => ({required Object error}) => 'Error: ${error}',
 			'messages.streamInterrupted' => 'The stream was interrupted. Press play or seek to retry.',
 			'messages.liveStreamInterrupted' => 'The live stream was interrupted. Press play to retry.',
-			_ => null,
-		} ?? switch (path) {
 			'messages.fileInfoNotAvailable' => 'File information not available',
 			'messages.errorLoadingFileInfo' => ({required Object error}) => 'Error loading file info: ${error}',
 			'messages.errorLoadingSeries' => 'Error loading series',
@@ -6001,13 +6021,13 @@ extension on Translations {
 			'watchTogether.recentRooms' => 'Recent Rooms',
 			'watchTogether.renameRoom' => 'Rename Room',
 			'watchTogether.removeRoom' => 'Remove',
+			_ => null,
+		} ?? switch (path) {
 			'watchTogether.guestSwitchUnavailable' => 'Couldn\'t switch — server unavailable for sync',
 			'watchTogether.guestSwitchFailed' => 'Couldn\'t switch — content not found on this server',
 			'downloads.title' => 'Downloads',
 			'downloads.manage' => 'Manage',
 			'downloads.tvShows' => 'TV Shows',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.movies' => 'Movies',
 			'downloads.music' => 'Music',
 			'downloads.tracksQueued' => ({required Object count}) => '${count} tracks queued for download',

--- a/lib/media/media_server_client.dart
+++ b/lib/media/media_server_client.dart
@@ -277,6 +277,12 @@ abstract class MediaServerClient {
   /// internally; the neutral name matches the Continue Watching UI surface.
   Future<List<MediaItem>> fetchContinueWatching({int? count = 20});
 
+  /// The next unwatched episode for each series the user is following.
+  ///
+  /// This is a distinct home surface from [fetchContinueWatching]. Backends
+  /// without a dedicated Next Up concept return an empty list by default.
+  Future<List<MediaItem>> fetchNextUp({int? count = 20}) async => const [];
+
   /// Curated home-screen hubs across all libraries (Plex Discover; Jellyfin
   /// synthesizes `Latest` plus optional `Resume` + `NextUp`).
   Future<List<MediaHub>> fetchGlobalHubs({int limit = defaultHubPreviewLimit, bool includePlaybackHubs = true});
@@ -714,6 +720,12 @@ abstract interface class SeasonEpisodePagingClient {
 /// implementations — both clients use `implements MediaServerClient` so a
 /// shared base class isn't an option, but a `mixin on MediaServerClient` is.
 mixin MediaServerCacheMixin implements MediaServerClient {
+  // Concrete clients use `implements MediaServerClient`, so they do not inherit
+  // default interface bodies. Keep the optional Next Up capability empty here;
+  // Jellyfin's later browse mixin overrides it with `/Shows/NextUp`.
+  @override
+  Future<List<MediaItem>> fetchNextUp({int? count = 20}) async => const [];
+
   /// Fetch with cache fallback: offline → cached only; online → try network,
   /// cache the result, fall back to cached on any error.
   ///

--- a/lib/models/catalog/catalog_item.dart
+++ b/lib/models/catalog/catalog_item.dart
@@ -4,7 +4,7 @@ import '../../media/media_kind.dart';
 import '../../utils/external_ids.dart';
 
 /// External catalog providers that can back the Explore tab.
-enum CatalogSourceId { trakt, mal, seerr }
+enum CatalogSourceId { trakt, mal, seerr, jellyfin }
 
 /// Normalized airing/production status across providers (Trakt `status`,
 /// MAL `status`). Null when unknown or uninteresting (released movies).

--- a/lib/navigation/profile_session_screen.dart
+++ b/lib/navigation/profile_session_screen.dart
@@ -164,10 +164,17 @@ class _ProfileSessionScreenState extends State<ProfileSessionScreen> {
                   return provider;
                 },
               ),
-              ChangeNotifierProxyProvider3<
+              ChangeNotifierProvider(
+                create: (context) =>
+                    HiddenLibrariesProvider(storageService: context.read<StorageService>(), profileId: activeId),
+                lazy: true,
+              ),
+              ChangeNotifierProxyProvider5<
                 TraktAccountProvider,
                 TrackersProvider,
                 SeerrAccountProvider,
+                MultiServerProvider,
+                HiddenLibrariesProvider,
                 CatalogSourcesProvider
               >(
                 create: (context) {
@@ -179,9 +186,9 @@ class _ProfileSessionScreenState extends State<ProfileSessionScreen> {
                   );
                   return provider;
                 },
-                update: (_, trakt, trackers, seerr, previous) {
+                update: (_, trakt, trackers, seerr, multiServer, hiddenLibraries, previous) {
                   final provider = previous ?? CatalogSourcesProvider();
-                  provider.update(trakt, trackers, seerr);
+                  provider.update(trakt, trackers, seerr, multiServer, hiddenLibraries);
                   return provider;
                 },
               ),
@@ -190,11 +197,6 @@ class _ProfileSessionScreenState extends State<ProfileSessionScreen> {
                 lazy: true,
               ),
               Provider(create: (context) => CatalogLibraryMatcher(context.read<MultiServerProvider>()), lazy: true),
-              ChangeNotifierProvider(
-                create: (context) =>
-                    HiddenLibrariesProvider(storageService: context.read<StorageService>(), profileId: activeId),
-                lazy: true,
-              ),
               ChangeNotifierProvider(
                 create: (context) {
                   final activeProfile = context.read<ActiveProfileProvider>();

--- a/lib/providers/catalog_sources_provider.dart
+++ b/lib/providers/catalog_sources_provider.dart
@@ -1,17 +1,23 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
+import '../media/ids.dart';
+import '../media/media_backend.dart';
+import '../media/media_server_client.dart';
 import '../mixins/disposable_change_notifier_mixin.dart';
 import '../models/catalog/catalog_item.dart';
 import '../profiles/profile.dart';
 import '../services/base_shared_preferences_service.dart';
 import '../services/catalog/catalog_source.dart';
+import '../services/catalog/jellyfin_favorites_catalog_source.dart';
 import '../services/catalog/mal_catalog_source.dart';
 import '../services/catalog/seerr_catalog_source.dart';
 import '../services/catalog/trakt_catalog_source.dart';
 import '../services/seerr/seerr_client.dart';
 import '../services/trackers/mal/mal_client.dart';
 import '../services/trakt/trakt_client.dart';
+import 'hidden_libraries_provider.dart';
+import 'multi_server_provider.dart';
 import 'seerr_account_provider.dart';
 import 'trakt_account_provider.dart';
 import 'trackers_provider.dart';
@@ -19,11 +25,12 @@ import 'trackers_provider.dart';
 /// Enumerates the connected [CatalogSource]s for the active profile and owns
 /// which one the Explore tab shows.
 ///
-/// Profile-scoped; rebuilt through a `ChangeNotifierProxyProvider3` on
+/// Profile-scoped; rebuilt through a `ChangeNotifierProxyProvider5` on
 /// [TraktAccountProvider], [TrackersProvider] (MAL), and
-/// [SeerrAccountProvider] so sources appear and
-/// disappear live when a provider is connected or disconnected mid-session
-/// (which also drives the Explore tab's visibility).
+/// [SeerrAccountProvider] plus the online media-server set so sources appear and
+/// disappear live when a provider is connected or disconnected mid-session,
+/// and [HiddenLibrariesProvider] so Jellyfin Favorites follows library
+/// visibility changes (which also drives the Explore tab's visibility).
 class CatalogSourcesProvider extends ChangeNotifier with DisposableChangeNotifierMixin {
   static const String _activeSourceBaseKey = 'catalog_active_source';
 
@@ -33,12 +40,15 @@ class CatalogSourcesProvider extends ChangeNotifier with DisposableChangeNotifie
   MalClient? _lastMalClient;
   SeerrCatalogSource? _seerr;
   SeerrClient? _lastSeerrClient;
+  JellyfinFavoritesCatalogSource? _jellyfinFavorites;
+  List<MediaServerClient> _lastJellyfinClients = const [];
+  Set<String> _lastHiddenLibraryKeys = const {};
   CatalogSourceId? _preferredSourceId;
   String _activeUserUuid = '';
 
-  List<CatalogSource> get connectedSources => [?_trakt, ?_mal, ?_seerr];
+  List<CatalogSource> get connectedSources => [?_trakt, ?_mal, ?_seerr, ?_jellyfinFavorites];
 
-  bool get hasAnySource => _trakt != null || _mal != null || _seerr != null;
+  bool get hasAnySource => connectedSources.isNotEmpty;
 
   /// The connected Seerr source, for the request surfaces (detail-screen
   /// Request action and sheet) that need Seerr's client beyond the
@@ -94,7 +104,13 @@ class CatalogSourcesProvider extends ChangeNotifier with DisposableChangeNotifie
 
   /// Proxy-provider update hook: rebuild a source when its catalog client
   /// was rebound (connect/disconnect/profile switch).
-  void update(TraktAccountProvider trakt, TrackersProvider trackers, SeerrAccountProvider seerr) {
+  void update(
+    TraktAccountProvider trakt,
+    TrackersProvider trackers,
+    SeerrAccountProvider seerr,
+    MultiServerProvider multiServer,
+    HiddenLibrariesProvider hiddenLibraries,
+  ) {
     var changed = false;
 
     final traktClient = trakt.catalogClient;
@@ -121,7 +137,32 @@ class CatalogSourcesProvider extends ChangeNotifier with DisposableChangeNotifie
       changed = true;
     }
 
+    final jellyfinClients = <MediaServerClient>[
+      for (final id in multiServer.onlineServerIds)
+        if (multiServer.getClientForServer(ServerId(id)) case final MediaServerClient client)
+          if (client.backend == MediaBackend.jellyfin) client,
+    ];
+    final hiddenLibraryKeys = hiddenLibraries.hiddenLibraryKeys;
+    if (!_sameClientList(jellyfinClients, _lastJellyfinClients) ||
+        !setEquals(hiddenLibraryKeys, _lastHiddenLibraryKeys)) {
+      _lastJellyfinClients = List.unmodifiable(jellyfinClients);
+      _lastHiddenLibraryKeys = Set.unmodifiable(hiddenLibraryKeys);
+      _jellyfinFavorites?.dispose();
+      _jellyfinFavorites = jellyfinClients.isEmpty
+          ? null
+          : JellyfinFavoritesCatalogSource(jellyfinClients, hiddenLibraryKeys: hiddenLibraryKeys);
+      changed = true;
+    }
+
     if (changed) safeNotifyListeners();
+  }
+
+  static bool _sameClientList(List<MediaServerClient> a, List<MediaServerClient> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (!identical(a[i], b[i])) return false;
+    }
+    return true;
   }
 
   @override
@@ -132,6 +173,10 @@ class CatalogSourcesProvider extends ChangeNotifier with DisposableChangeNotifie
     _mal = null;
     _seerr?.dispose();
     _seerr = null;
+    _jellyfinFavorites?.dispose();
+    _jellyfinFavorites = null;
+    _lastJellyfinClients = const [];
+    _lastHiddenLibraryKeys = const {};
     super.dispose();
   }
 }

--- a/lib/providers/catalog_sources_provider.dart
+++ b/lib/providers/catalog_sources_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 
 import '../media/ids.dart';
 import '../media/media_backend.dart';
+import '../media/media_item.dart';
 import '../media/media_server_client.dart';
 import '../mixins/disposable_change_notifier_mixin.dart';
 import '../models/catalog/catalog_item.dart';
@@ -71,6 +72,14 @@ class CatalogSourcesProvider extends ChangeNotifier with DisposableChangeNotifie
   /// surfaces that offer a choice (media-detail bookmark with several
   /// providers connected).
   List<CatalogSource> get watchlistCapableSources => [...connectedSources.where((source) => source.supportsWatchlist)];
+
+  /// Notify Explore that a Jellyfin item's server-side favorite membership
+  /// changed. Other backends either do not expose this flag or manage their
+  /// list through the normal catalog watchlist machinery.
+  void notifyServerFavoriteChanged(MediaItem item) {
+    if (item.backend != MediaBackend.jellyfin) return;
+    _jellyfinFavorites?.notifyFavoriteChanged();
+  }
 
   /// The watchlist source catalog-item surfaces (detail screen, card menu)
   /// must bind to: the item's OWN source — a MAL card toggles the MAL Plan to

--- a/lib/providers/discover_provider.dart
+++ b/lib/providers/discover_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../i18n/strings.g.dart';
 import '../media/ids.dart';
 import '../media/media_hub.dart';
 import '../media/media_item.dart';
@@ -23,12 +24,12 @@ import 'multi_server_provider.dart';
 
 enum DiscoverLoadState { initial, loading, loaded, error }
 
-/// Owns the Discover tab's data: the Continue Watching row and the home hub
-/// list, including the refresh policy that used to live in the screen —
-/// durable watch events refresh only Continue Watching (one on-deck call,
-/// zero hub refetches), playback progress patches the visible row in place,
+/// Owns the Discover tab's data: the Continue Watching row, the dedicated Next
+/// Up row, and the remaining home hubs. Durable watch events refresh both
+/// playback rows without refetching recommendation hubs, playback progress
+/// patches the visible Continue Watching row in place,
 /// deletions drop the item from every visible list in place and then refresh
-/// only Continue Watching, hidden-library changes trigger a full reload,
+/// both playback rows, hidden-library changes trigger a full reload,
 /// library-order changes re-sort hubs in place without refetching, and the
 /// platform launcher shelf syncs from every on-deck update.
 ///
@@ -41,6 +42,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   /// second request.
   static const int continueWatchingPreviewLimit = 20;
   static const int _continueWatchingProbeLimit = continueWatchingPreviewLimit + 1;
+  static const int nextUpPreviewLimit = defaultHubPreviewLimit;
+  static const String _nextUpHubId = 'home.nextup';
 
   DiscoverProvider(
     this._multiServer,
@@ -91,6 +94,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   StreamSubscription<DeletionEvent>? _deletionSubscription;
 
   List<MediaItem> _onDeck = [];
+  List<MediaItem> _nextUp = [];
+  List<MediaHub> _regularHubs = [];
   List<MediaHub> _hubs = [];
   bool _hasMoreContinueWatching = false;
   DiscoverLoadState _onDeckState = DiscoverLoadState.initial;
@@ -113,7 +118,11 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   /// Online servers whose home-hub fetch succeeded in the current hub list.
   Set<String> _loadedHubServerIds = {};
 
-  Set<String> get _fullyLoadedServerIds => _loadedOnDeckServerIds.intersection(_loadedHubServerIds);
+  /// Online servers whose dedicated Next Up fetch succeeded.
+  Set<String> _loadedNextUpServerIds = {};
+
+  Set<String> get _fullyLoadedServerIds =>
+      _loadedOnDeckServerIds.intersection(_loadedNextUpServerIds).intersection(_loadedHubServerIds);
 
   late final CoalescedLoadCoordinator<String> _loadCoordinator;
 
@@ -193,10 +202,14 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       final useGlobalHubs = settings.read(SettingsService.useGlobalHubs);
       final aggregation = _multiServer.aggregationService;
 
-      // On-deck and hubs fetch in parallel; on-deck is published as soon as
-      // it lands so the hero renders while hubs are still loading.
+      // Both playback shelves and the recommendation hubs fetch in parallel;
+      // on-deck is still published first so the hero can render immediately.
       final onDeckFuture = aggregation.getOnDeckFromAllServers(
         limit: _continueWatchingProbeLimit,
+        hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys,
+      );
+      final nextUpFuture = aggregation.getNextUpFromAllServers(
+        limit: nextUpPreviewLimit,
         hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys,
       );
       final hubsFuture = aggregation.getHubsFromAllServers(
@@ -232,32 +245,60 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
         _loadedOnDeckServerIds = fetchedOnDeck.succeededServerIds;
         _loadGeneration++;
         safeNotifyListeners();
-        unawaited(_syncSystemShelf(_onDeck));
+      }
+      unawaited(_syncSystemShelf(_onDeck));
+
+      Future<void> publishNextUp() async {
+        final fetchedNextUp = await nextUpFuture;
+        if (isDisposed) return;
+        _loadedNextUpServerIds = fetchedNextUp.succeededServerIds;
+        if (fetchedNextUp.succeededServerIds.isEmpty && _nextUp.isNotEmpty) {
+          appLogger.w('DiscoverProvider: next-up pass failed on all servers; keeping previous items');
+        } else if (fetchedNextUp.succeededServerIds.isEmpty &&
+            (fetchedNextUp.cancelledServerIds.isNotEmpty || isProfileBinding())) {
+          appLogger.d('DiscoverProvider: next-up pass disrupted with no prior content; keeping previous state');
+        } else {
+          _applyNextUp(fetchedNextUp.items);
+          _rebuildHubs();
+          safeNotifyListeners();
+        }
       }
 
-      final fetchedHubs = await hubsFuture;
-      if (isDisposed) return;
+      Future<void> publishRegularHubs() async {
+        final fetchedHubs = await hubsFuture;
+        if (isDisposed) return;
 
-      if (fetchedHubs.succeededServerIds.isEmpty && _hubs.isNotEmpty) {
-        appLogger.w('DiscoverProvider: hub pass failed on all servers; keeping previous hubs');
+        if (fetchedHubs.succeededServerIds.isEmpty && _regularHubs.isNotEmpty) {
+          appLogger.w('DiscoverProvider: hub pass failed on all servers; keeping previous hubs');
+          _hubsState = DiscoverLoadState.loaded;
+          _loadedHubServerIds = fetchedHubs.succeededServerIds;
+          safeNotifyListeners();
+          return;
+        }
+        if (fetchedHubs.succeededServerIds.isEmpty &&
+            (fetchedHubs.cancelledServerIds.isNotEmpty || isProfileBinding())) {
+          appLogger.d('DiscoverProvider: hub pass disrupted with no prior content; keeping loading state');
+          return;
+        }
+
+        final filteredHubs = _filterDiscoverHubs(fetchedHubs.hubs);
+        sortMediaHubsByLibraryOrder(filteredHubs, _libraries.libraries);
+
+        appLogger.d(
+          'DiscoverProvider: ${_onDeck.length} on-deck items, ${_nextUp.length} next-up items, '
+          '${filteredHubs.length} recommendation hubs',
+        );
+        _regularHubs = filteredHubs;
+        _rebuildHubs();
         _hubsState = DiscoverLoadState.loaded;
         _loadedHubServerIds = fetchedHubs.succeededServerIds;
         safeNotifyListeners();
-        return;
-      }
-      if (fetchedHubs.succeededServerIds.isEmpty && (fetchedHubs.cancelledServerIds.isNotEmpty || isProfileBinding())) {
-        appLogger.d('DiscoverProvider: hub pass disrupted with no prior content; keeping loading state');
-        return;
       }
 
-      final filteredHubs = _filterDiscoverHubs(fetchedHubs.hubs);
-      sortMediaHubsByLibraryOrder(filteredHubs, _libraries.libraries);
-
-      appLogger.d('DiscoverProvider: ${_onDeck.length} on-deck items, ${filteredHubs.length} hubs');
-      _hubs = filteredHubs;
-      _hubsState = DiscoverLoadState.loaded;
-      _loadedHubServerIds = fetchedHubs.succeededServerIds;
-      safeNotifyListeners();
+      // Recency enrichment for Jellyfin Next Up includes a separate item
+      // lookup. Publish regular hubs independently so that slow enrichment
+      // never holds an already-complete recommendation surface behind it.
+      await Future.wait([publishNextUp(), publishRegularHubs()]);
     } catch (e) {
       if (isDisposed) return;
       appLogger.e('Failed to load discover content', error: e);
@@ -268,8 +309,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     }
   }
 
-  /// Fetch Continue Watching + hubs from [serverIds] only (servers that came
-  /// online after the last full pass) and merge them into the loaded state.
+  /// Fetch both playback shelves + hubs from [serverIds] only (servers that
+  /// came online after the last full pass) and merge them into loaded state.
   /// Failures keep the loaded state and leave the ids un-loaded, so the next
   /// status emission retries them.
   Future<void> _loadDeltaOnce(Set<String> serverIds) async {
@@ -277,9 +318,13 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     // A full pass may have covered these ids while they sat in the queue.
     final ids = serverIds.difference(_fullyLoadedServerIds);
     final onDeckIds = ids.difference(_loadedOnDeckServerIds);
+    final nextUpIds = ids.difference(_loadedNextUpServerIds);
     final hubIds = ids.difference(_loadedHubServerIds);
-    if (onDeckIds.isEmpty && hubIds.isEmpty) return;
-    appLogger.d('DiscoverProvider: merging content from newly-online servers $ids (onDeck=$onDeckIds, hubs=$hubIds)');
+    if (onDeckIds.isEmpty && nextUpIds.isEmpty && hubIds.isEmpty) return;
+    appLogger.d(
+      'DiscoverProvider: merging content from newly-online servers $ids '
+      '(onDeck=$onDeckIds, nextUp=$nextUpIds, hubs=$hubIds)',
+    );
 
     try {
       await _hiddenLibraries.ensureInitialized();
@@ -297,6 +342,13 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
               hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys,
               serverIds: onDeckIds,
             );
+      final Future<NextUpAggregationResult?> nextUpFuture = nextUpIds.isEmpty
+          ? Future<NextUpAggregationResult?>.value()
+          : aggregation.getNextUpFromAllServers(
+              limit: nextUpPreviewLimit,
+              hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys,
+              serverIds: nextUpIds,
+            );
       final Future<HubAggregationResult?> hubsFuture = hubIds.isEmpty
           ? Future<HubAggregationResult?>.value()
           : aggregation.getHubsFromAllServers(
@@ -307,6 +359,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
             );
 
       final freshOnDeck = await onDeckFuture;
+      final freshNextUp = await nextUpFuture;
       final freshHubs = await hubsFuture;
       if (isDisposed) return;
 
@@ -327,18 +380,28 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
         // Watching refresh (the hero clamps instead of resetting).
       }
 
+      if (freshNextUp != null) {
+        _nextUp = await aggregation.mergeNextUp(_nextUp, freshNextUp.items, limit: nextUpPreviewLimit);
+        if (isDisposed) return;
+        _loadedNextUpServerIds = {..._loadedNextUpServerIds, ...freshNextUp.succeededServerIds};
+      }
+
       if (freshHubs != null) {
         final succeededHubIds = freshHubs.succeededServerIds;
         final mergedHubs = [
-          ..._hubs.where((hub) => hub.serverId == null || !succeededHubIds.contains(hub.serverId)),
+          ..._regularHubs.where((hub) => hub.serverId == null || !succeededHubIds.contains(hub.serverId)),
           ..._filterDiscoverHubs(freshHubs.hubs),
         ];
         sortMediaHubsByLibraryOrder(mergedHubs, _libraries.libraries);
-        _hubs = mergedHubs;
+        _regularHubs = mergedHubs;
         _loadedHubServerIds = {..._loadedHubServerIds, ...succeededHubIds};
       }
 
-      appLogger.d('DiscoverProvider: ${_onDeck.length} on-deck items, ${_hubs.length} hubs after merging $ids');
+      _rebuildHubs();
+      appLogger.d(
+        'DiscoverProvider: ${_onDeck.length} on-deck items, ${_nextUp.length} next-up items, '
+        '${_regularHubs.length} recommendation hubs after merging $ids',
+      );
       safeNotifyListeners();
       unawaited(_syncSystemShelf(_onDeck));
     } catch (e) {
@@ -362,7 +425,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     }).toList();
   }
 
-  /// Background refresh of Continue Watching only. Concurrent events coalesce
+  /// Background refresh of both playback shelves. Concurrent events coalesce
   /// into the active request plus at most one trailing fresh request.
   Future<void> refreshContinueWatching() {
     final active = _continueWatchingRefreshFuture;
@@ -392,10 +455,17 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       if (!_multiServer.hasConnectedServers) return;
       final revision = _contentRevision;
       final hiddenKeys = Set<String>.of(_hiddenLibraries.hiddenLibraryKeys);
-      final fetched = await _multiServer.aggregationService.getOnDeckFromAllServers(
+      final aggregation = _multiServer.aggregationService;
+      final onDeckFuture = aggregation.getOnDeckFromAllServers(
         limit: _continueWatchingProbeLimit,
         hiddenLibraryKeys: hiddenKeys,
       );
+      final nextUpFuture = aggregation.getNextUpFromAllServers(
+        limit: nextUpPreviewLimit,
+        hiddenLibraryKeys: hiddenKeys,
+      );
+      final fetched = await onDeckFuture;
+      final fetchedNextUp = await nextUpFuture;
       if (isDisposed) return;
       if (revision != _contentRevision) {
         _continueWatchingRefreshQueued = true;
@@ -403,10 +473,17 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       }
       _applyOnDeck(fetched.items);
       _loadedOnDeckServerIds = fetched.succeededServerIds;
+      _loadedNextUpServerIds = fetchedNextUp.succeededServerIds;
+      if (fetchedNextUp.succeededServerIds.isNotEmpty || _nextUp.isEmpty) {
+        _applyNextUp(fetchedNextUp.items);
+      } else {
+        appLogger.w('DiscoverProvider: next-up refresh failed on all servers; keeping previous items');
+      }
+      _rebuildHubs();
       safeNotifyListeners();
       unawaited(_syncSystemShelf(_onDeck));
     } catch (e) {
-      appLogger.w('Failed to refresh Continue Watching', error: e);
+      appLogger.w('Failed to refresh playback shelves', error: e);
     }
   }
 
@@ -444,15 +521,21 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       _onDeck = List.of(_onDeck)..[onDeckIndex] = updatedItem;
     }
 
-    for (var i = 0; i < _hubs.length; i++) {
-      final hub = _hubs[i];
+    final nextUpIndex = _nextUp.indexWhere((item) => item.globalKey == sourceGlobalKey);
+    if (nextUpIndex != -1) {
+      _nextUp = List.of(_nextUp)..[nextUpIndex] = updatedItem;
+    }
+
+    for (var i = 0; i < _regularHubs.length; i++) {
+      final hub = _regularHubs[i];
       final itemIndex = hub.items.indexWhere((item) => item.globalKey == sourceGlobalKey);
       if (itemIndex != -1) {
         final newItems = List<MediaItem>.from(hub.items);
         newItems[itemIndex] = updatedItem;
-        _hubs = List.of(_hubs)..[i] = hub.copyWith(items: newItems);
+        _regularHubs = List.of(_regularHubs)..[i] = hub.copyWith(items: newItems);
       }
     }
+    _rebuildHubs();
   }
 
   void _applyOnDeck(List<MediaItem> fetched) {
@@ -461,13 +544,32 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     _hasMoreContinueWatching = hasMore;
   }
 
+  void _applyNextUp(List<MediaItem> fetched) {
+    _nextUp = fetched.length > nextUpPreviewLimit ? fetched.take(nextUpPreviewLimit).toList() : fetched;
+  }
+
+  void _rebuildHubs() {
+    _hubs = [
+      if (_nextUp.isNotEmpty)
+        MediaHub(
+          id: _nextUpHubId,
+          identifier: _nextUpHubId,
+          title: t.discover.nextUp,
+          type: 'episode',
+          items: _nextUp,
+          size: _nextUp.length,
+        ),
+      ..._regularHubs,
+    ];
+  }
+
   // --- Event reactions -----------------------------------------------------
 
-  /// Watch on-deck items and their parent shows/seasons (an episode's watch
-  /// flip changes what Continue Watching should show for its series).
+  /// Watch both playback rows and their parent shows/seasons: an episode's
+  /// durable watch flip can change Continue Watching and Next Up together.
   Set<String>? get _watchedIds {
     final keys = <String>{};
-    for (final item in _onDeck) {
+    for (final item in [..._onDeck, ..._nextUp]) {
       keys.add(item.id);
       if (item.parentId != null) keys.add(item.parentId!);
       if (item.grandparentId != null) keys.add(item.grandparentId!);
@@ -477,7 +579,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
 
   Set<String>? get _watchedGlobalKeys {
     final keys = <String>{};
-    for (final item in _onDeck) {
+    for (final item in [..._onDeck, ..._nextUp]) {
       final serverId = item.serverId;
       if (serverId == null) return null;
 
@@ -510,9 +612,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     unawaited(refreshContinueWatching());
   }
 
-  /// Deletions can affect any visible list, so the filter covers on-deck and
-  /// hub items plus their parents (a deleted season/show takes its visible
-  /// episodes with it).
+  /// Deletions can affect any visible list, so the filter covers both playback
+  /// rows and recommendation hubs plus their parents.
   Set<String>? get _deletionIds {
     final keys = <String>{};
     void addItem(MediaItem item) {
@@ -522,7 +623,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     }
 
     _onDeck.forEach(addItem);
-    for (final hub in _hubs) {
+    _nextUp.forEach(addItem);
+    for (final hub in _regularHubs) {
       hub.items.forEach(addItem);
     }
     return keys;
@@ -543,7 +645,10 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     for (final item in _onDeck) {
       if (!addItem(item)) return null;
     }
-    for (final hub in _hubs) {
+    for (final item in _nextUp) {
+      if (!addItem(item)) return null;
+    }
+    for (final hub in _regularHubs) {
       for (final item in hub.items) {
         if (!addItem(item)) return null;
       }
@@ -552,8 +657,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   }
 
   void _onDeletion(DeletionEvent event) {
-    // On-deck and hubs are server-backed: a download-only deletion leaves the
-    // server item in place, so it must not evict anything here.
+    // Home rows are server-backed: a download-only deletion leaves the server
+    // item in place, so it must not evict anything here.
     if (event.isDownloadOnly) return;
 
     bool affected(MediaItem item) =>
@@ -565,15 +670,23 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       _onDeck = remainingOnDeck;
       changed = true;
     }
-    for (var i = 0; i < _hubs.length; i++) {
-      final hub = _hubs[i];
+    final remainingNextUp = _nextUp.where((item) => !affected(item)).toList();
+    if (remainingNextUp.length != _nextUp.length) {
+      _nextUp = remainingNextUp;
+      changed = true;
+    }
+    for (var i = 0; i < _regularHubs.length; i++) {
+      final hub = _regularHubs[i];
       final newItems = hub.items.where((item) => !affected(item)).toList();
       if (newItems.length != hub.items.length) {
-        _hubs = List.of(_hubs)..[i] = hub.copyWith(items: newItems);
+        _regularHubs = List.of(_regularHubs)..[i] = hub.copyWith(items: newItems);
         changed = true;
       }
     }
-    if (changed) safeNotifyListeners();
+    if (changed) {
+      _rebuildHubs();
+      safeNotifyListeners();
+    }
     unawaited(refreshContinueWatching());
   }
 
@@ -590,11 +703,12 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     final currentKeys = _libraryOrderKeys();
     if (listEquals(currentKeys, _lastSeenLibraryOrderKeys)) return;
     _lastSeenLibraryOrderKeys = currentKeys;
-    if (_hubs.isEmpty) return;
+    if (_regularHubs.isEmpty) return;
 
-    final sortedHubs = List<MediaHub>.from(_hubs);
+    final sortedHubs = List<MediaHub>.from(_regularHubs);
     if (!sortMediaHubsByLibraryOrder(sortedHubs, _libraries.libraries)) return;
-    _hubs = sortedHubs;
+    _regularHubs = sortedHubs;
+    _rebuildHubs();
     safeNotifyListeners();
   }
 
@@ -603,11 +717,10 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   // --- Platform launcher shelf ----------------------------------------------
 
   /// Sync Continue Watching to the platform launcher shelf. Rapid updates
-  /// coalesce: a sync that arrives while one is in flight queues exactly one
-  /// follow-up pass with the latest items.
-  Future<void> _syncSystemShelf(List<MediaItem> onDeck) async {
+  /// coalesce into at most one follow-up pass with the latest items.
+  Future<void> _syncSystemShelf(List<MediaItem> items) async {
     if (isDisposed) return;
-    _pendingSystemShelfItems = List<MediaItem>.unmodifiable(onDeck);
+    _pendingSystemShelfItems = List<MediaItem>.unmodifiable(items);
     if (_systemShelfSyncFuture != null) {
       await _systemShelfSyncFuture;
       return;

--- a/lib/providers/explore_provider.dart
+++ b/lib/providers/explore_provider.dart
@@ -22,8 +22,8 @@ typedef ExploreRowHub = ({CatalogRowId row, MediaHub hub});
 ///
 /// Lives inside the profile-keyed provider subtree. Listens to
 /// [CatalogSourcesProvider] for the active source (connect/disconnect/switch)
-/// and to the source's watchlist changes so the Watchlist row stays current
-/// after mutations from anywhere in the app.
+/// and to the source's mutable-row changes so Watchlist or Jellyfin Favorites
+/// stays current after mutations from anywhere in the app.
 class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin {
   /// Rows reload when the tab is shown after this long.
   static const Duration staleAfter = Duration(minutes: 15);
@@ -31,14 +31,14 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
   static const int viewAllPageLimit = 100;
   static const int viewAllMaxPages = 3;
 
-  /// Watchlist mutations notify optimistically before the API call finishes;
-  /// the row refetch waits out the burst so it reads settled server state.
-  static const Duration _watchlistRefreshDelay = Duration(seconds: 1);
+  /// Membership mutations can notify optimistically before the API call
+  /// finishes; the row refetch waits out the burst so it reads settled state.
+  static const Duration _membershipRefreshDelay = Duration(seconds: 1);
 
   ExploreProvider(this._catalogSources) {
     _catalogSources.addListener(_onSourcesChanged);
     _source = _catalogSources.activeSource;
-    _source?.watchlistChanges.addListener(_onWatchlistChanged);
+    _addMembershipListener(_source);
   }
 
   final CatalogSourcesProvider _catalogSources;
@@ -50,15 +50,15 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
   DateTime? _loadedAt;
   final FutureCoalescer<void> _loadCoalescer = FutureCoalescer();
   int _generation = 0;
-  Timer? _watchlistRefreshTimer;
+  Timer? _membershipRefreshTimer;
 
-  // Watchlist-row freshness: every membership change bumps the mutation
-  // epoch; a successful row refetch records which epoch it covered. A tab
-  // re-shown with uncovered mutations refetches immediately — the debounced
-  // timer alone can lose the race when the user navigates back quickly.
-  int _watchlistMutationEpoch = 0;
-  int _watchlistRowFetchedEpoch = 0;
-  final FutureCoalescer<void> _watchlistRefreshCoalescer = FutureCoalescer();
+  // Mutable-row freshness: every membership change bumps the mutation epoch;
+  // a successful row refetch records which epoch it covered. A tab re-shown
+  // with uncovered mutations refetches immediately — the debounced timer
+  // alone can lose the race when the user navigates back quickly.
+  int _membershipMutationEpoch = 0;
+  int _membershipRowFetchedEpoch = 0;
+  final FutureCoalescer<void> _membershipRefreshCoalescer = FutureCoalescer();
 
   List<ExploreRowHub>? _hubsCache;
   (int, String)? _hubsCacheKey;
@@ -132,8 +132,8 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
       unawaited(load());
       return;
     }
-    if (_watchlistRowFetchedEpoch < _watchlistMutationEpoch) {
-      unawaited(_refreshWatchlistRow());
+    if (_membershipRowFetchedEpoch < _membershipMutationEpoch) {
+      unawaited(_refreshMembershipRow());
     }
   }
 
@@ -150,7 +150,8 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     final source = _source;
     if (source == null) return;
     final generation = _generation;
-    final mutationEpochAtStart = _watchlistMutationEpoch;
+    final mutableRow = _mutableRowFor(source);
+    final mutationEpochAtStart = _membershipMutationEpoch;
 
     _state = ExploreLoadState.loading;
     _errorMessage = null;
@@ -172,10 +173,10 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
       for (var i = 0; i < rows.length; i++)
         if (results[i] case final ExploreMediaPage page) rows[i]: page,
     };
-    // A debounced watchlist-row refresh that landed while this load was in
+    // A debounced mutable-row refresh that landed while this load was in
     // flight covered later mutations than our page — keep the fresher one.
-    if (_watchlistRowFetchedEpoch > mutationEpochAtStart) {
-      fetched.remove(CatalogRowId.watchlist);
+    if (mutableRow != null && _membershipRowFetchedEpoch > mutationEpochAtStart) {
+      fetched.remove(mutableRow);
     }
 
     if (fetched.isEmpty) {
@@ -194,15 +195,21 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
       _state = ExploreLoadState.loaded;
       _loadedAt = DateTime.now();
       _rowsEpoch++;
-      if (fetched.containsKey(CatalogRowId.watchlist) && mutationEpochAtStart > _watchlistRowFetchedEpoch) {
-        _watchlistRowFetchedEpoch = mutationEpochAtStart;
+      if (mutableRow != null && fetched.containsKey(mutableRow) && mutationEpochAtStart > _membershipRowFetchedEpoch) {
+        _membershipRowFetchedEpoch = mutationEpochAtStart;
       }
     }
     // Mutations that landed while the load was in flight aren't reflected in
     // the page we just stored — schedule the debounced catch-up ourselves
     // (the mutation-time notification skips rows that aren't loaded yet).
-    if (_rows.containsKey(CatalogRowId.watchlist) && _watchlistRowFetchedEpoch < _watchlistMutationEpoch) {
-      _scheduleWatchlistRefresh();
+    if (mutableRow != null && _rows.containsKey(mutableRow)) {
+      if (_membershipRowFetchedEpoch < _membershipMutationEpoch) {
+        _scheduleMembershipRefresh();
+      } else {
+        // The full load covered the pending membership mutation, so the
+        // existing debounce would only fetch the same row a second time.
+        _membershipRefreshTimer?.cancel();
+      }
     }
     safeNotifyListeners();
   }
@@ -229,18 +236,18 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
   void _onSourcesChanged() {
     final next = _catalogSources.activeSource;
     if (identical(next, _source)) return;
-    _source?.watchlistChanges.removeListener(_onWatchlistChanged);
+    _removeMembershipListener(_source);
     _source = next;
-    _source?.watchlistChanges.addListener(_onWatchlistChanged);
+    _addMembershipListener(_source);
     _generation++;
-    _watchlistRefreshTimer?.cancel();
+    _membershipRefreshTimer?.cancel();
     // Detach any in-flight passes for the old source: their generation guard
     // already discards their results, but the new source's load must not
     // coalesce into them (that left the tab stuck on the loading state).
     _loadCoalescer.reset();
-    _watchlistRefreshCoalescer.reset();
-    _watchlistMutationEpoch = 0;
-    _watchlistRowFetchedEpoch = 0;
+    _membershipRefreshCoalescer.reset();
+    _membershipMutationEpoch = 0;
+    _membershipRowFetchedEpoch = 0;
     _rows = {};
     _loadedAt = null;
     _errorMessage = null;
@@ -250,52 +257,85 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     if (next != null) unawaited(load());
   }
 
-  void _onWatchlistChanged() {
+  CatalogRowId? _mutableRowFor(CatalogSource source) {
+    if (source case final MutableCatalogRowSource mutableSource) {
+      return mutableSource.mutableRow;
+    }
+    if (source.supportsWatchlist && source.supportedRows.contains(CatalogRowId.watchlist)) {
+      return CatalogRowId.watchlist;
+    }
+    return null;
+  }
+
+  Listenable _membershipChangesFor(CatalogSource source) {
+    if (source case final MutableCatalogRowSource mutableSource) {
+      return mutableSource.mutableRowChanges;
+    }
+    return source.watchlistChanges;
+  }
+
+  void _addMembershipListener(CatalogSource? source) {
+    if (source == null) return;
+    _membershipChangesFor(source).addListener(_onMembershipChanged);
+  }
+
+  void _removeMembershipListener(CatalogSource? source) {
+    if (source == null) return;
+    _membershipChangesFor(source).removeListener(_onMembershipChanged);
+  }
+
+  void _onMembershipChanged() {
+    final source = _source;
+    if (source == null) return;
+    final mutableRow = _mutableRowFor(source);
+    if (mutableRow == null) return;
     // Always bump: a mutation during the initial full load has no row to
     // patch yet, but the load's completion checks this epoch to catch up.
-    _watchlistMutationEpoch++;
-    if (!_rows.containsKey(CatalogRowId.watchlist)) return;
-    _scheduleWatchlistRefresh();
+    _membershipMutationEpoch++;
+    if (!_rows.containsKey(mutableRow)) return;
+    _scheduleMembershipRefresh();
   }
 
-  void _scheduleWatchlistRefresh() {
-    _watchlistRefreshTimer?.cancel();
-    _watchlistRefreshTimer = Timer(_watchlistRefreshDelay, () => unawaited(_refreshWatchlistRow()));
+  void _scheduleMembershipRefresh() {
+    _membershipRefreshTimer?.cancel();
+    _membershipRefreshTimer = Timer(_membershipRefreshDelay, () => unawaited(_refreshMembershipRow()));
   }
 
-  Future<void> _refreshWatchlistRow() => _watchlistRefreshCoalescer.run(_refreshWatchlistRowOnce);
+  Future<void> _refreshMembershipRow() => _membershipRefreshCoalescer.run(_refreshMembershipRowOnce);
 
-  Future<void> _refreshWatchlistRowOnce() async {
+  Future<void> _refreshMembershipRowOnce() async {
     final source = _source;
     if (source == null || isDisposed) return;
+    final mutableRow = _mutableRowFor(source);
+    if (mutableRow == null) return;
     final generation = _generation;
-    final coveredEpoch = _watchlistMutationEpoch;
+    final coveredEpoch = _membershipMutationEpoch;
     try {
-      final page = await source.fetchExploreRow(CatalogRowId.watchlist, limit: rowLimit);
+      final page = await source.fetchExploreRow(mutableRow, limit: rowLimit);
       if (isDisposed || generation != _generation) return;
-      _rows = {..._rows, CatalogRowId.watchlist: page};
+      _rows = {..._rows, mutableRow: page};
       _rowsEpoch++;
-      _watchlistRowFetchedEpoch = coveredEpoch;
+      _membershipRowFetchedEpoch = coveredEpoch;
       safeNotifyListeners();
-      if (_watchlistMutationEpoch > coveredEpoch) {
+      if (_membershipMutationEpoch > coveredEpoch) {
         // Mutations that arrived while this pass was in flight coalesced
         // into it but aren't reflected in its page — go around once more.
-        _scheduleWatchlistRefresh();
+        _scheduleMembershipRefresh();
       } else {
         // Fully caught up: a still-pending debounce would only refetch the
         // same state.
-        _watchlistRefreshTimer?.cancel();
+        _membershipRefreshTimer?.cancel();
       }
     } catch (e) {
-      appLogger.w('Explore: watchlist row refresh failed', error: e);
+      appLogger.w('Explore: ${mutableRow.name} row refresh failed', error: e);
     }
   }
 
   @override
   void dispose() {
     _catalogSources.removeListener(_onSourcesChanged);
-    _source?.watchlistChanges.removeListener(_onWatchlistChanged);
-    _watchlistRefreshTimer?.cancel();
+    _removeMembershipListener(_source);
+    _membershipRefreshTimer?.cancel();
     super.dispose();
   }
 }

--- a/lib/providers/explore_provider.dart
+++ b/lib/providers/explore_provider.dart
@@ -44,7 +44,7 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
   final CatalogSourcesProvider _catalogSources;
   CatalogSource? _source;
 
-  Map<CatalogRowId, CatalogPage> _rows = {};
+  Map<CatalogRowId, ExploreMediaPage> _rows = {};
   ExploreLoadState _state = ExploreLoadState.initial;
   String? _errorMessage;
   DateTime? _loadedAt;
@@ -82,7 +82,7 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     if (_hubsCache != null && key == _hubsCacheKey) return _hubsCache!;
     final hubs = <ExploreRowHub>[
       for (final row in source.supportedRows)
-        if (_rows[row] case final CatalogPage page)
+        if (_rows[row] case final ExploreMediaPage page)
           if (page.items.isNotEmpty)
             (
               row: row,
@@ -91,7 +91,7 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
                 identifier: 'explore.${row.name}',
                 title: rowTitle(row),
                 type: 'mixed',
-                items: [for (final item in page.items) item.toMediaItem()],
+                items: page.items,
                 size: page.items.length,
                 more: page.hasMore,
               ),
@@ -103,6 +103,7 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
   }
 
   static String rowTitle(CatalogRowId row) => switch (row) {
+    CatalogRowId.favorites => t.libraries.filterCategories.favorites,
     CatalogRowId.watchlist => t.explore.rows.watchlist,
     CatalogRowId.recommendedMovies => t.explore.rows.recommendedMovies,
     CatalogRowId.recommendedShows => t.explore.rows.recommendedShows,
@@ -159,7 +160,7 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     Object? firstError;
     final results = await Future.wait([
       for (final row in rows)
-        source.fetchRow(row, limit: rowLimit).then<CatalogPage?>((page) => page).catchError((Object e) {
+        source.fetchExploreRow(row, limit: rowLimit).then<ExploreMediaPage?>((page) => page).catchError((Object e) {
           appLogger.w('Explore: ${source.id.name} row ${row.name} failed', error: e);
           firstError ??= e;
           return null;
@@ -167,9 +168,9 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     ]);
     if (isDisposed || generation != _generation) return;
 
-    final fetched = <CatalogRowId, CatalogPage>{
+    final fetched = <CatalogRowId, ExploreMediaPage>{
       for (var i = 0; i < rows.length; i++)
-        if (results[i] case final CatalogPage page) rows[i]: page,
+        if (results[i] case final ExploreMediaPage page) rows[i]: page,
     };
     // A debounced watchlist-row refresh that landed while this load was in
     // flight covered later mutations than our page — keep the fresher one.
@@ -213,8 +214,8 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     final items = <MediaItem>[];
     var page = 1;
     while (true) {
-      final res = await source.fetchRow(row, page: page, limit: viewAllPageLimit);
-      items.addAll([for (final item in res.items) item.toMediaItem()]);
+      final res = await source.fetchExploreRow(row, page: page, limit: viewAllPageLimit);
+      items.addAll(res.items);
       if (!res.hasMore) break;
       if (page >= viewAllMaxPages) {
         appLogger.w('Explore: ${row.name} View All truncated at ${items.length} items ($page pages)');
@@ -270,7 +271,7 @@ class ExploreProvider extends ChangeNotifier with DisposableChangeNotifierMixin 
     final generation = _generation;
     final coveredEpoch = _watchlistMutationEpoch;
     try {
-      final page = await source.fetchRow(CatalogRowId.watchlist, limit: rowLimit);
+      final page = await source.fetchExploreRow(CatalogRowId.watchlist, limit: rowLimit);
       if (isDisposed || generation != _generation) return;
       _rows = {..._rows, CatalogRowId.watchlist: page};
       _rowsEpoch++;

--- a/lib/providers/watch_state_store.dart
+++ b/lib/providers/watch_state_store.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import '../media/media_item.dart';
 import '../mixins/disposable_change_notifier_mixin.dart';
 import '../services/watch_state_resolver.dart';
+import '../utils/favorite_state_notifier.dart';
 import '../utils/global_key_utils.dart';
 import '../utils/watch_state_notifier.dart';
 
@@ -83,6 +84,16 @@ class _WatchStatePatchEntry {
   int get hashCode => Object.hash(patch, updatedAt, sequence, isSessionEvent);
 }
 
+class _FavoritePatchEntry {
+  final bool isFavorite;
+  final int sequence;
+  final DateTime expiresAt;
+
+  const _FavoritePatchEntry(this.isFavorite, this.sequence, this.expiresAt);
+
+  bool isExpiredAt(DateTime now) => !now.isBefore(expiresAt);
+}
+
 /// The single session-local layer for watch-state freshness.
 ///
 /// Server fetches remain the source of truth; [MediaItem] snapshots are never
@@ -93,13 +104,22 @@ class _WatchStatePatchEntry {
 /// marking a show/season reaches every descendant, while a later per-item
 /// event still overrides an older container mark.
 class WatchStateStore extends ChangeNotifier with DisposableChangeNotifierMixin {
-  WatchStateStore() {
+  WatchStateStore({this.favoritePatchLifetime = const Duration(seconds: 30), DateTime Function()? favoriteClock})
+    : _favoriteClock = favoriteClock ?? DateTime.now {
     _subscription = WatchStateNotifier().stream.listen(_onWatchStateEvent);
+    _favoriteSubscription = FavoriteStateNotifier().stream.listen(_onFavoriteStateEvent);
   }
 
+  final Duration favoritePatchLifetime;
+  final DateTime Function() _favoriteClock;
   StreamSubscription<WatchStateEvent>? _subscription;
+  StreamSubscription<FavoriteStateEvent>? _favoriteSubscription;
   final Map<String, _WatchStatePatchEntry> _patches = {};
   final Map<String, _WatchStatePatchEntry> _hydratedPatches = {};
+  final Map<String, _FavoritePatchEntry> _favoritePatches = {};
+  final Set<String> _favoriteReconciliations = {};
+  Timer? _favoriteExpiryTimer;
+  DateTime? _favoriteExpiryAt;
   String? _activeProfileId;
   Map<String, String?> _activeClientScopesByServer = const {};
   int _sequence = 0;
@@ -129,6 +149,43 @@ class WatchStateStore extends ChangeNotifier with DisposableChangeNotifierMixin 
 
   WatchStatePatch? patchForGlobalKey(String globalKey) => _entryFor(globalKey)?.patch;
 
+  ({String key, _FavoritePatchEntry? entry}) _favoriteEntryForGlobalKey(String globalKey) {
+    _scheduleFavoriteExpiryNotification();
+    final now = _favoriteClock();
+    final parsed = parseGlobalKey(globalKey);
+    if (parsed != null) {
+      final scoped = _activeClientScopesByServer[parsed.serverId];
+      if (scoped != null && scoped.isNotEmpty) {
+        final key = buildGlobalKey(ServerId(scoped), parsed.ratingKey);
+        final entry = _favoritePatches[key];
+        if (entry?.isExpiredAt(now) ?? false) {
+          _scheduleFavoriteReconciliation(key, entry!.sequence);
+          return (key: key, entry: null);
+        }
+        return (key: key, entry: entry);
+      }
+    }
+    final entry = _favoritePatches[globalKey];
+    if (entry?.isExpiredAt(now) ?? false) {
+      _scheduleFavoriteReconciliation(globalKey, entry!.sequence);
+      return (key: globalKey, entry: null);
+    }
+    return (key: globalKey, entry: entry);
+  }
+
+  bool? favoriteForGlobalKey(String globalKey) => _favoriteEntryForGlobalKey(globalKey).entry?.isFavorite;
+
+  bool? favoriteForItem(MediaItem item) {
+    final resolved = _favoriteEntryForGlobalKey(item.globalKey);
+    final entry = resolved.entry;
+    if (entry == null) return null;
+    if (item.isFavorite == entry.isFavorite) {
+      _scheduleFavoriteReconciliation(resolved.key, entry.sequence);
+      return null;
+    }
+    return entry.isFavorite;
+  }
+
   WatchStatePatch? patchForItem(MediaItem item) {
     var best = _entryFor(item.globalKey);
     if (item.parentChain.isNotEmpty) {
@@ -143,29 +200,32 @@ class WatchStateStore extends ChangeNotifier with DisposableChangeNotifierMixin 
   }
 
   MediaItem apply(MediaItem item) {
-    return applyPatch(item, patchForItem(item));
+    return applyPatch(item, patchForItem(item), isFavorite: favoriteForItem(item));
   }
 
   List<MediaItem> applyAll(List<MediaItem> items) {
-    if (_patches.isEmpty && _hydratedPatches.isEmpty) return items;
+    if (_patches.isEmpty && _hydratedPatches.isEmpty && _favoritePatches.isEmpty) return items;
     return [for (final item in items) apply(item)];
   }
 
-  static MediaItem applyPatch(MediaItem item, WatchStatePatch? patch) {
-    if (patch == null) return item;
-    return WatchStateSnapshot(
-      isWatched: patch.isWatched,
-      hasViewOffsetMs: patch.hasViewOffsetMs,
-      viewOffsetMs: patch.viewOffsetMs,
-    ).apply(item);
+  static MediaItem applyPatch(MediaItem item, WatchStatePatch? patch, {bool? isFavorite}) {
+    final watchStateItem = patch == null
+        ? item
+        : WatchStateSnapshot(
+            isWatched: patch.isWatched,
+            hasViewOffsetMs: patch.hasViewOffsetMs,
+            viewOffsetMs: patch.viewOffsetMs,
+          ).apply(item);
+    return isFavorite == null ? watchStateItem : watchStateItem.copyWith(isFavorite: isFavorite);
   }
 
   void setActiveProfileId(String? profileId) {
     if (_activeProfileId == profileId) return;
     _activeProfileId = profileId;
-    if (_patches.isEmpty && _hydratedPatches.isEmpty) return;
+    if (_patches.isEmpty && _hydratedPatches.isEmpty && _favoritePatches.isEmpty) return;
     _patches.clear();
     _hydratedPatches.clear();
+    _clearFavoritePatches();
     safeNotifyListeners();
   }
 
@@ -176,7 +236,7 @@ class WatchStateStore extends ChangeNotifier with DisposableChangeNotifierMixin 
     };
     if (mapEquals(_activeClientScopesByServer, normalized)) return;
     _activeClientScopesByServer = Map.unmodifiable(normalized);
-    if (_patches.isNotEmpty || _hydratedPatches.isNotEmpty) safeNotifyListeners();
+    if (_patches.isNotEmpty || _hydratedPatches.isNotEmpty || _favoritePatches.isNotEmpty) safeNotifyListeners();
   }
 
   /// Replace the persisted local-action layer without disturbing newer
@@ -220,10 +280,100 @@ class WatchStateStore extends ChangeNotifier with DisposableChangeNotifierMixin 
     safeNotifyListeners();
   }
 
+  void _onFavoriteStateEvent(FavoriteStateEvent event) {
+    final key = event.stateKey;
+    final sequence = ++_sequence;
+    _favoritePatches[key] = _FavoritePatchEntry(
+      event.isFavorite,
+      sequence,
+      _favoriteClock().add(favoritePatchLifetime),
+    );
+    _favoriteReconciliations.remove(key);
+    // Consuming listeners re-run a favorite lookup below, which arms the
+    // shared expiry timer. Relay-only listeners should not retain a timer for
+    // state they never read (notably the download metadata bridge).
+    safeNotifyListeners();
+  }
+
+  void _scheduleFavoriteReconciliation(String key, int sequence) {
+    if (!_favoriteReconciliations.add(key)) return;
+    scheduleMicrotask(() {
+      _favoriteReconciliations.remove(key);
+      if (isDisposed || _favoritePatches[key]?.sequence != sequence) return;
+      _favoritePatches.remove(key);
+      _scheduleFavoriteExpiryNotification();
+      safeNotifyListeners();
+    });
+  }
+
+  void _scheduleFavoriteExpiryNotification() {
+    if (isDisposed || !hasListeners || _favoritePatches.isEmpty) {
+      _cancelFavoriteExpiryTimer();
+      return;
+    }
+
+    DateTime? earliest;
+    for (final entry in _favoritePatches.values) {
+      if (earliest == null || entry.expiresAt.isBefore(earliest)) earliest = entry.expiresAt;
+    }
+    if (earliest == null) {
+      _cancelFavoriteExpiryTimer();
+      return;
+    }
+    if (_favoriteExpiryTimer?.isActive == true && _favoriteExpiryAt == earliest) return;
+
+    _favoriteExpiryTimer?.cancel();
+    _favoriteExpiryAt = earliest;
+    final remaining = earliest.difference(_favoriteClock());
+    _favoriteExpiryTimer = Timer(remaining.isNegative ? Duration.zero : remaining, () {
+      if (isDisposed || _favoriteExpiryAt != earliest) return;
+      _favoriteExpiryTimer = null;
+      _favoriteExpiryAt = null;
+      final now = _favoriteClock();
+      final expiredKeys = [
+        for (final entry in _favoritePatches.entries)
+          if (entry.value.isExpiredAt(now)) entry.key,
+      ];
+      for (final key in expiredKeys) {
+        _favoritePatches.remove(key);
+        _favoriteReconciliations.remove(key);
+      }
+      if (expiredKeys.isNotEmpty) safeNotifyListeners();
+      _scheduleFavoriteExpiryNotification();
+    });
+  }
+
+  void _cancelFavoriteExpiryTimer() {
+    _favoriteExpiryTimer?.cancel();
+    _favoriteExpiryTimer = null;
+    _favoriteExpiryAt = null;
+  }
+
+  void _clearFavoritePatches() {
+    _cancelFavoriteExpiryTimer();
+    _favoriteReconciliations.clear();
+    _favoritePatches.clear();
+  }
+
+  @override
+  void addListener(VoidCallback listener) {
+    super.addListener(listener);
+    _scheduleFavoriteExpiryNotification();
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    super.removeListener(listener);
+    if (!hasListeners) _cancelFavoriteExpiryTimer();
+  }
+
   @override
   void dispose() {
     _subscription?.cancel();
     _subscription = null;
+    _favoriteSubscription?.cancel();
+    _favoriteSubscription = null;
+    _clearFavoritePatches();
     super.dispose();
   }
 }
@@ -236,8 +386,10 @@ extension WatchStateResolution on BuildContext {
   /// ancestor). Use in `build`.
   MediaItem withFreshWatchState(MediaItem item) {
     try {
-      final patch = select<WatchStateStore, WatchStatePatch?>((store) => store.patchForItem(item));
-      return WatchStateStore.applyPatch(item, patch);
+      final state = select<WatchStateStore, (WatchStatePatch?, bool?)>(
+        (store) => (store.patchForItem(item), store.favoriteForItem(item)),
+      );
+      return WatchStateStore.applyPatch(item, state.$1, isFavorite: state.$2);
     } on ProviderNotFoundException {
       return item;
     }

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -128,6 +128,7 @@ class ExploreScreenState extends State<ExploreScreen>
   }
 
   static IconData _rowIcon(CatalogRowId row) => switch (row) {
+    CatalogRowId.favorites => Symbols.favorite_rounded,
     CatalogRowId.watchlist => Symbols.bookmark_rounded,
     CatalogRowId.recommendedMovies ||
     CatalogRowId.recommendedShows ||
@@ -241,7 +242,7 @@ class ExploreScreenState extends State<ExploreScreen>
           key: _actionBarKey,
           onNavigateDown: () => _orderedHubKeys.firstOrNull?.currentState?.requestFocusFromMemory(),
           actions: [
-            if (sources.activeSource case final CatalogSource source)
+            if (sources.activeSource case final CatalogSource source when source.supportsExploreSearch)
               FocusableAction(
                 icon: Symbols.search_rounded,
                 tooltip: t.common.search,
@@ -301,6 +302,7 @@ class ExploreScreenState extends State<ExploreScreen>
                 key: _orderedHubKeys[i],
                 hub: rowHubs[i].hub,
                 icon: _rowIcon(rowHubs[i].row),
+                onRefresh: explore.activeSource is MediaItemCatalogSource ? (_) => unawaited(_explore.load()) : null,
                 loadMoreItems: rowHubs[i].hub.more ? () => _explore.loadAllForRow(rowHubs[i].row) : null,
                 onVerticalNavigation: (isUp) => _handleVerticalNavigation(i, isUp),
                 onNavigateUp: i == 0 ? () => _actionBarKey.currentState?.requestFocusOnFirst() : null,
@@ -369,7 +371,7 @@ class ExploreScreenState extends State<ExploreScreen>
                       parentOwnsFocus: true,
                     ),
                   ),
-                if (active != null)
+                if (active != null && active.supportsExploreSearch)
                   FocusableAction(
                     icon: Symbols.search_rounded,
                     iconColor: foregroundColor,
@@ -431,6 +433,7 @@ class ExploreScreenState extends State<ExploreScreen>
                 hubs: tvHubs,
                 iconForHub: (hub, _) => _rowIcon(_rowForHub(hub) ?? CatalogRowId.watchlist),
                 onFocusedItemChanged: _setSpotlightItem,
+                onRefresh: _explore.activeSource is MediaItemCatalogSource ? (_) => unawaited(_explore.load()) : null,
                 loadMoreItems: (hub) {
                   final row = _rowForHub(hub);
                   return row == null ? Future.value(hub.items) : _explore.loadAllForRow(row);

--- a/lib/screens/media_detail/action_buttons.dart
+++ b/lib/screens/media_detail/action_buttons.dart
@@ -203,6 +203,26 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
           _buildWatchedToggleButton(metadata, actionButtonStyle, tvScale, showFocus: state.showFocus),
     );
 
+    final favoriteClient = _getMediaClientForMetadata(context);
+    final canFavorite =
+        !widget.isOffline &&
+        (metadata.isMovie || metadata.isShow) &&
+        (favoriteClient?.capabilities.userFavorites ?? false);
+    final isFavorite = metadata.isFavorite == true;
+    final favoriteAction = !canFavorite
+        ? null
+        : FocusableAction(
+            debugLabel: 'detail_favorite',
+            onPressed: _favoriteMutationInFlight ? null : () => unawaited(_handleFavoriteTogglePressed(metadata)),
+            builder: (context, state) => iconActionButton(
+              state,
+              onPressed: _favoriteMutationInFlight ? null : () => unawaited(_handleFavoriteTogglePressed(metadata)),
+              icon: AppIcon(Symbols.favorite_rounded, fill: isFavorite ? 1 : 0),
+              tooltip: isFavorite ? t.mediaMenu.removeFromFavorites : t.mediaMenu.addToFavorites,
+              foregroundColor: isFavorite ? Colors.redAccent : null,
+            ),
+          );
+
     // Watchlist toggle for the connected catalog sources (Trakt, MAL).
     // Membership reads each source's session snapshot — no per-open API
     // call. Filled when the item is on ANY source's watchlist; with several
@@ -257,6 +277,7 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
       ?shuffleAction,
       ?downloadAction,
       watchedAction,
+      ?favoriteAction,
       ?watchlistAction,
       ?moreActionsAction,
     ];
@@ -320,6 +341,51 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
         return actionBar(compactActionsFor(maxWidth));
       },
     );
+  }
+
+  Future<void> _handleFavoriteTogglePressed(MediaItem metadata) async {
+    if (_favoriteMutationInFlight || widget.isOffline || (!metadata.isMovie && !metadata.isShow)) return;
+    final client = _getMediaClientForMetadata(context);
+    if (client == null || !client.capabilities.userFavorites) return;
+    final catalogSources = Provider.of<CatalogSourcesProvider?>(context, listen: false);
+
+    final previous = metadata.isFavorite == true;
+    final next = !previous;
+    final previousOverrideItemKey = _favoriteOverrideItemKey;
+    final previousOverride = _favoriteOverride;
+    setStateIfMounted(() {
+      _favoriteMutationInFlight = true;
+      _setFavoriteOverride(metadata, next, expires: false);
+      _fullMetadata = _metadata.copyWith(isFavorite: next);
+    });
+
+    try {
+      await client.setFavorite(metadata, next);
+      final updated = metadata.copyWith(isFavorite: next);
+      FavoriteStateNotifier().notifyFavorite(item: updated, cacheServerId: client.cacheServerId, isFavorite: next);
+      catalogSources?.notifyServerFavoriteChanged(updated);
+      if (!mounted) return;
+      setStateIfMounted(() {
+        _setFavoriteOverride(updated, next);
+        _fullMetadata = _metadata.copyWith(isFavorite: next);
+        _watchStateChanged = true;
+      });
+      showSuccessSnackBar(context, next ? t.mediaMenu.addedToFavorites : t.mediaMenu.removedFromFavorites);
+    } catch (e) {
+      appLogger.w('Failed to update server favorite', error: e);
+      if (!mounted) return;
+      setStateIfMounted(() {
+        if (previousOverrideItemKey != null && previousOverride != null) {
+          _setFavoriteOverrideForKey(previousOverrideItemKey, previousOverride);
+        } else {
+          _clearFavoriteOverride();
+        }
+        _fullMetadata = _applyFavoriteOverride(_metadata.copyWith(isFavorite: previous));
+      });
+      showErrorSnackBar(context, t.mediaMenu.favoritesUpdateFailed);
+    } finally {
+      setStateIfMounted(() => _favoriteMutationInFlight = false);
+    }
   }
 
   Future<void> _handleWatchlistTogglePressed(MediaItem metadata) async {
@@ -434,6 +500,13 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
       key: _contextMenuKey,
       item: metadata,
       onRefresh: (source) => unawaited(_refreshItemInPlace(source)),
+      onFavoriteChanged: (favorite) {
+        setStateIfMounted(() {
+          _setFavoriteOverride(metadata, favorite);
+          _fullMetadata = _metadata.copyWith(isFavorite: favorite);
+          _watchStateChanged = true;
+        });
+      },
       onPlayTrailer: onPlayTrailer,
       child: Builder(
         builder: (buttonContext) => IconButton.filledTonal(

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -86,6 +86,7 @@ import '../mixins/mounted_set_state_mixin.dart';
 import '../mixins/server_bound_media_mixin.dart';
 import '../utils/watch_state_notifier.dart';
 import '../utils/deletion_notifier.dart';
+import '../utils/favorite_state_notifier.dart';
 import '../utils/global_key_utils.dart';
 import '../widgets/episode_card.dart';
 import '../widgets/fitting_title_text.dart';
@@ -268,9 +269,11 @@ PageRoute<bool> mediaDetailRoute({
 
 class _MediaDetailScreenState extends State<MediaDetailScreen>
     with WatchStateAware, DeletionAware, MountedSetStateMixin, ServerBoundMediaMixin, RouteAware {
+  static const Duration _favoriteOverrideLifetime = Duration(seconds: 15);
+
   /// Public input alias — used as the live source of truth until the detail
   /// fetch returns. Holds backend-neutral [MediaItem] data.
-  MediaItem get _metadata => _fullMetadata ?? widget.metadata;
+  MediaItem get _metadata => _applyFavoriteOverride(_fullMetadata ?? widget.metadata);
   List<MediaItem> _seasons = [];
   bool _isLoadingSeasons = false;
   bool _seasonsLoadFailed = false; // the seasons fetch threw (vs. a genuinely empty show)
@@ -315,6 +318,11 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   List<CatalogSource> _watchlistListenedSources = const [];
   final GlobalKey _watchlistButtonKey = GlobalKey();
   bool _watchlistMutationInFlight = false;
+  bool _favoriteMutationInFlight = false;
+  String? _favoriteOverrideItemKey;
+  bool? _favoriteOverride;
+  Timer? _favoriteOverrideTimer;
+  int _favoriteOverrideGeneration = 0;
 
   // Inline season tabs
   int _selectedSeasonIndex = 0;
@@ -326,6 +334,44 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       return const PagedMediaListState<MediaItem>();
     }
     return _seasonEpisodePager.stateFor(_seasons[_selectedSeasonIndex].id);
+  }
+
+  MediaItem _applyFavoriteOverride(MediaItem item) {
+    final favorite = _favoriteOverride;
+    if (_favoriteOverrideItemKey != item.globalKey || favorite == null) return item;
+    return item.copyWith(isFavorite: favorite);
+  }
+
+  void _setFavoriteOverride(MediaItem item, bool favorite, {bool expires = true}) {
+    _setFavoriteOverrideForKey(item.globalKey, favorite, expires: expires);
+  }
+
+  void _setFavoriteOverrideForKey(String itemKey, bool favorite, {bool expires = true}) {
+    final generation = ++_favoriteOverrideGeneration;
+    _favoriteOverrideItemKey = itemKey;
+    _favoriteOverride = favorite;
+    _favoriteOverrideTimer?.cancel();
+    _favoriteOverrideTimer = null;
+    if (!expires) return;
+    _favoriteOverrideTimer = Timer(_favoriteOverrideLifetime, () {
+      if (!mounted || generation != _favoriteOverrideGeneration) return;
+      setStateIfMounted(_clearFavoriteOverride);
+    });
+  }
+
+  void _clearFavoriteOverride() {
+    _favoriteOverrideGeneration++;
+    _favoriteOverrideTimer?.cancel();
+    _favoriteOverrideTimer = null;
+    _favoriteOverrideItemKey = null;
+    _favoriteOverride = null;
+  }
+
+  void _reconcileFavoriteOverride(MediaItem item) {
+    final favorite = _favoriteOverride;
+    if (_favoriteOverrideItemKey == item.globalKey && favorite != null && item.isFavorite == favorite) {
+      _clearFavoriteOverride();
+    }
   }
 
   bool get _isLoadingEpisodes => _allEpisodes.isInitialLoading;
@@ -465,6 +511,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   void _patchItemEverywhere(String sourceGlobalKey, MediaItem item) {
     final base = _fullMetadata ?? widget.metadata;
     if (base.globalKey == sourceGlobalKey) {
+      _reconcileFavoriteOverride(item);
       _fullMetadata = _normalizeRefreshedItem(item, base);
     }
 
@@ -664,6 +711,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                 refreshedMetadata,
               );
         setStateIfMounted(() {
+          _reconcileFavoriteOverride(refreshedMetadata);
           _fullMetadata = refreshedMetadata;
           _onDeckEpisode = refreshedOnDeck;
         });
@@ -860,6 +908,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
   @override
   void dispose() {
+    _favoriteOverrideTimer?.cancel();
     for (final source in _watchlistListenedSources) {
       source.watchlistChanges.removeListener(_onWatchlistSourceChanged);
     }
@@ -1101,19 +1150,33 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   }
 
   void _showRatingDialog(BuildContext sheetContext, MediaItem metadata) {
+    final catalogSources = Provider.of<CatalogSourcesProvider?>(context, listen: false);
+    final serverClient = _getMediaClientForMetadata(context);
     OverlaySheetController.of(sheetContext).show(
       showDragHandle: true,
       builder: (context) => RatingBottomSheet(
         item: metadata,
-        serverClient: _getMediaClientForMetadata(this.context),
+        serverClient: serverClient,
         onServerRatingChanged: (rating) {
           setStateIfMounted(() {
             _fullMetadata = (_fullMetadata ?? widget.metadata).copyWith(userRating: rating);
           });
         },
         onServerFavoriteChanged: (favorite) {
+          final updated = metadata.copyWith(isFavorite: favorite);
+          if (serverClient != null) {
+            FavoriteStateNotifier().notifyFavorite(
+              item: updated,
+              cacheServerId: serverClient.cacheServerId,
+              isFavorite: favorite,
+            );
+          }
+          catalogSources?.notifyServerFavoriteChanged(updated);
+          if (!mounted) return;
           setStateIfMounted(() {
-            _fullMetadata = (_fullMetadata ?? widget.metadata).copyWith(isFavorite: favorite);
+            _setFavoriteOverride(metadata, favorite);
+            _fullMetadata = _metadata.copyWith(isFavorite: favorite);
+            _watchStateChanged = true;
           });
         },
       ),
@@ -1388,6 +1451,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
             );
 
       setState(() {
+        _reconcileFavoriteOverride(base);
         _fullMetadata = base;
         _onDeckEpisode = onDeckWithServerId;
         _isLoadingMetadata = false;
@@ -1450,7 +1514,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
       // a Plex client and a section id. The library section id came from
       // Plex as an int but lands in [MediaItem.libraryId] as the string
       // form (or null on Jellyfin items).
-      final sectionId = (_fullMetadata ?? _metadata).libraryId;
+      final sectionId = _metadata.libraryId;
       final seasonsFuture = client.fetchChildren(_metadata.id);
       // Prefs are a per-library nicety (Plex "flatten seasons"); a failure here
       // must never take down the seasons list, so degrade to defaults.
@@ -1969,7 +2033,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   /// Focus the first visible section above cast: season tabs → overview → play button.
   /// Shared by cast UP, extras UP, and related hub UP handlers.
   void _focusSectionAboveCast() {
-    final metadata = _fullMetadata ?? _metadata;
+    final metadata = _metadata;
     if (metadata.isShow && !_showEpisodesDirectly && _seasons.isNotEmpty && _seasonTabFocusNodes.isNotEmpty) {
       _seasonTabFocusNodes[_selectedSeasonIndex].requestFocus();
       _scrollSectionIntoView(_seasonsSectionKey);
@@ -1984,7 +2048,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
   /// Focus the first visible section above extras: cast → season tabs → overview → play button.
   void _focusSectionAboveExtras() {
-    final metadata = _fullMetadata ?? _metadata;
+    final metadata = _metadata;
     if (metadata.roles != null && metadata.roles!.isNotEmpty) {
       _castStripKey.currentState?.requestFocus();
       _scrollSectionIntoView(_castSectionKey);
@@ -1994,7 +2058,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   }
 
   bool get _hasInfoRows {
-    final metadata = _fullMetadata ?? _metadata;
+    final metadata = _metadata;
     return metadata.studio != null || metadata.contentRating != null;
   }
 
@@ -2116,7 +2180,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
   /// Focus the overview, or the first available content section when there is no overview.
   void _focusBelowActionRow() {
-    final metadata = _fullMetadata ?? _metadata;
+    final metadata = _metadata;
 
     if (PlatformDetector.isTV()) {
       _tvDetailRailKey.currentState?.requestFocus();
@@ -2134,7 +2198,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
   /// Focus the first available content section after the overview.
   void _focusBelowOverview() {
-    final metadata = _fullMetadata ?? _metadata;
+    final metadata = _metadata;
 
     // DOWN order: season tabs → episodes → cast → extras → related hubs → info rows.
     if (metadata.isShow && !_showEpisodesDirectly && _seasons.isNotEmpty && _seasonTabFocusNodes.isNotEmpty) {
@@ -2558,7 +2622,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
               ? () {
                   if (!_showEpisodesDirectly) {
                     _focusSelectedSeasonTab();
-                  } else if (!PlatformDetector.isTV() && (_fullMetadata ?? _metadata).summary?.isNotEmpty == true) {
+                  } else if (!PlatformDetector.isTV() && _metadata.summary?.isNotEmpty == true) {
                     _overviewFocusNode.requestFocus();
                     _scrollSectionIntoView(_overviewSectionKey);
                   } else {
@@ -2729,7 +2793,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   }
 
   String? _seriesIdForSeason(MediaItem season) {
-    if (_metadata.isShow) return (_fullMetadata ?? _metadata).id;
+    if (_metadata.isShow) return _metadata.id;
     return season.grandparentId ?? season.parentId ?? _metadata.grandparentId ?? _metadata.parentId;
   }
 
@@ -2767,7 +2831,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
     required ServerId serverId,
   }) {
     if (_metadata.isShow) {
-      return normalizeSeasonEpisodes(episodes, show: _fullMetadata ?? _metadata, season: season);
+      return normalizeSeasonEpisodes(episodes, show: _metadata, season: season);
     }
 
     return _enrichPlayableEpisodes(episodes, serverId)
@@ -3022,7 +3086,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   Widget build(BuildContext context) {
     // Session-fresh hero: server snapshot resolved against the watch-state
     // store (onWatchStateChanged rebuilds on relevant events).
-    final metadata = _fresh(_fullMetadata ?? _metadata);
+    final metadata = _fresh(_metadata);
     final isShow = metadata.isShow;
     final isMobile = PlatformDetector.isMobile(context);
     final isTv = PlatformDetector.isTV();
@@ -4355,7 +4419,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
     if (_extras == null || _extras!.isEmpty) return null;
 
     // If there's a trailerKey (Plex `primaryExtraKey`), try to find that specific trailer
-    final metadata = _fullMetadata ?? _metadata;
+    final metadata = _metadata;
     if (metadata case PlexMediaItem(:final trailerKey?)) {
       // Extract rating key from trailerKey (e.g., "/library/metadata/52601" -> "52601")
       final primaryKey = trailerKey.split('/').last;

--- a/lib/services/catalog/catalog_source.dart
+++ b/lib/services/catalog/catalog_source.dart
@@ -73,6 +73,17 @@ abstract interface class MediaItemCatalogSource {
   Future<ExploreMediaPage> fetchMediaRow(CatalogRowId row, {int page = 1, int limit = 25});
 }
 
+/// Optional capability for a catalog source whose server-backed row can
+/// change outside the external-watchlist methods on [CatalogSource].
+///
+/// Jellyfin Favorites uses this to invalidate its Explore row after a media
+/// item's per-user favorite flag changes elsewhere in the app.
+abstract interface class MutableCatalogRowSource {
+  CatalogRowId get mutableRow;
+
+  Listenable get mutableRowChanges;
+}
+
 /// A pluggable external catalog provider backing the Explore tab (Trakt
 /// today; Overseerr/Jellyfin or MAL later).
 ///

--- a/lib/services/catalog/catalog_source.dart
+++ b/lib/services/catalog/catalog_source.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/foundation.dart';
 
 import '../../media/media_kind.dart';
+import '../../media/media_item.dart';
 import '../../models/catalog/catalog_cast_member.dart';
 import '../../models/catalog/catalog_item.dart';
 import '../../utils/external_ids.dart';
 
 /// Content rows a catalog source can serve on the Explore tab.
 enum CatalogRowId {
+  favorites,
   watchlist,
   recommendedMovies,
   recommendedShows,
@@ -48,6 +50,27 @@ class CatalogPage {
   final bool hasMore;
 
   const CatalogPage({required this.items, this.hasMore = false});
+}
+
+/// A page ready for Explore's existing media-card stack.
+///
+/// External catalogs are adapted from [CatalogPage] into rendering-only
+/// [CatalogItem.toMediaItem] stand-ins. Server-backed Explore sources can
+/// implement [MediaItemCatalogSource] and return real [MediaItem]s instead,
+/// preserving their server identity and normal navigation path.
+class ExploreMediaPage {
+  final List<MediaItem> items;
+  final bool hasMore;
+
+  const ExploreMediaPage({required this.items, this.hasMore = false});
+}
+
+/// Optional capability for a [CatalogSource] whose Explore rows are already
+/// server-backed [MediaItem]s rather than external [CatalogItem]s.
+abstract interface class MediaItemCatalogSource {
+  bool get supportsExploreSearch;
+
+  Future<ExploreMediaPage> fetchMediaRow(CatalogRowId row, {int page = 1, int limit = 25});
 }
 
 /// A pluggable external catalog provider backing the Explore tab (Trakt
@@ -106,4 +129,24 @@ abstract class CatalogSource {
   Listenable get watchlistChanges;
 
   void dispose();
+}
+
+/// Explore-facing adapter shared by external and server-backed sources.
+extension ExploreCatalogSource on CatalogSource {
+  bool get supportsExploreSearch => switch (this) {
+    final MediaItemCatalogSource source => source.supportsExploreSearch,
+    _ => true,
+  };
+
+  Future<ExploreMediaPage> fetchExploreRow(CatalogRowId row, {int page = 1, int limit = 25}) async {
+    if (this is MediaItemCatalogSource) {
+      final mediaSource = this as MediaItemCatalogSource;
+      return mediaSource.fetchMediaRow(row, page: page, limit: limit);
+    }
+    final pageResult = await fetchRow(row, page: page, limit: limit);
+    return ExploreMediaPage(
+      items: [for (final item in pageResult.items) item.toMediaItem()],
+      hasMore: pageResult.hasMore,
+    );
+  }
 }

--- a/lib/services/catalog/jellyfin_favorites_catalog_source.dart
+++ b/lib/services/catalog/jellyfin_favorites_catalog_source.dart
@@ -19,7 +19,7 @@ typedef _FavoriteLibrary = ({MediaServerClient client, MediaLibrary library});
 /// Unlike Trakt/MAL, these rows contain real server items. The
 /// [MediaItemCatalogSource] capability keeps them out of the external-catalog
 /// stand-in conversion so taps route directly to the owning Jellyfin server.
-class JellyfinFavoritesCatalogSource implements CatalogSource, MediaItemCatalogSource {
+class JellyfinFavoritesCatalogSource implements CatalogSource, MediaItemCatalogSource, MutableCatalogRowSource {
   JellyfinFavoritesCatalogSource(List<MediaServerClient> clients, {Set<String> hiddenLibraryKeys = const {}})
     : _clients = List.unmodifiable(clients),
       _hiddenLibraryKeys = Set.unmodifiable(hiddenLibraryKeys);
@@ -45,6 +45,15 @@ class JellyfinFavoritesCatalogSource implements CatalogSource, MediaItemCatalogS
 
   @override
   Listenable get watchlistChanges => _changes;
+
+  @override
+  CatalogRowId get mutableRow => CatalogRowId.favorites;
+
+  @override
+  Listenable get mutableRowChanges => _changes;
+
+  /// Invalidate the Favorites row after a successful server-side mutation.
+  void notifyFavoriteChanged() => _changes.notify();
 
   @override
   Future<ExploreMediaPage> fetchMediaRow(CatalogRowId row, {int page = 1, int limit = 25}) async {

--- a/lib/services/catalog/jellyfin_favorites_catalog_source.dart
+++ b/lib/services/catalog/jellyfin_favorites_catalog_source.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/foundation.dart';
+
+import '../../i18n/strings.g.dart';
+import '../../media/library_query.dart';
+import '../../media/media_item.dart';
+import '../../media/media_kind.dart';
+import '../../media/media_library.dart';
+import '../../media/media_server_client.dart';
+import '../../models/catalog/catalog_cast_member.dart';
+import '../../models/catalog/catalog_item.dart';
+import '../../utils/app_logger.dart';
+import '../../utils/external_ids.dart';
+import 'catalog_source.dart';
+
+typedef _FavoriteLibrary = ({MediaServerClient client, MediaLibrary library});
+
+/// Selectable Explore source backed by the active user's Jellyfin favorites.
+///
+/// Unlike Trakt/MAL, these rows contain real server items. The
+/// [MediaItemCatalogSource] capability keeps them out of the external-catalog
+/// stand-in conversion so taps route directly to the owning Jellyfin server.
+class JellyfinFavoritesCatalogSource implements CatalogSource, MediaItemCatalogSource {
+  JellyfinFavoritesCatalogSource(List<MediaServerClient> clients, {Set<String> hiddenLibraryKeys = const {}})
+    : _clients = List.unmodifiable(clients),
+      _hiddenLibraryKeys = Set.unmodifiable(hiddenLibraryKeys);
+
+  final List<MediaServerClient> _clients;
+  final Set<String> _hiddenLibraryKeys;
+  final WatchlistChangeNotifier _changes = WatchlistChangeNotifier();
+
+  @override
+  CatalogSourceId get id => CatalogSourceId.jellyfin;
+
+  @override
+  String get displayName => 'Jellyfin ${t.libraries.filterCategories.favorites}';
+
+  @override
+  List<CatalogRowId> get supportedRows => const [CatalogRowId.favorites];
+
+  @override
+  bool get supportsWatchlist => false;
+
+  @override
+  bool get supportsExploreSearch => false;
+
+  @override
+  Listenable get watchlistChanges => _changes;
+
+  @override
+  Future<ExploreMediaPage> fetchMediaRow(CatalogRowId row, {int page = 1, int limit = 25}) async {
+    if (row != CatalogRowId.favorites) throw ArgumentError('Jellyfin Favorites does not serve ${row.name}');
+    if (page < 1 || limit <= 0 || _clients.isEmpty) return const ExploreMediaPage(items: []);
+
+    final libraries = await _favoriteLibraries();
+    if (libraries.isEmpty) return const ExploreMediaPage(items: []);
+
+    // Fetch every source through the end of the requested global page. Since
+    // each response is title-sorted, no source can contribute more than this
+    // many items to the prefix, allowing a deterministic cross-server slice.
+    final requestedEnd = page * limit;
+    Object? firstError;
+    final pages = await Future.wait<LibraryPage<MediaItem>?>([
+      for (final target in libraries)
+        () async {
+          try {
+            return await target.client.fetchLibraryContent(
+              target.library.id,
+              LibraryQuery(
+                offset: 0,
+                limit: requestedEnd,
+                sort: const LibrarySort(field: 'title', direction: LibrarySortDirection.ascending),
+                favoritesOnly: true,
+              ),
+            );
+          } catch (error, stackTrace) {
+            firstError ??= error;
+            appLogger.w(
+              'Jellyfin Favorites: failed to load ${target.library.globalKey}',
+              error: error,
+              stackTrace: stackTrace,
+            );
+            return null;
+          }
+        }(),
+    ]);
+
+    final successful = pages.whereType<LibraryPage<MediaItem>>().toList();
+    if (successful.isEmpty && firstError != null) throw firstError!;
+
+    final seen = <String>{};
+    final merged = <MediaItem>[
+      for (final result in successful)
+        for (final item in result.items)
+          if ((item.kind.isVideo || item.kind.isShowRelated) && seen.add(item.globalKey)) item,
+    ];
+    merged.sort(_compareItems);
+
+    final start = (page - 1) * limit;
+    final end = requestedEnd < merged.length ? requestedEnd : merged.length;
+    final items = start >= merged.length ? const <MediaItem>[] : merged.sublist(start, end);
+    final hasMore = merged.length > requestedEnd || successful.any((result) => result.totalCount > result.items.length);
+    return ExploreMediaPage(items: items, hasMore: hasMore);
+  }
+
+  Future<List<_FavoriteLibrary>> _favoriteLibraries() async {
+    Object? firstError;
+    final results = await Future.wait<List<_FavoriteLibrary>?>([
+      for (final client in _clients)
+        () async {
+          try {
+            final libraries = await client.fetchLibraries();
+            return [
+              for (final library in libraries)
+                if (!library.hidden &&
+                    !_hiddenLibraryKeys.contains(library.globalKey) &&
+                    (library.kind == MediaKind.movie ||
+                        library.kind == MediaKind.show ||
+                        library.kind == MediaKind.clip ||
+                        library.kind == MediaKind.unknown))
+                  (client: client, library: library),
+            ];
+          } catch (error, stackTrace) {
+            firstError ??= error;
+            appLogger.w(
+              'Jellyfin Favorites: failed to load libraries from ${client.serverId}',
+              error: error,
+              stackTrace: stackTrace,
+            );
+            return null;
+          }
+        }(),
+    ]);
+    final successful = results.whereType<List<_FavoriteLibrary>>().toList();
+    if (successful.isEmpty && firstError != null) throw firstError!;
+    return [for (final result in successful) ...result];
+  }
+
+  static int _compareItems(MediaItem a, MediaItem b) {
+    final byTitle = (a.title ?? '').toLowerCase().compareTo((b.title ?? '').toLowerCase());
+    if (byTitle != 0) return byTitle;
+    final byYear = (a.year ?? 0).compareTo(b.year ?? 0);
+    if (byYear != 0) return byYear;
+    return a.globalKey.compareTo(b.globalKey);
+  }
+
+  // External-catalog operations do not apply to real Jellyfin items.
+  @override
+  Future<CatalogPage> fetchRow(CatalogRowId row, {int page = 1, int limit = 25}) =>
+      throw UnsupportedError('Jellyfin Favorites rows contain server media items');
+
+  @override
+  Future<List<CatalogItem>> search(String query, {int limit = 30}) async => const [];
+
+  @override
+  Future<List<CatalogCastMember>> fetchCast(CatalogItem item, {int limit = 20}) async => const [];
+
+  @override
+  Future<List<CatalogItem>> fetchRelated(CatalogItem item, {int limit = 20}) async => const [];
+
+  @override
+  Future<void> ensureWatchlistLoaded() async {}
+
+  @override
+  bool? isOnWatchlist(MediaKind kind, CatalogItemIds ids) => null;
+
+  @override
+  Future<CatalogItemIds?> resolveItemIds(MediaKind kind, ExternalIds external) async => null;
+
+  @override
+  Future<void> addToWatchlist(MediaKind kind, CatalogItemIds ids) =>
+      throw UnsupportedError('Jellyfin Favorites is not an external watchlist');
+
+  @override
+  Future<void> removeFromWatchlist(MediaKind kind, CatalogItemIds ids) =>
+      throw UnsupportedError('Jellyfin Favorites is not an external watchlist');
+
+  @override
+  void dispose() => _changes.dispose();
+}

--- a/lib/services/catalog/mal_catalog_source.dart
+++ b/lib/services/catalog/mal_catalog_source.dart
@@ -69,6 +69,7 @@ class MalCatalogSource with CatalogWatchlistMachinery implements CatalogSource {
       CatalogRowId.trendingShows ||
       CatalogRowId.popularMovies ||
       CatalogRowId.popularShows ||
+      CatalogRowId.favorites ||
       CatalogRowId.trending ||
       CatalogRowId.upcomingMovies ||
       CatalogRowId.upcomingShows => throw ArgumentError('MAL does not serve ${row.name}'),

--- a/lib/services/catalog/seerr_catalog_source.dart
+++ b/lib/services/catalog/seerr_catalog_source.dart
@@ -62,6 +62,7 @@ class SeerrCatalogSource implements CatalogSource {
       CatalogRowId.upcomingMovies => client.getUpcomingMovies(page: page),
       CatalogRowId.upcomingShows => client.getUpcomingTv(page: page),
       CatalogRowId.watchlist ||
+      CatalogRowId.favorites ||
       CatalogRowId.recommendedMovies ||
       CatalogRowId.recommendedShows ||
       CatalogRowId.trendingMovies ||

--- a/lib/services/catalog/trakt_catalog_source.dart
+++ b/lib/services/catalog/trakt_catalog_source.dart
@@ -84,6 +84,7 @@ class TraktCatalogSource with CatalogWatchlistMachinery implements CatalogSource
       case CatalogRowId.suggestedAnime:
       case CatalogRowId.airingAnime:
       case CatalogRowId.popularAnime:
+      case CatalogRowId.favorites:
       case CatalogRowId.trending:
       case CatalogRowId.upcomingMovies:
       case CatalogRowId.upcomingShows:

--- a/lib/services/data_aggregation_service.dart
+++ b/lib/services/data_aggregation_service.dart
@@ -19,6 +19,11 @@ typedef OnDeckAggregationResult = ({
   Set<String> succeededServerIds,
   Set<String> cancelledServerIds,
 });
+typedef NextUpAggregationResult = ({
+  List<MediaItem> items,
+  Set<String> succeededServerIds,
+  Set<String> cancelledServerIds,
+});
 typedef HubAggregationResult = ({List<MediaHub> hubs, Set<String> succeededServerIds, Set<String> cancelledServerIds});
 typedef LibraryAggregationResult = ({
   List<MediaLibrary> libraries,
@@ -36,8 +41,8 @@ bool _isCancellation(Object error) => error is MediaServerHttpException && error
 /// merges the results. Single-server operations now go through the
 /// [MediaServerClient] interface directly (resolved via
 /// [ProviderExtensions.tryGetMediaClientForServer] etc.), so this service
-/// only owns the genuinely multi-server flows: home/discover hubs, on-deck,
-/// search, and the global library list.
+/// only owns the genuinely multi-server flows: home/discover hubs, playback
+/// shelves, search, and the global library list.
 class DataAggregationService {
   final MultiServerManager _serverManager;
 
@@ -143,8 +148,7 @@ class DataAggregationService {
     }
 
     // Sort by most recently viewed, falling back to addedAt for unwatched items.
-    // Same key as JellyfinClient's continue-watching merge (MediaItem.recencySortKey)
-    // so per-server and cross-server ordering can't drift apart.
+    // Shared with the Next Up shelf so playback-row ordering can't drift.
     filteredOnDeck.sort((a, b) => b.recencySortKey.compareTo(a.recencySortKey));
 
     filteredOnDeck = await _deduplicateContinueWatching(filteredOnDeck);
@@ -157,6 +161,56 @@ class DataAggregationService {
     return (items: items, succeededServerIds: succeededServerIds, cancelledServerIds: cancelledServerIds);
   }
 
+  /// Fetch dedicated Next Up rows from every online server. Backends without a
+  /// Next Up surface contribute an empty successful result through the neutral
+  /// client's default implementation. Items use the same hidden-library,
+  /// recency, and cross-server identity rules as Continue Watching.
+  Future<NextUpAggregationResult> getNextUpFromAllServers({
+    int? limit,
+    Set<String>? hiddenLibraryKeys,
+    Set<String>? serverIds,
+  }) async {
+    final clients = _clientsFor(serverIds);
+    if (clients.isEmpty) {
+      appLogger.w('No online servers available for fetching next up');
+      return (items: const <MediaItem>[], succeededServerIds: const <String>{}, cancelledServerIds: const <String>{});
+    }
+
+    final cancelledServerIds = <String>{};
+    final futures = clients.entries.map((entry) async {
+      try {
+        final items = await entry.value.fetchNextUp(count: limit);
+        return (serverId: entry.key, items: items);
+      } catch (e, st) {
+        if (_isCancellation(e)) cancelledServerIds.add(entry.key);
+        appLogger.e('Failed next-up fetch from ${entry.key}', error: e, stackTrace: st);
+        return (serverId: null, items: <MediaItem>[]);
+      }
+    });
+    final results = await Future.wait(futures);
+    final succeededServerIds = {
+      for (final result in results)
+        if (result.serverId != null) result.serverId!,
+    };
+    final allNextUp = results.expand((result) => result.items).toList();
+
+    List<MediaItem> filteredNextUp = allNextUp;
+    if (hiddenLibraryKeys != null && hiddenLibraryKeys.isNotEmpty) {
+      filteredNextUp = allNextUp.where((item) {
+        if (item.libraryId == null || item.serverId == null) return true;
+        final globalKey = buildGlobalKey(ServerId(item.serverId!), item.libraryId!);
+        return !hiddenLibraryKeys.contains(globalKey);
+      }).toList();
+    }
+
+    filteredNextUp.sort((a, b) => b.recencySortKey.compareTo(a.recencySortKey));
+    filteredNextUp = await _deduplicateContinueWatching(filteredNextUp);
+    final items = limit != null && limit < filteredNextUp.length ? filteredNextUp.sublist(0, limit) : filteredNextUp;
+
+    appLogger.i('Fetched ${items.length} next-up items from all servers');
+    return (items: items, succeededServerIds: succeededServerIds, cancelledServerIds: cancelledServerIds);
+  }
+
   /// Merge an [existing] Continue Watching list with [fresh] rows from
   /// newly-online servers: same recency ordering and cross-server identity
   /// dedup as [getOnDeckFromAllServers], applied to the union.
@@ -165,6 +219,10 @@ class DataAggregationService {
     final deduped = await _deduplicateContinueWatching(combined);
     return limit != null && limit < deduped.length ? deduped.sublist(0, limit) : deduped;
   }
+
+  /// Delta-merge counterpart to [getNextUpFromAllServers].
+  Future<List<MediaItem>> mergeNextUp(List<MediaItem> existing, List<MediaItem> fresh, {int? limit}) =>
+      mergeContinueWatching(existing, fresh, limit: limit);
 
   Future<List<MediaItem>> _deduplicateContinueWatching(List<MediaItem> items) async {
     if (items.length < 2) return items;

--- a/lib/services/jellyfin_api_cache.dart
+++ b/lib/services/jellyfin_api_cache.dart
@@ -27,6 +27,11 @@ class JellyfinApiCache extends ApiCache {
 
   JellyfinApiCache._(super.db);
 
+  int _favoriteMutationEpoch = 0;
+  int _itemFetchEpoch = 0;
+  final Map<(ServerId, String), ({int generation, bool isFavorite})> _favoriteMutationStates = {};
+  final Map<(ServerId, String), ({int sequence, int favoriteGeneration, bool? isFavorite})> _itemFetchCommits = {};
+
   /// Initialize the singleton with an [AppDatabase] instance. Also registers
   /// this instance with the [ApiCache] backend dispatch so callers using
   /// `ApiCache.forBackend(MediaBackend.jellyfin)` resolve here.
@@ -129,7 +134,8 @@ class JellyfinApiCache extends ApiCache {
   /// [viewedLeafCount] is ignored — Jellyfin tracks per-show rollup via
   /// `UserData.UnplayedItemCount`, computed from individual children rather
   /// than aggregated on the parent. The parameter is accepted for API parity
-  /// with the Plex caller.
+  /// with the Plex caller. The transaction makes the JSON read/patch/write
+  /// atomic with favorite patches and other writes on this Drift connection.
   @override
   Future<void> applyWatchState({
     required ServerId serverId,
@@ -139,57 +145,184 @@ class JellyfinApiCache extends ApiCache {
     int? lastViewedAt,
     int? viewedLeafCount,
   }) async {
-    final query = database.select(database.apiCache)
-      ..where((t) => _resolver.itemKeyPredicate(t.cacheKey, serverId, itemId));
-    final rows = await query.get();
-    if (rows.isEmpty) return;
-    if (!serverId.contains('/')) {
-      final userIds = <String>{
-        for (final row in rows)
-          if (JellyfinCacheResolver.parseItemKey(row.cacheKey) case final key?) key.userId,
-      };
-      if (userIds.length > 1) {
-        appLogger.w(
-          'Skipping ambiguous bare-scope Jellyfin watch-state cache write',
-          error: {'serverId': serverId, 'itemId': itemId, 'userCount': userIds.length},
-        );
-        return;
-      }
-    }
-    for (final row in rows) {
-      try {
-        final data = jsonDecode(row.data) as Map<String, dynamic>;
-        final userData = (data['UserData'] is Map<String, dynamic>)
-            ? (data['UserData'] as Map<String, dynamic>)
-            : <String, dynamic>{};
-        userData['Played'] = isWatched;
-        final positionTicks = viewOffsetMs != null ? viewOffsetMs * 10_000 : 0;
-        if (isWatched) {
-          final current = (userData['PlayCount'] as num?)?.toInt() ?? 0;
-          userData['PlayCount'] = current < 1 ? 1 : current;
-          userData['PlaybackPositionTicks'] = positionTicks;
-          userData['LastPlayedDate'] = lastViewedAt != null
-              ? DateTime.fromMillisecondsSinceEpoch(lastViewedAt * 1000, isUtc: true).toIso8601String()
-              : DateTime.now().toUtc().toIso8601String();
-        } else {
-          userData['PlayCount'] = 0;
-          userData['PlaybackPositionTicks'] = positionTicks;
-          if (lastViewedAt != null) {
-            userData['LastPlayedDate'] = DateTime.fromMillisecondsSinceEpoch(
-              lastViewedAt * 1000,
-              isUtc: true,
-            ).toIso8601String();
-          }
+    await database.transaction(() async {
+      final query = database.select(database.apiCache)
+        ..where((t) => _resolver.itemKeyPredicate(t.cacheKey, serverId, itemId));
+      final rows = await query.get();
+      if (rows.isEmpty) return;
+      if (!serverId.contains('/')) {
+        final userIds = <String>{
+          for (final row in rows)
+            if (JellyfinCacheResolver.parseItemKey(row.cacheKey) case final key?) key.userId,
+        };
+        if (userIds.length > 1) {
+          appLogger.w(
+            'Skipping ambiguous bare-scope Jellyfin watch-state cache write',
+            error: {'serverId': serverId, 'itemId': itemId, 'userCount': userIds.length},
+          );
+          return;
         }
-        data['UserData'] = userData;
-        final encoded = jsonEncode(data);
-        await (database.update(database.apiCache)..where((t) => t.cacheKey.equals(row.cacheKey))).write(
-          ApiCacheCompanion(data: Value(encoded), cachedAt: Value(DateTime.now())),
-        );
-      } catch (_) {
-        // Skip malformed entries.
       }
-    }
+      for (final row in rows) {
+        try {
+          final data = jsonDecode(row.data) as Map<String, dynamic>;
+          final userData = (data['UserData'] is Map<String, dynamic>)
+              ? (data['UserData'] as Map<String, dynamic>)
+              : <String, dynamic>{};
+          userData['Played'] = isWatched;
+          final positionTicks = viewOffsetMs != null ? viewOffsetMs * 10_000 : 0;
+          if (isWatched) {
+            final current = (userData['PlayCount'] as num?)?.toInt() ?? 0;
+            userData['PlayCount'] = current < 1 ? 1 : current;
+            userData['PlaybackPositionTicks'] = positionTicks;
+            userData['LastPlayedDate'] = lastViewedAt != null
+                ? DateTime.fromMillisecondsSinceEpoch(lastViewedAt * 1000, isUtc: true).toIso8601String()
+                : DateTime.now().toUtc().toIso8601String();
+          } else {
+            userData['PlayCount'] = 0;
+            userData['PlaybackPositionTicks'] = positionTicks;
+            if (lastViewedAt != null) {
+              userData['LastPlayedDate'] = DateTime.fromMillisecondsSinceEpoch(
+                lastViewedAt * 1000,
+                isUtc: true,
+              ).toIso8601String();
+            }
+          }
+          data['UserData'] = userData;
+          final encoded = jsonEncode(data);
+          await (database.update(database.apiCache)..where((t) => t.cacheKey.equals(row.cacheKey))).write(
+            ApiCacheCompanion(data: Value(encoded), cachedAt: Value(DateTime.now())),
+          );
+        } catch (_) {
+          // Skip malformed entries.
+        }
+      }
+    });
+  }
+
+  /// Persist a per-user favorite flip into cached `BaseItemDto` rows for
+  /// [itemId] without evicting pinned offline metadata. Compound Jellyfin
+  /// scope ids update only their user. A legacy bare machine id is accepted
+  /// only when its matching rows belong to one user; ambiguous multi-user
+  /// writes are skipped rather than leaking state across profiles. The
+  /// transaction prevents concurrent watch-state patches from overwriting the
+  /// favorite field (or vice versa).
+  Future<void> applyFavoriteState({
+    required ServerId serverId,
+    required String itemId,
+    required bool isFavorite,
+  }) async {
+    _favoriteMutationStates[(serverId, itemId)] = (generation: ++_favoriteMutationEpoch, isFavorite: isFavorite);
+    await database.transaction(() async {
+      final query = database.select(database.apiCache)
+        ..where((t) => _resolver.itemKeyPredicate(t.cacheKey, serverId, itemId));
+      final rows = await query.get();
+      if (rows.isEmpty) return;
+      if (!serverId.contains('/')) {
+        final userIds = <String>{
+          for (final row in rows)
+            if (JellyfinCacheResolver.parseItemKey(row.cacheKey) case final key?) key.userId,
+        };
+        if (userIds.length > 1) {
+          appLogger.w(
+            'Skipping ambiguous bare-scope Jellyfin favorite cache write',
+            error: {'serverId': serverId, 'itemId': itemId, 'userCount': userIds.length},
+          );
+          return;
+        }
+      }
+      for (final row in rows) {
+        try {
+          final data = jsonDecode(row.data) as Map<String, dynamic>;
+          final userData = (data['UserData'] is Map<String, dynamic>)
+              ? (data['UserData'] as Map<String, dynamic>)
+              : <String, dynamic>{};
+          userData['IsFavorite'] = isFavorite;
+          data['UserData'] = userData;
+          await (database.update(database.apiCache)..where((t) => t.cacheKey.equals(row.cacheKey))).write(
+            ApiCacheCompanion(data: Value(jsonEncode(data)), cachedAt: Value(DateTime.now())),
+          );
+        } catch (_) {
+          // Skip malformed entries.
+        }
+      }
+    });
+  }
+
+  /// Stamp an item GET with both its favorite-state generation and start
+  /// sequence. [putFetchedItem] uses the token to reject an older same-
+  /// generation response when a newer request has already committed.
+  ({int favoriteGeneration, int fetchSequence}) beginItemFetch(ServerId serverId, String itemId) => (
+    favoriteGeneration: _favoriteMutationStates[(serverId, itemId)]?.generation ?? 0,
+    fetchSequence: ++_itemFetchEpoch,
+  );
+
+  /// Cache an item GET without letting a response started before a successful
+  /// favorite mutation overwrite the newer local state.
+  ///
+  /// The generation check and cache write share a transaction with the
+  /// favorite cache patch. If a mutation completed after the GET started, its
+  /// latest favorite value is merged into both the returned DTO and cached
+  /// JSON. A response started at the current generation remains authoritative;
+  /// its favorite value becomes the barrier applied to any still-older GETs.
+  Future<Map<String, dynamic>> putFetchedItem({
+    required ServerId serverId,
+    required String itemId,
+    required String endpoint,
+    required int favoriteGenerationAtStart,
+    required int fetchSequence,
+    required Map<String, dynamic> data,
+  }) async {
+    return database.transaction(() async {
+      final key = (serverId, itemId);
+      final committed = _itemFetchCommits[key];
+      final state = _favoriteMutationStates[key];
+      if (committed != null && fetchSequence < committed.sequence) {
+        final barrierFavorite = state != null && state.generation > committed.favoriteGeneration
+            ? state.isFavorite
+            : committed.isFavorite ??
+                  (state != null && state.generation == committed.favoriteGeneration ? state.isFavorite : null);
+        return barrierFavorite == null ? data : _withFavoriteState(data, barrierFavorite);
+      }
+
+      var effective = data;
+      var effectiveFavoriteGeneration = favoriteGenerationAtStart;
+      if (state != null && state.generation > favoriteGenerationAtStart) {
+        effective = _withFavoriteState(data, state.isFavorite);
+        effectiveFavoriteGeneration = state.generation;
+      }
+      await put(serverId, endpoint, effective);
+
+      final effectiveFavorite = _favoriteStateFrom(effective);
+      final stateAfterWrite = _favoriteMutationStates[key];
+      if (effectiveFavorite != null && stateAfterWrite?.generation == favoriteGenerationAtStart) {
+        _favoriteMutationStates[key] = (generation: favoriteGenerationAtStart, isFavorite: effectiveFavorite);
+      } else if (effectiveFavorite != null && state == null && stateAfterWrite == null) {
+        _favoriteMutationStates[key] = (generation: favoriteGenerationAtStart, isFavorite: effectiveFavorite);
+      }
+      _itemFetchCommits[key] = (
+        sequence: fetchSequence,
+        favoriteGeneration: effectiveFavoriteGeneration,
+        isFavorite: effectiveFavorite,
+      );
+      return effective;
+    });
+  }
+
+  static bool? _favoriteStateFrom(Map<String, dynamic> data) {
+    final userData = data['UserData'];
+    if (userData is! Map<String, dynamic>) return null;
+    final isFavorite = userData['IsFavorite'];
+    return isFavorite is bool ? isFavorite : null;
+  }
+
+  static Map<String, dynamic> _withFavoriteState(Map<String, dynamic> data, bool isFavorite) {
+    final effective = Map<String, dynamic>.from(data);
+    final rawUserData = data['UserData'];
+    final userData = rawUserData is Map<String, dynamic> ? Map<String, dynamic>.from(rawUserData) : <String, dynamic>{};
+    userData['IsFavorite'] = isFavorite;
+    effective['UserData'] = userData;
+    return effective;
   }
 
   /// Load all pinned Jellyfin metadata in a single query.

--- a/lib/services/jellyfin_client/parts/browse.dart
+++ b/lib/services/jellyfin_client/parts/browse.dart
@@ -104,7 +104,7 @@ const _episodeQueuePageSize = 200;
 /// rows with their series' last-watched date (see [_attachSeriesLastPlayed]).
 /// Mirrors [_episodeQueuePageSize]; covers far more distinct series than the
 /// Next Up list ever returns, while keeping the response bounded.
-const _continueWatchingSeriesLookback = 200;
+const _nextUpSeriesLookback = 200;
 
 const _childrenPageSize = 500;
 const _pagedListPageSize = 200;
@@ -1197,31 +1197,31 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
 
   @override
   Future<List<MediaItem>> fetchContinueWatching({int? count = 20}) async {
-    final results = await Future.wait([
-      _fetchItemsArray('/UserItems/Resume', {
-        'userId': connection.userId,
-        'Limit': ?count?.toString(),
-        'Fields': _browseFields,
-        'MediaTypes': 'Video',
-        'Recursive': 'true',
-        'EnableTotalRecordCount': 'false',
-        ...jellyfinImageQueryParameters,
-      }, retry: _continueWatchingRetry),
-      _safeFetchItemsArray('/Shows/NextUp', {
-        'userId': connection.userId,
-        'Limit': ?count?.toString(),
-        'Fields': _browseFields,
-        'EnableResumable': 'false',
-        'EnableTotalRecordCount': 'false',
-        ...jellyfinImageQueryParameters,
-      }, retry: _continueWatchingRetry),
-    ]);
+    if (count != null && count <= 0) return const [];
+    final items = await _fetchItemsArray('/UserItems/Resume', {
+      'userId': connection.userId,
+      'Limit': ?count?.toString(),
+      'Fields': _browseFields,
+      'MediaTypes': 'Video',
+      'Recursive': 'true',
+      'EnableTotalRecordCount': 'false',
+      ...jellyfinImageQueryParameters,
+    }, retry: _continueWatchingRetry);
+    return _mapItems(items);
+  }
 
-    return _mergeContinueWatchingAndNextUp(
-      resume: _mapItems(results.first),
-      nextUp: await _attachSeriesLastPlayed(_mapItems(results[1])),
-      limit: count,
-    );
+  @override
+  Future<List<MediaItem>> fetchNextUp({int? count = 20}) async {
+    if (count != null && count <= 0) return const [];
+    final items = await _fetchItemsArray('/Shows/NextUp', {
+      'userId': connection.userId,
+      'Limit': ?count?.toString(),
+      'Fields': _browseFields,
+      'EnableResumable': 'false',
+      'EnableTotalRecordCount': 'false',
+      ...jellyfinImageQueryParameters,
+    }, retry: _continueWatchingRetry);
+    return _attachSeriesLastPlayed(_mapItems(items));
   }
 
   @override
@@ -1717,10 +1717,9 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
 
   /// Jellyfin's `/Shows/NextUp` returns the *next* (unwatched) episode for each
   /// series, so those rows have no `LastPlayedDate` of their own and a Series DTO
-  /// doesn't expose an aggregated one. To let the Continue Watching shelf
-  /// interleave Next Up with resume items by recency, stamp each Next Up episode
-  /// with its series' last-watched date, read from the most recently played
-  /// episode of that series.
+  /// doesn't expose an aggregated one. Stamp each Next Up episode with its
+  /// series' last-watched date so the dedicated shelf can be sorted by recency
+  /// across servers.
   Future<List<MediaItem>> _attachSeriesLastPlayed(List<MediaItem> nextUp) async {
     final pendingSeriesIds = <String>{
       for (final item in nextUp)
@@ -1746,7 +1745,7 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
       'SortBy': 'DatePlayed',
       'SortOrder': 'Descending',
       'Fields': _queueFields,
-      'Limit': _continueWatchingSeriesLookback.toString(),
+      'Limit': _nextUpSeriesLookback.toString(),
       'EnableImages': 'false',
       'EnableTotalRecordCount': 'false',
     });
@@ -1768,45 +1767,6 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
         else
           item,
     ];
-  }
-
-  /// Merge Jellyfin's two continue-watching sources into one recency-ordered
-  /// shelf. Resume items are deduped first so an in-progress episode wins over
-  /// the same series' Next Up entry, then the combined list is ordered by
-  /// [MediaItem.recencySortKey] (matching `DataAggregationService`) before the
-  /// limit is applied — so a recent Next Up episode is never starved by a long
-  /// run of older resume items.
-  List<MediaItem> _mergeContinueWatchingAndNextUp({
-    required List<MediaItem> resume,
-    required List<MediaItem> nextUp,
-    required int? limit,
-  }) {
-    if (limit != null && limit <= 0) return const [];
-
-    final merged = <MediaItem>[];
-    final seenIds = <String>{};
-    final seenSeriesIds = <String>{};
-
-    // Resume first: first-wins dedup makes an in-progress episode beat the same
-    // series' Next Up entry.
-    for (final item in [...resume, ...nextUp]) {
-      if (!seenIds.add(item.id)) continue;
-      final seriesId = item.kind == MediaKind.episode ? item.grandparentId : null;
-      if (seriesId != null && !seenSeriesIds.add(seriesId)) continue;
-      merged.add(item);
-    }
-
-    // Stable sort by recency: Dart's List.sort isn't stable, so break ties on the
-    // insertion index to keep ordering deterministic across refreshes.
-    final ordered = [for (var i = 0; i < merged.length; i++) (item: merged[i], index: i)];
-    ordered.sort((a, b) {
-      final byRecency = b.item.recencySortKey.compareTo(a.item.recencySortKey);
-      return byRecency != 0 ? byRecency : a.index.compareTo(b.index);
-    });
-    final result = [for (final entry in ordered) entry.item];
-
-    if (limit != null && result.length > limit) return result.sublist(0, limit);
-    return result;
   }
 
   /// GET [path], optionally under a hub-surface transport policy ([retry]):

--- a/lib/services/jellyfin_client/parts/browse.dart
+++ b/lib/services/jellyfin_client/parts/browse.dart
@@ -531,17 +531,42 @@ mixin _JellyfinBrowseMethods on MediaServerCacheMixin {
       if (cached is Map<String, dynamic>) return _mapItem(cached);
       return null;
     }
+    final scopedServerId = ServerId(cacheServerId);
+    JellyfinApiCache? resolveItemCache() {
+      try {
+        final resolved = cache;
+        return resolved is JellyfinApiCache ? resolved : null;
+      } catch (_) {
+        return null;
+      }
+    }
+
+    final itemCacheAtStart = resolveItemCache();
+    final itemFetch = itemCacheAtStart?.beginItemFetch(scopedServerId, id);
     try {
       final response = await _http.get(endpoint, queryParameters: {'Fields': _detailFields});
       throwIfHttpError(response);
       final data = response.data;
       if (data is! Map<String, dynamic>) return null;
+      var effectiveData = data;
       try {
-        await cache.put(ServerId(cacheServerId), endpoint, data);
+        final itemCache = itemCacheAtStart ?? resolveItemCache();
+        if (itemCache != null && itemFetch != null) {
+          effectiveData = await itemCache.putFetchedItem(
+            serverId: scopedServerId,
+            itemId: id,
+            endpoint: endpoint,
+            favoriteGenerationAtStart: itemFetch.favoriteGeneration,
+            fetchSequence: itemFetch.fetchSequence,
+            data: data,
+          );
+        } else {
+          await cache.put(scopedServerId, endpoint, data);
+        }
       } catch (e, st) {
         appLogger.w('JellyfinClient.fetchItem cache write failed', error: e, stackTrace: st);
       }
-      return _mapItem(data);
+      return _mapItem(effectiveData);
     } on MediaServerHttpException catch (e) {
       if (e.statusCode == 404) return null;
       rethrow;

--- a/lib/services/jellyfin_client/parts/watch_state.dart
+++ b/lib/services/jellyfin_client/parts/watch_state.dart
@@ -54,5 +54,14 @@ mixin _JellyfinWatchStateMethods on MediaServerCacheMixin {
         ? await _http.post(path, queryParameters: {'userId': connection.userId})
         : await _http.delete(path, queryParameters: {'userId': connection.userId});
     throwIfHttpError(response);
+    try {
+      await (cache as JellyfinApiCache).applyFavoriteState(
+        serverId: ServerId(cacheServerId),
+        itemId: itemId,
+        isFavorite: isFavorite,
+      );
+    } catch (e, st) {
+      appLogger.w('Jellyfin favorite cache update failed', error: e, stackTrace: st);
+    }
   }
 }

--- a/lib/utils/favorite_state_notifier.dart
+++ b/lib/utils/favorite_state_notifier.dart
@@ -1,0 +1,56 @@
+import '../media/ids.dart';
+import '../media/media_item.dart';
+import 'app_logger.dart';
+import 'base_notifier.dart';
+import 'global_key_utils.dart';
+
+class FavoriteStateEvent {
+  final String itemId;
+  final String globalKey;
+  final ServerId serverId;
+  final String cacheServerId;
+  final bool isFavorite;
+
+  FavoriteStateEvent({
+    required this.itemId,
+    required this.serverId,
+    required this.cacheServerId,
+    required this.isFavorite,
+  }) : globalKey = buildGlobalKey(serverId, itemId);
+
+  String get stateKey => cacheServerId.isNotEmpty && cacheServerId != serverId.value
+      ? buildGlobalKey(ServerId(cacheServerId), itemId)
+      : globalKey;
+
+  @override
+  String toString() => 'FavoriteStateEvent($globalKey, isFavorite: $isFavorite)';
+}
+
+/// Session-wide favorite updates for server-backed media.
+///
+/// The server remains authoritative, while this notifier bridges the interval
+/// before lists are fetched again. It also survives the detail route being
+/// dismissed while a favorite request is still in flight.
+class FavoriteStateNotifier extends BaseNotifier<FavoriteStateEvent> {
+  static final FavoriteStateNotifier _instance = FavoriteStateNotifier._internal();
+
+  factory FavoriteStateNotifier() => _instance;
+
+  FavoriteStateNotifier._internal();
+
+  void notifyFavorite({required MediaItem item, required String cacheServerId, required bool isFavorite}) {
+    final serverId = serverIdOrNull(item.serverId);
+    if (serverId == null) {
+      appLogger.w('FavoriteStateNotifier: missing serverId for ${item.id}, skipping favorite event');
+      return;
+    }
+    final event = FavoriteStateEvent(
+      itemId: item.id,
+      serverId: serverId,
+      cacheServerId: cacheServerId,
+      isFavorite: isFavorite,
+    );
+    appLogger.d('FavoriteStateNotifier: $event');
+    notify(event);
+  }
+}

--- a/lib/widgets/catalog_source_logo.dart
+++ b/lib/widgets/catalog_source_logo.dart
@@ -26,6 +26,7 @@ class CatalogSourceLogo extends StatelessWidget {
           CatalogSourceId.trakt => 'assets/trakt_circlemark.svg',
           CatalogSourceId.mal => 'assets/mal_mark.svg',
           CatalogSourceId.seerr => 'assets/seerr_mark.svg',
+          CatalogSourceId.jellyfin => 'assets/jellyfin_icon.svg',
         };
     final color = IconTheme.of(context).color ?? Theme.of(context).colorScheme.onSurface;
     return SvgPicture.asset(

--- a/lib/widgets/media_context_menu.dart
+++ b/lib/widgets/media_context_menu.dart
@@ -28,6 +28,7 @@ import '../utils/quality_preset_labels.dart';
 import '../utils/media_version_resolver.dart';
 import '../utils/global_key_utils.dart';
 import '../providers/download_provider.dart';
+import '../providers/catalog_sources_provider.dart';
 import '../providers/multi_server_provider.dart';
 import '../providers/offline_mode_provider.dart';
 import '../profiles/active_profile_provider.dart';
@@ -38,6 +39,7 @@ import '../utils/library_refresh_notifier.dart';
 import '../utils/media_navigation_helper.dart';
 import '../utils/media_server_http_client.dart';
 import '../utils/music_navigation.dart';
+import '../utils/favorite_state_notifier.dart';
 import '../utils/platform_detector.dart';
 import '../utils/snackbar_helper.dart';
 import '../utils/dialogs.dart';
@@ -98,6 +100,7 @@ class MediaContextMenu extends StatefulWidget {
   /// [_itemAsMediaItem] / [_itemAsPlaylist] helpers.
   final Object item;
   final void Function(MediaItem source)? onRefresh;
+  final ValueChanged<bool>? onFavoriteChanged;
   final VoidCallback? onRemoveFromContinueWatching;
   final VoidCallback? onListRefresh; // For refreshing list after deletion
   final VoidCallback? onTap;
@@ -119,6 +122,7 @@ class MediaContextMenu extends StatefulWidget {
     super.key,
     required this.item,
     this.onRefresh,
+    this.onFavoriteChanged,
     this.onRemoveFromContinueWatching,
     this.onListRefresh,
     this.onTap,
@@ -134,7 +138,13 @@ class MediaContextMenu extends StatefulWidget {
 }
 
 class MediaContextMenuState extends State<MediaContextMenu> {
+  static const Duration _favoriteOverrideLifetime = Duration(seconds: 15);
+
   Offset? _tapPosition;
+  String? _favoriteOverrideItemKey;
+  bool? _favoriteOverride;
+  Timer? _favoriteOverrideTimer;
+  int _favoriteOverrideGeneration = 0;
 
   bool _openedFromKeyboard = false;
   bool _isContextMenuOpen = false;
@@ -144,6 +154,40 @@ class MediaContextMenuState extends State<MediaContextMenu> {
   void _notifyRefresh(MediaItem source) {
     if (!mounted) return;
     widget.onRefresh?.call(source);
+  }
+
+  void _notifyFavoriteChanged(
+    MediaItem source,
+    bool favorite, {
+    required String cacheServerId,
+    required CatalogSourcesProvider? catalogSources,
+  }) {
+    final updated = source.copyWith(isFavorite: favorite);
+    FavoriteStateNotifier().notifyFavorite(item: updated, cacheServerId: cacheServerId, isFavorite: favorite);
+    catalogSources?.notifyServerFavoriteChanged(updated);
+    if (!mounted) return;
+    _setFavoriteOverride(source.globalKey, favorite);
+    widget.onFavoriteChanged?.call(favorite);
+    _notifyRefresh(updated);
+  }
+
+  void _setFavoriteOverride(String itemKey, bool favorite) {
+    final generation = ++_favoriteOverrideGeneration;
+    _favoriteOverrideItemKey = itemKey;
+    _favoriteOverride = favorite;
+    _favoriteOverrideTimer?.cancel();
+    _favoriteOverrideTimer = Timer(_favoriteOverrideLifetime, () {
+      if (!mounted || generation != _favoriteOverrideGeneration) return;
+      setState(_clearFavoriteOverride);
+    });
+  }
+
+  void _clearFavoriteOverride() {
+    _favoriteOverrideGeneration++;
+    _favoriteOverrideTimer?.cancel();
+    _favoriteOverrideTimer = null;
+    _favoriteOverrideItemKey = null;
+    _favoriteOverride = null;
   }
 
   void _notifyListRefresh() {
@@ -156,7 +200,39 @@ class MediaContextMenuState extends State<MediaContextMenu> {
   /// Returns `null` for playlists.
   MediaItem? get _mediaItem {
     final item = widget.item;
-    return item is MediaItem ? context.readFreshWatchState(item) : null;
+    if (item is! MediaItem) return null;
+    final fresh = context.readFreshWatchState(item);
+    final favorite = _favoriteOverride;
+    if (_favoriteOverrideItemKey == fresh.globalKey && favorite != null) {
+      if (fresh.isFavorite == favorite) {
+        _clearFavoriteOverride();
+        return fresh;
+      }
+      return fresh.copyWith(isFavorite: favorite);
+    }
+    return fresh;
+  }
+
+  @override
+  void didUpdateWidget(covariant MediaContextMenu oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final oldItem = oldWidget.item;
+    final newItem = widget.item;
+    if (oldItem is! MediaItem || newItem is! MediaItem || oldItem.globalKey != newItem.globalKey) {
+      _clearFavoriteOverride();
+      return;
+    }
+    // Drop the local bridge once the parent supplies the settled server state.
+    if (_favoriteOverride != null && newItem.isFavorite == _favoriteOverride) {
+      _clearFavoriteOverride();
+    }
+  }
+
+  @override
+  void dispose() {
+    _favoriteOverrideTimer?.cancel();
+    _favoriteOverrideTimer = null;
+    super.dispose();
   }
 
   /// The widget's [item] cast as a [MediaPlaylist]. Returns `null` for media items.
@@ -256,6 +332,10 @@ class MediaContextMenuState extends State<MediaContextMenu> {
     final itemServerOnline =
         _itemServerId != null && multiServerProvider.serverManager.isClientOnline(ServerId(_itemServerId!));
     final canRemoveFromContinueWatching = mediaClient?.capabilities.continueWatchingRemoval ?? false;
+    final canFavorite =
+        itemServerOnline &&
+        (mediaKind == MediaKind.movie || mediaKind == MediaKind.show) &&
+        (mediaClient?.capabilities.userFavorites ?? false);
     final canEditMetadata = isAdmin && supportsMetadataEdit(mediaClient, mediaKind);
 
     final menuActions = <_MenuAction>[];
@@ -384,6 +464,17 @@ class MediaContextMenuState extends State<MediaContextMenu> {
 
       if (widget.isInContinueWatching && isVideoKind) {
         menuActions.add(_MenuAction(value: 'details', icon: Symbols.info_rounded, label: t.mediaMenu.viewDetails));
+      }
+
+      if (canFavorite) {
+        final isFavorite = mediaItem.isFavorite == true;
+        menuActions.add(
+          _MenuAction(
+            value: 'toggle_favorite',
+            icon: isFavorite ? Symbols.favorite_rounded : Symbols.favorite_border_rounded,
+            label: isFavorite ? t.mediaMenu.removeFromFavorites : t.mediaMenu.addToFavorites,
+          ),
+        );
       }
 
       if (isVideoKind) {
@@ -672,6 +763,25 @@ class MediaContextMenuState extends State<MediaContextMenu> {
           didNavigate = true;
           if (context.mounted) {
             await navigateToMediaItemDetails(context, mediaItem!, onRefresh: _notifyRefresh);
+          }
+          break;
+
+        case 'toggle_favorite':
+          final item = mediaItem;
+          final client = mediaClient;
+          if (item == null || client == null || !client.capabilities.userFavorites) break;
+          final favorite = item.isFavorite != true;
+          if (!mounted) break;
+          final catalogSources = Provider.of<CatalogSourcesProvider?>(this.context, listen: false);
+          try {
+            await client.setFavorite(item, favorite);
+            _notifyFavoriteChanged(item, favorite, cacheServerId: client.cacheServerId, catalogSources: catalogSources);
+            if (context.mounted) {
+              showSuccessSnackBar(context, favorite ? t.mediaMenu.addedToFavorites : t.mediaMenu.removedFromFavorites);
+            }
+          } catch (e) {
+            appLogger.w('Failed to update server favorite', error: e);
+            if (context.mounted) showErrorSnackBar(context, t.mediaMenu.favoritesUpdateFailed);
           }
           break;
 
@@ -1312,6 +1422,7 @@ class MediaContextMenuState extends State<MediaContextMenu> {
 
   Future<void> _showRatingSheet(BuildContext context, MediaItem item, MediaServerClient client) async {
     if (!mounted) return;
+    final catalogSources = Provider.of<CatalogSourcesProvider?>(this.context, listen: false);
     // Presented from the menu's own context so a screen-level
     // OverlaySheetHost is found (see _showContextMenu).
     await OverlaySheetController.showAdaptive(
@@ -1322,7 +1433,8 @@ class MediaContextMenuState extends State<MediaContextMenu> {
         item: item,
         serverClient: client,
         onServerRatingChanged: (_) => _notifyRefresh(item),
-        onServerFavoriteChanged: (_) => _notifyRefresh(item),
+        onServerFavoriteChanged: (favorite) =>
+            _notifyFavoriteChanged(item, favorite, cacheServerId: client.cacheServerId, catalogSources: catalogSources),
       ),
     );
   }

--- a/test/providers/catalog_sources_provider_test.dart
+++ b/test/providers/catalog_sources_provider_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/models/catalog/catalog_item.dart';
 import 'package:plezy/providers/catalog_sources_provider.dart';
 import 'package:plezy/providers/hidden_libraries_provider.dart';
@@ -10,6 +12,7 @@ import 'package:plezy/services/data_aggregation_service.dart';
 import 'package:plezy/services/multi_server_manager.dart';
 
 import '../test_helpers/backend_client_fixtures.dart';
+import '../test_helpers/media_items.dart';
 import '../test_helpers/prefs.dart';
 
 void main() {
@@ -41,6 +44,18 @@ void main() {
 
     await sources.setActiveSource(CatalogSourceId.jellyfin);
     expect(sources.activeSource?.id, CatalogSourceId.jellyfin);
+
+    var favoriteNotifications = 0;
+    sources.activeSource!.watchlistChanges.addListener(() => favoriteNotifications++);
+    sources.notifyServerFavoriteChanged(
+      testMediaItem(
+        id: 'movie-1',
+        backend: MediaBackend.jellyfin,
+        kind: MediaKind.movie,
+        serverId: client.serverId.value,
+      ),
+    );
+    expect(favoriteNotifications, 1);
 
     manager.debugMarkAuthErrorForTesting(client.serverId);
     await pumpEventQueue();

--- a/test/providers/catalog_sources_provider_test.dart
+++ b/test/providers/catalog_sources_provider_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/models/catalog/catalog_item.dart';
+import 'package:plezy/providers/catalog_sources_provider.dart';
+import 'package:plezy/providers/hidden_libraries_provider.dart';
+import 'package:plezy/providers/multi_server_provider.dart';
+import 'package:plezy/providers/seerr_account_provider.dart';
+import 'package:plezy/providers/trackers_provider.dart';
+import 'package:plezy/providers/trakt_account_provider.dart';
+import 'package:plezy/services/data_aggregation_service.dart';
+import 'package:plezy/services/multi_server_manager.dart';
+
+import '../test_helpers/backend_client_fixtures.dart';
+import '../test_helpers/prefs.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(resetSharedPreferencesForTest);
+
+  test('Jellyfin Favorites disappears offline and restores the persisted source preference', () async {
+    final client = testJellyfinClient();
+    final manager = MultiServerManager()..debugRegisterJellyfinClientForTesting(client);
+    final multiServer = MultiServerProvider(manager, DataAggregationService(manager));
+    final trakt = TraktAccountProvider();
+    final trackers = TrackersProvider();
+    final seerr = SeerrAccountProvider();
+    final hiddenLibraries = HiddenLibrariesProvider();
+    final sources = CatalogSourcesProvider();
+    addTearDown(sources.dispose);
+    addTearDown(seerr.dispose);
+    addTearDown(trackers.dispose);
+    addTearDown(trakt.dispose);
+    addTearDown(hiddenLibraries.dispose);
+    addTearDown(multiServer.dispose);
+    addTearDown(manager.dispose);
+
+    await sources.onActiveProfileChanged('profile-1');
+    await hiddenLibraries.ensureInitialized();
+    sources.update(trakt, trackers, seerr, multiServer, hiddenLibraries);
+    expect(sources.connectedSources.map((source) => source.id), [CatalogSourceId.jellyfin]);
+
+    await sources.setActiveSource(CatalogSourceId.jellyfin);
+    expect(sources.activeSource?.id, CatalogSourceId.jellyfin);
+
+    manager.debugMarkAuthErrorForTesting(client.serverId);
+    await pumpEventQueue();
+    sources.update(trakt, trackers, seerr, multiServer, hiddenLibraries);
+    expect(sources.hasAnySource, isFalse);
+    expect(sources.activeSource, isNull);
+
+    manager.debugRegisterJellyfinClientForTesting(client);
+    sources.update(trakt, trackers, seerr, multiServer, hiddenLibraries);
+    expect(sources.activeSource?.id, CatalogSourceId.jellyfin);
+  });
+}

--- a/test/providers/discover_provider_test.dart
+++ b/test/providers/discover_provider_test.dart
@@ -57,25 +57,32 @@ MediaHub _hub(
 );
 
 /// Counting fake — the provider's fetch-cost policy is the contract under
-/// test: a durable watch event must cost exactly one on-deck call and zero hub
-/// refetches, progress zero calls, an order change zero calls, and a hidden-set
-/// change one full pass.
+/// test: a durable watch event must cost one call to each playback shelf and
+/// zero hub refetches, progress zero calls, an order change zero calls, and a
+/// hidden-set change one full pass.
 class _FakeAggregationService extends DataAggregationService {
   _FakeAggregationService(super.serverManager);
 
   int onDeckCalls = 0;
+  int nextUpCalls = 0;
   int hubCalls = 0;
   Set<String>? lastOnDeckServerIds;
+  Set<String>? lastNextUpServerIds;
   Set<String>? lastHubsServerIds;
   Set<String>? onDeckSucceededServerIds;
+  Set<String>? nextUpSucceededServerIds;
   Set<String>? hubSucceededServerIds;
   Set<String> onDeckCancelledServerIds = const {};
+  Set<String> nextUpCancelledServerIds = const {};
   Set<String> hubCancelledServerIds = const {};
   List<MediaItem> Function() onDeckResult = () => const [];
+  List<MediaItem> Function() nextUpResult = () => const [];
   List<MediaHub> Function() hubsResult = () => const [];
   Future<void>? onDeckGate;
+  Future<void>? nextUpGate;
   Future<void>? hubGate;
   Completer<void>? onDeckStarted;
+  Completer<void>? nextUpStarted;
   Completer<void>? hubStarted;
 
   @override
@@ -95,6 +102,26 @@ class _FakeAggregationService extends DataAggregationService {
       items: limit != null && items.length > limit ? items.sublist(0, limit) : items,
       succeededServerIds: onDeckSucceededServerIds ?? serverIds ?? const {'server_1'},
       cancelledServerIds: onDeckCancelledServerIds,
+    );
+  }
+
+  @override
+  Future<NextUpAggregationResult> getNextUpFromAllServers({
+    int? limit,
+    Set<String>? hiddenLibraryKeys,
+    Set<String>? serverIds,
+  }) async {
+    nextUpCalls++;
+    lastNextUpServerIds = serverIds;
+    final started = nextUpStarted;
+    if (started != null && !started.isCompleted) started.complete();
+    final gate = nextUpGate;
+    if (gate != null) await gate;
+    final items = nextUpResult();
+    return (
+      items: limit != null && items.length > limit ? items.sublist(0, limit) : items,
+      succeededServerIds: nextUpSucceededServerIds ?? serverIds ?? const {'server_1'},
+      cancelledServerIds: nextUpCancelledServerIds,
     );
   }
 
@@ -206,7 +233,45 @@ void main() {
     expect(provider.areHubsLoading, isFalse);
     expect(provider.errorMessage, isNull);
     expect(aggregation.onDeckCalls, 2);
+    expect(aggregation.nextUpCalls, 2);
     expect(aggregation.hubCalls, 2);
+  });
+
+  test('load prepends one synthetic Next Up hub and keeps the system shelf on-deck only', () async {
+    aggregation.onDeckResult = () => [_item('resume')];
+    aggregation.nextUpResult = () => [_item('next')];
+    aggregation.hubsResult = () => [_hub('recommendation')];
+
+    await provider.load();
+    await pumpEventQueue();
+
+    expect(provider.hubs.map((hub) => hub.id), ['home.nextup', 'recommendation']);
+    expect(provider.hubs.first.identifier, 'home.nextup');
+    expect(provider.hubs.first.items.map((item) => item.id), ['next']);
+    expect(shelfSyncs.last.map((item) => item.id), ['resume']);
+  });
+
+  test('slow Next Up enrichment does not hold completed recommendation hubs', () async {
+    final nextUpGate = Completer<void>();
+    aggregation.nextUpGate = nextUpGate.future;
+    aggregation.nextUpStarted = Completer<void>();
+    aggregation.onDeckResult = () => [_item('resume')];
+    aggregation.nextUpResult = () => [_item('next')];
+    aggregation.hubsResult = () => [_hub('recommendation')];
+
+    var loadCompleted = false;
+    final load = provider.load().whenComplete(() => loadCompleted = true);
+    await aggregation.nextUpStarted!.future;
+    await pumpEventQueue();
+
+    expect(provider.areHubsLoading, isFalse);
+    expect(provider.hubs.map((hub) => hub.id), ['recommendation']);
+    expect(loadCompleted, isFalse);
+
+    nextUpGate.complete();
+    await load;
+
+    expect(provider.hubs.map((hub) => hub.id), ['home.nextup', 'recommendation']);
   });
 
   test('a failed in-flight pass still runs one coalesced trailing pass', () async {
@@ -282,24 +347,49 @@ void main() {
     expect(provider.hubs.map((h) => h.id), ['keep']);
   });
 
-  test('watched and unwatched events refresh continue watching only', () async {
+  test('watched and unwatched events refresh both playback shelves only', () async {
     aggregation.onDeckResult = () => [_item('ep-1', parentId: 'season-1')];
+    aggregation.nextUpResult = () => [_item('next-1', grandparentId: 'show-1')];
     aggregation.hubsResult = () => [_hub('hub-1')];
     await provider.load();
     final onDeckCallsBefore = aggregation.onDeckCalls;
+    final nextUpCallsBefore = aggregation.nextUpCalls;
     final hubCallsBefore = aggregation.hubCalls;
 
     WatchStateNotifier().notifyWatched(item: _item('ep-1', parentId: 'season-1'));
     await pumpEventQueue();
 
     expect(aggregation.onDeckCalls, onDeckCallsBefore + 1);
+    expect(aggregation.nextUpCalls, nextUpCallsBefore + 1);
     expect(aggregation.hubCalls, hubCallsBefore);
 
     WatchStateNotifier().notifyWatched(item: _item('ep-1', parentId: 'season-1'), isNowWatched: false);
     await pumpEventQueue();
 
     expect(aggregation.onDeckCalls, onDeckCallsBefore + 2);
+    expect(aggregation.nextUpCalls, nextUpCallsBefore + 2);
     expect(aggregation.hubCalls, hubCallsBefore);
+  });
+
+  test('watching a Next Up item refreshes and replaces the synthetic hub', () async {
+    final next = _item('next-1', grandparentId: 'show-1');
+    aggregation.onDeckResult = () => [_item('resume')];
+    aggregation.nextUpResult = () => [next];
+    aggregation.hubsResult = () => [_hub('hub-1')];
+    await provider.load();
+    final onDeckCallsBefore = aggregation.onDeckCalls;
+    final nextUpCallsBefore = aggregation.nextUpCalls;
+    final hubCallsBefore = aggregation.hubCalls;
+    aggregation.nextUpResult = () => [_item('next-2', grandparentId: 'show-2')];
+
+    WatchStateNotifier().notifyWatched(item: next);
+    await pumpEventQueue();
+
+    expect(aggregation.onDeckCalls, onDeckCallsBefore + 1);
+    expect(aggregation.nextUpCalls, nextUpCallsBefore + 1);
+    expect(aggregation.hubCalls, hubCallsBefore);
+    expect(provider.hubs.first.id, 'home.nextup');
+    expect(provider.hubs.first.items.map((item) => item.id), ['next-2']);
   });
 
   test('sub-threshold progress patches the row without refetching', () async {
@@ -310,6 +400,7 @@ void main() {
     await pumpEventQueue();
     shelfSyncs.clear();
     final onDeckCallsBefore = aggregation.onDeckCalls;
+    final nextUpCallsBefore = aggregation.nextUpCalls;
     final hubCallsBefore = aggregation.hubCalls;
 
     WatchStateNotifier().notifyProgress(item: playing, viewOffset: 30000, duration: 100000);
@@ -320,6 +411,7 @@ void main() {
     expect(provider.onDeck, hasLength(DiscoverProvider.continueWatchingPreviewLimit));
     expect(provider.hasMoreContinueWatching, isTrue);
     expect(aggregation.onDeckCalls, onDeckCallsBefore);
+    expect(aggregation.nextUpCalls, nextUpCallsBefore);
     expect(aggregation.hubCalls, hubCallsBefore);
     expect(shelfSyncs, hasLength(1));
     expect(shelfSyncs.single.first.viewOffsetMs, 30000);
@@ -455,6 +547,20 @@ void main() {
     expect(provider.onDeck.map((i) => i.id), ['a']);
     expect(provider.errorMessage, isNull);
     expect(provider.isLoading, isFalse);
+  });
+
+  test('playback refresh preserves prior Next Up when every server fetch fails', () async {
+    aggregation.onDeckResult = () => [_item('resume')];
+    aggregation.nextUpResult = () => [_item('next-stale')];
+    await provider.load();
+    expect(provider.hubs.first.items.map((item) => item.id), ['next-stale']);
+
+    aggregation.nextUpSucceededServerIds = const {};
+    aggregation.nextUpResult = () => const [];
+    await provider.refreshContinueWatching();
+
+    expect(provider.hubs.first.id, 'home.nextup');
+    expect(provider.hubs.first.items.map((item) => item.id), ['next-stale']);
   });
 
   test('load failure surfaces the error and ends both loading states', () async {
@@ -662,14 +768,18 @@ void main() {
     final generationBefore = provider.loadGeneration;
 
     aggregation.onDeckResult = () => [_item('b', serverId: 'server_2')];
+    aggregation.nextUpResult = () => [_item('next-b', serverId: 'server_2')];
     aggregation.hubsResult = () => [_hub('hub-2', serverId: 'server_2')];
     await provider.syncToOnlineServers({'server_1', 'server_2'});
 
     // The fetch fanned out to the new server only…
     expect(aggregation.lastOnDeckServerIds, {'server_2'});
+    expect(aggregation.lastNextUpServerIds, {'server_2'});
     expect(aggregation.lastHubsServerIds, {'server_2'});
     // …and merged into the loaded state instead of replacing it.
     expect(provider.onDeck.map((i) => i.id), containsAll(['a', 'b']));
+    expect(provider.hubs.first.id, 'home.nextup');
+    expect(provider.hubs.first.items.map((i) => i.id), ['next-b']);
     expect(provider.hubs.map((h) => h.id), containsAll(['hub-1', 'hub-2']));
     // A delta behaves like a background refresh: no hero carousel reset.
     expect(provider.loadGeneration, generationBefore);

--- a/test/providers/explore_provider_test.dart
+++ b/test/providers/explore_provider_test.dart
@@ -82,6 +82,19 @@ class _FakeSource implements CatalogSource {
   void dispose() => watchlist.dispose();
 }
 
+class _FakeMutableSource extends _FakeSource implements MutableCatalogRowSource {
+  _FakeMutableSource() : super(CatalogSourceId.jellyfin, rows: const [CatalogRowId.favorites]);
+
+  @override
+  bool get supportsWatchlist => false;
+
+  @override
+  CatalogRowId get mutableRow => CatalogRowId.favorites;
+
+  @override
+  Listenable get mutableRowChanges => watchlist;
+}
+
 /// Drives [activeSource] directly; the real provider derives it from the
 /// account providers, which is irrelevant to ExploreProvider's contract.
 class _FakeSourcesProvider extends CatalogSourcesProvider {
@@ -165,6 +178,40 @@ void main() {
       explore.ensureFresh();
       await _pumpMicrotasks();
       expect(source.fetches[CatalogRowId.watchlist], refetchesBefore + 1);
+    });
+
+    test('Jellyfin favorite mutation refreshes the Favorites row', () async {
+      final source = _FakeMutableSource();
+      addTearDown(source.dispose);
+
+      sources.setActive(source);
+      await _pumpMicrotasks();
+      expect(explore.state, ExploreLoadState.loaded);
+      expect(source.fetches[CatalogRowId.favorites], 1);
+
+      source.watchlist.notify();
+      explore.ensureFresh();
+      await _pumpMicrotasks();
+
+      expect(source.fetches[CatalogRowId.favorites], 2);
+      expect(explore.rowHubs.single.row, CatalogRowId.favorites);
+    });
+
+    test('full load cancels a redundant pending Favorites refresh', () async {
+      final source = _FakeMutableSource();
+      addTearDown(source.dispose);
+
+      sources.setActive(source);
+      await _pumpMicrotasks();
+      expect(source.fetches[CatalogRowId.favorites], 1);
+
+      source.watchlist.notify();
+      await explore.load();
+      expect(source.fetches[CatalogRowId.favorites], 2);
+
+      await Future<void>.delayed(const Duration(milliseconds: 1100));
+      await _pumpMicrotasks();
+      expect(source.fetches[CatalogRowId.favorites], 2);
     });
   });
 }

--- a/test/providers/watch_state_store_test.dart
+++ b/test/providers/watch_state_store_test.dart
@@ -1,14 +1,25 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plezy/media/ids.dart';
 import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
 
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/providers/watch_state_store.dart';
+import 'package:plezy/utils/favorite_state_notifier.dart';
 import 'package:plezy/utils/watch_state_notifier.dart';
 import '../test_helpers/media_items.dart';
 
 Future<void> _emit(WatchStateEvent event) async {
   WatchStateNotifier().notify(event);
+  await Future<void>.delayed(Duration.zero);
+}
+
+Future<void> _emitFavorite(MediaItem item, bool favorite, {String? cacheServerId}) async {
+  FavoriteStateNotifier().notifyFavorite(
+    item: item,
+    cacheServerId: cacheServerId ?? item.serverId ?? '',
+    isFavorite: favorite,
+  );
   await Future<void>.delayed(Duration.zero);
 }
 
@@ -44,6 +55,145 @@ final _episode = testMediaItem(
 );
 
 void main() {
+  test('favorite events patch the exact item across the session', () async {
+    final store = WatchStateStore();
+    addTearDown(store.dispose);
+    final movie = testMediaItem(
+      id: 'movie-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      serverId: 'jf-machine',
+      isFavorite: false,
+    );
+
+    await _emitFavorite(movie, true);
+
+    expect(store.favoriteForItem(movie), isTrue);
+    expect(store.apply(movie).isFavorite, isTrue);
+  });
+
+  test('a show favorite does not leak through the episode parent chain', () async {
+    final store = WatchStateStore();
+    addTearDown(store.dispose);
+    final show = testMediaItem(
+      id: 'show-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.show,
+      serverId: 'jf-machine',
+    );
+
+    await _emitFavorite(show, true);
+
+    expect(store.apply(show).isFavorite, isTrue);
+    expect(store.favoriteForItem(_episode), isNull);
+    expect(store.apply(_episode).isFavorite, _episode.isFavorite);
+  });
+
+  test('a scoped favorite completion cannot leak into a newly active Jellyfin user', () async {
+    final store = WatchStateStore();
+    addTearDown(store.dispose);
+    store
+      ..setActiveProfileId('profile-b')
+      ..setActiveClientScopesByServer({'jf-machine': 'jf-machine/user-b'});
+    final movie = testMediaItem(
+      id: 'movie-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      serverId: 'jf-machine',
+      isFavorite: false,
+    );
+
+    // Models user A's request completing after the session remounted for B.
+    await _emitFavorite(movie, true, cacheServerId: 'jf-machine/user-a');
+
+    expect(store.favoriteForItem(movie), isNull);
+    expect(store.apply(movie).isFavorite, isFalse);
+  });
+
+  test('active scoped favorite lookup does not fall back to an unscoped patch', () async {
+    final store = WatchStateStore();
+    addTearDown(store.dispose);
+    store.setActiveClientScopesByServer({'jf-machine': 'jf-machine/user-b'});
+    final movie = testMediaItem(
+      id: 'movie-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      serverId: 'jf-machine',
+      isFavorite: false,
+    );
+
+    await _emitFavorite(movie, true, cacheServerId: 'jf-machine');
+
+    expect(store.favoriteForItem(movie), isNull);
+    expect(store.apply(movie).isFavorite, isFalse);
+  });
+
+  test('favorite patch reconciles when a server snapshot reaches the same state', () async {
+    final store = WatchStateStore();
+    addTearDown(store.dispose);
+    final movie = testMediaItem(
+      id: 'movie-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      serverId: 'jf-machine',
+      isFavorite: false,
+    );
+    await _emitFavorite(movie, true);
+    expect(store.favoriteForGlobalKey(movie.globalKey), isTrue);
+
+    final settled = movie.copyWith(isFavorite: true);
+    expect(store.apply(settled).isFavorite, isTrue);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(store.favoriteForGlobalKey(movie.globalKey), isNull);
+  });
+
+  test('favorite patch expires so a later authoritative snapshot can take over', () async {
+    final store = WatchStateStore(favoritePatchLifetime: const Duration(milliseconds: 20));
+    addTearDown(store.dispose);
+    final movie = testMediaItem(
+      id: 'movie-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      serverId: 'jf-machine',
+      isFavorite: false,
+    );
+
+    await _emitFavorite(movie, true);
+    expect(store.apply(movie).isFavorite, isTrue);
+    await Future<void>.delayed(const Duration(milliseconds: 30));
+
+    expect(store.favoriteForItem(movie), isNull);
+    expect(store.apply(movie).isFavorite, isFalse);
+  });
+
+  testWidgets('favorite expiry notifies an idle listener and reveals the server snapshot', (tester) async {
+    var now = DateTime.utc(2026, 1, 1);
+    final store = WatchStateStore(favoritePatchLifetime: const Duration(milliseconds: 20), favoriteClock: () => now);
+    addTearDown(store.dispose);
+    final movie = testMediaItem(
+      id: 'movie-1',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      serverId: 'jf-machine',
+      isFavorite: false,
+    );
+    FavoriteStateNotifier().notifyFavorite(item: movie, cacheServerId: movie.serverId!, isFavorite: true);
+    await tester.pump();
+
+    var notifications = 0;
+    void listener() => notifications++;
+    store.addListener(listener);
+    expect(store.apply(movie).isFavorite, isTrue);
+
+    now = now.add(const Duration(milliseconds: 21));
+    await tester.pump(const Duration(milliseconds: 21));
+
+    expect(notifications, 1);
+    expect(store.apply(movie).isFavorite, isFalse);
+    store.removeListener(listener);
+  });
+
   test('removed from continue watching does not replace an existing watched patch', () async {
     final provider = WatchStateStore();
     addTearDown(provider.dispose);

--- a/test/screens/explore_screen_test.dart
+++ b/test/screens/explore_screen_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/models/catalog/catalog_item.dart';
 import 'package:plezy/providers/catalog_sources_provider.dart';
@@ -11,6 +13,7 @@ import 'package:plezy/services/catalog/catalog_source.dart';
 import 'package:plezy/services/settings_service.dart';
 import 'package:plezy/theme/mono_theme.dart';
 import 'package:plezy/utils/platform_detector.dart';
+import 'package:plezy/widgets/catalog_source_logo.dart';
 import 'package:provider/provider.dart';
 
 import '../test_helpers/prefs.dart';
@@ -58,6 +61,49 @@ class _FakeCatalogSource implements CatalogSource {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+class _FakeJellyfinFavoritesSource implements CatalogSource, MediaItemCatalogSource {
+  final WatchlistChangeNotifier _changes = WatchlistChangeNotifier();
+
+  @override
+  CatalogSourceId get id => CatalogSourceId.jellyfin;
+
+  @override
+  String get displayName => 'Jellyfin Favorites';
+
+  @override
+  List<CatalogRowId> get supportedRows => const [CatalogRowId.favorites];
+
+  @override
+  bool get supportsExploreSearch => false;
+
+  @override
+  bool get supportsWatchlist => false;
+
+  @override
+  Listenable get watchlistChanges => _changes;
+
+  @override
+  Future<ExploreMediaPage> fetchMediaRow(CatalogRowId row, {int page = 1, int limit = 25}) async {
+    return ExploreMediaPage(
+      items: [
+        MediaItem(
+          id: 'favorite-1',
+          backend: MediaBackend.jellyfin,
+          kind: MediaKind.movie,
+          title: 'Favorite Movie',
+          serverId: 'jellyfin-1',
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() => _changes.dispose();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class _FakeCatalogSourcesProvider extends CatalogSourcesProvider {
   _FakeCatalogSourcesProvider(this.sources);
 
@@ -71,6 +117,7 @@ Future<_FakeCatalogSourcesProvider> _pumpExplore(
   WidgetTester tester, {
   int? traktItemId = 1,
   int? malItemId = 2,
+  bool includeJellyfin = false,
 }) async {
   tester.view.devicePixelRatio = 1;
   tester.view.physicalSize = const Size(1280, 720);
@@ -79,12 +126,14 @@ Future<_FakeCatalogSourcesProvider> _pumpExplore(
 
   final trakt = _FakeCatalogSource(CatalogSourceId.trakt, 'Trakt', traktItemId);
   final mal = _FakeCatalogSource(CatalogSourceId.mal, 'MyAnimeList', malItemId);
-  final sources = _FakeCatalogSourcesProvider([trakt, mal]);
+  final jellyfin = includeJellyfin ? _FakeJellyfinFavoritesSource() : null;
+  final sources = _FakeCatalogSourcesProvider([trakt, mal, ?jellyfin]);
   final explore = ExploreProvider(sources);
   addTearDown(explore.dispose);
   addTearDown(sources.dispose);
   addTearDown(trakt.dispose);
   addTearDown(mal.dispose);
+  if (jellyfin != null) addTearDown(jellyfin.dispose);
 
   await tester.pumpWidget(
     TranslationProvider(
@@ -164,5 +213,28 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pump();
     expect(FocusManager.instance.primaryFocus?.debugLabel, 'tv_browse_rail');
+  });
+
+  testWidgets('Jellyfin Favorites is selectable, uses its logo, and omits catalog search', (tester) async {
+    final sources = await _pumpExplore(tester, includeJellyfin: true);
+    tester.state<ExploreScreenState>(find.byType(ExploreScreen)).focusActiveTabIfReady();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.select);
+    await tester.pumpAndSettle();
+
+    expect(sources.activeSource?.id, CatalogSourceId.jellyfin);
+    expect(find.text('Jellyfin Favorites'), findsOneWidget);
+    expect(find.text('Favorite Movie'), findsWidgets);
+    expect(find.byTooltip(t.common.search), findsNothing);
+    expect(
+      find.byWidgetPredicate((widget) => widget is CatalogSourceLogo && widget.id == CatalogSourceId.jellyfin),
+      findsWidgets,
+    );
   });
 }

--- a/test/screens/media_detail_screen_test.dart
+++ b/test/screens/media_detail_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:plezy/media/media_item.dart';
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/media/media_server_client.dart';
 import 'package:plezy/media/server_capabilities.dart';
+import 'package:plezy/providers/catalog_sources_provider.dart';
 import 'package:plezy/providers/download_provider.dart';
 import 'package:plezy/providers/multi_server_provider.dart';
 import 'package:plezy/providers/watch_state_store.dart';
@@ -170,6 +171,255 @@ void main() {
     await tester.pump();
 
     expect(tester.widget<AnimatedOpacity>(revealGate).opacity, 1);
+  });
+
+  testWidgets('Jellyfin movie detail toggles the server favorite action', (tester) async {
+    await SettingsService.getInstance();
+    tester.view.physicalSize = const Size(1280, 720);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final movie = testMediaItem(
+      id: 'favorite_movie',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      title: 'Favorite Movie',
+      serverId: 'server_1',
+      isFavorite: false,
+    );
+    final client = _FakeMediaServerClient(show: movie, childrenByParent: const {});
+    final manager = MultiServerManager()..debugRegisterClientForTesting(client);
+    final provider = MultiServerProvider(manager, DataAggregationService(manager));
+    addTearDown(provider.dispose);
+    addTearDown(manager.dispose);
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: ChangeNotifierProvider<MultiServerProvider>.value(
+          value: provider,
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(child: MediaDetailScreen(metadata: movie)),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.byTooltip(t.mediaMenu.addToFavorites), findsOneWidget);
+    await tester.tap(find.byTooltip(t.mediaMenu.addToFavorites));
+    await tester.pumpAndSettle();
+
+    expect(client.favoriteValues, [true]);
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsOneWidget);
+
+    await tester.tap(find.byTooltip(t.mediaMenu.removeFromFavorites));
+    await tester.pumpAndSettle();
+
+    expect(client.favoriteValues, [true, false]);
+    expect(find.byTooltip(t.mediaMenu.addToFavorites), findsOneWidget);
+  });
+
+  testWidgets('favorite override survives stale metadata refreshes before and after completion', (tester) async {
+    await SettingsService.getInstance();
+    final movie = testMediaItem(
+      id: 'favorite_refresh_race',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      title: 'Favorite Refresh Race',
+      serverId: 'server_1',
+      isFavorite: false,
+    );
+    final favoriteGate = Completer<void>();
+    final staleBeforeCompletion = Completer<MediaItem?>();
+    final staleAfterCompletion = Completer<MediaItem?>();
+    final client = _FakeMediaServerClient(
+      show: movie,
+      childrenByParent: const {},
+      favoriteGate: favoriteGate,
+      itemFetchResults: [Future.value(movie), staleBeforeCompletion.future, staleAfterCompletion.future],
+    );
+    final manager = MultiServerManager()..debugRegisterClientForTesting(client);
+    final provider = MultiServerProvider(manager, DataAggregationService(manager));
+    addTearDown(provider.dispose);
+    addTearDown(manager.dispose);
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: ChangeNotifierProvider<MultiServerProvider>.value(
+          value: provider,
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(child: MediaDetailScreen(metadata: movie)),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    await tester.tap(find.byTooltip(t.mediaMenu.addToFavorites));
+    await tester.pump();
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsOneWidget);
+
+    WatchStateNotifier().notifyWatched(item: movie);
+    await tester.pump();
+    expect(client.fetchItemWithOnDeckCalls, 2);
+    staleBeforeCompletion.complete(movie);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsOneWidget);
+
+    favoriteGate.complete();
+    await tester.pump();
+    await tester.pump();
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsOneWidget);
+
+    WatchStateNotifier().notifyWatched(item: movie);
+    await tester.pump();
+    expect(client.fetchItemWithOnDeckCalls, 3);
+    staleAfterCompletion.complete(movie);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsOneWidget);
+
+    // The bridge is bounded: if later server snapshots continue to disagree,
+    // the server eventually becomes authoritative again.
+    await tester.pump(const Duration(seconds: 16));
+    expect(find.byTooltip(t.mediaMenu.addToFavorites), findsOneWidget);
+  });
+
+  testWidgets('favorite detail action is hidden for unsupported clients and item types', (tester) async {
+    await SettingsService.getInstance();
+
+    Future<void> pumpDetail(MediaItem item, _FakeMediaServerClient client) async {
+      final manager = MultiServerManager()..debugRegisterClientForTesting(client);
+      final provider = MultiServerProvider(manager, DataAggregationService(manager));
+      addTearDown(provider.dispose);
+      addTearDown(manager.dispose);
+      await tester.pumpWidget(
+        TranslationProvider(
+          child: ChangeNotifierProvider<MultiServerProvider>.value(
+            value: provider,
+            child: MaterialApp(
+              theme: monoTheme(dark: true),
+              home: withProfileNavigationScope(child: MediaDetailScreen(metadata: item)),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+    }
+
+    final episode = testMediaItem(
+      id: 'favorite_episode',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.episode,
+      title: 'Favorite Episode',
+      serverId: 'server_1',
+    );
+    await pumpDetail(episode, _FakeMediaServerClient(show: episode, childrenByParent: const {}));
+    expect(find.byTooltip(t.mediaMenu.addToFavorites), findsNothing);
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsNothing);
+
+    final plexMovie = testMediaItem(
+      id: 'favorite_plex_movie',
+      backend: MediaBackend.plex,
+      kind: MediaKind.movie,
+      title: 'Plex Movie',
+      serverId: 'server_1',
+    );
+    await pumpDetail(
+      plexMovie,
+      _FakeMediaServerClient(
+        show: plexMovie,
+        childrenByParent: const {},
+        clientBackend: MediaBackend.plex,
+        clientCapabilities: ServerCapabilities.plex,
+      ),
+    );
+    expect(find.byTooltip(t.mediaMenu.addToFavorites), findsNothing);
+    expect(find.byTooltip(t.mediaMenu.removeFromFavorites), findsNothing);
+  });
+
+  testWidgets('favorite completion after Back updates Explore and the originating session item', (tester) async {
+    await SettingsService.getInstance();
+    final movie = testMediaItem(
+      id: 'favorite_dispose',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      title: 'Favorite Dispose',
+      serverId: 'server_1',
+    );
+    final favoriteGate = Completer<void>();
+    final client = _FakeMediaServerClient(show: movie, childrenByParent: const {}, favoriteGate: favoriteGate);
+    final manager = MultiServerManager()..debugRegisterClientForTesting(client);
+    final provider = MultiServerProvider(manager, DataAggregationService(manager));
+    final catalogSources = _RecordingCatalogSourcesProvider();
+    final watchStateStore = WatchStateStore();
+    final navigatorKey = GlobalKey<NavigatorState>();
+    addTearDown(provider.dispose);
+    addTearDown(manager.dispose);
+    addTearDown(catalogSources.dispose);
+    addTearDown(watchStateStore.dispose);
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: provider),
+            ChangeNotifierProvider<CatalogSourcesProvider>.value(value: catalogSources),
+            ChangeNotifierProvider<WatchStateStore>.value(value: watchStateStore),
+          ],
+          child: withProfileNavigationScope(
+            child: MaterialApp(
+              navigatorKey: navigatorKey,
+              theme: monoTheme(dark: true),
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => Column(
+                    children: [
+                      Consumer<WatchStateStore>(
+                        builder: (_, store, _) => Text('favorite: ${store.apply(movie).isFavorite == true}'),
+                      ),
+                      FilledButton(
+                        onPressed: () => Navigator.push(context, mediaDetailRoute(metadata: movie)),
+                        child: const Text('Open details'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(find.text('favorite: false'), findsOneWidget);
+    await tester.tap(find.text('Open details'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip(t.mediaMenu.addToFavorites));
+    await tester.pump();
+    expect(client.favoriteValues, [true]);
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    expect(find.text('favorite: false'), findsOneWidget);
+
+    favoriteGate.complete();
+    await tester.pump();
+    await tester.pump();
+
+    expect(catalogSources.favoriteChanges.map((item) => item.id), ['favorite_dispose']);
+    expect(find.text('favorite: true'), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('TV detail shows Rotten Tomatoes rating badge in metadata line', (tester) async {
@@ -704,10 +954,11 @@ void main() {
       String? initialSeasonId,
       int? initialSeasonIndex,
       String? initialEpisodeId,
+      Size viewSize = const Size(1100, 2400),
     }) async {
       TvDetectionService.debugSetAppleTVOverride(false);
       await SettingsService.getInstance();
-      tester.view.physicalSize = const Size(1100, 2400);
+      tester.view.physicalSize = viewSize;
       tester.view.devicePixelRatio = 1;
       addTearDown(tester.view.resetPhysicalSize);
       addTearDown(tester.view.resetDevicePixelRatio);
@@ -805,6 +1056,17 @@ void main() {
       expect(overviewFocus, findsOneWidget);
       return tester.widget<Focus>(overviewFocus).focusNode!;
     }
+
+    testWidgets('compact detail keeps Watched and More ahead of the direct Favorite action', (tester) async {
+      final show = buildShow();
+
+      await pumpPhoneDetail(tester, singleSeasonClient(show), show, viewSize: const Size(300, 1200));
+
+      final actionBar = tester.widget<FocusableActionBar>(find.byType(FocusableActionBar));
+      final actionLabels = actionBar.actions.map((action) => action.debugLabel);
+      expect(actionLabels, containsAll(<String>['detail_play', 'detail_watched', 'detail_more']));
+      expect(actionLabels, isNot(contains('detail_favorite')));
+    });
 
     testWidgets('overflowing overview DOWN reaches the first real section', (tester) async {
       const summary =
@@ -1031,7 +1293,13 @@ class _FakeMediaServerClient implements MediaServerClient {
   final Map<String, Future<List<MediaItem>>> childrenPageFutures;
   final Map<String, Object> childrenPageErrors;
   final Future<List<MediaItem>>? pendingPlayableDescendants;
+  final MediaBackend clientBackend;
+  final ServerCapabilities clientCapabilities;
+  final Completer<void>? favoriteGate;
+  final List<Future<MediaItem?>> itemFetchResults;
   final childrenPageCalls = <({String parentId, int? start, int? size})>[];
+  final favoriteValues = <bool>[];
+  int fetchItemWithOnDeckCalls = 0;
 
   _FakeMediaServerClient({
     required this.show,
@@ -1039,6 +1307,10 @@ class _FakeMediaServerClient implements MediaServerClient {
     this.childrenPageFutures = const {},
     this.childrenPageErrors = const {},
     this.pendingPlayableDescendants,
+    this.clientBackend = MediaBackend.jellyfin,
+    this.clientCapabilities = ServerCapabilities.jellyfin,
+    this.favoriteGate,
+    this.itemFetchResults = const [],
   });
 
   @override
@@ -1048,14 +1320,16 @@ class _FakeMediaServerClient implements MediaServerClient {
   String? get serverName => 'Server';
 
   @override
-  MediaBackend get backend => MediaBackend.jellyfin;
+  MediaBackend get backend => clientBackend;
 
   @override
-  ServerCapabilities get capabilities => ServerCapabilities.jellyfin;
+  ServerCapabilities get capabilities => clientCapabilities;
 
   @override
   Future<({MediaItem? item, MediaItem? onDeckEpisode})> fetchItemWithOnDeck(String id) async {
-    return (item: show, onDeckEpisode: null);
+    final call = fetchItemWithOnDeckCalls++;
+    final item = call < itemFetchResults.length ? await itemFetchResults[call] : show;
+    return (item: item, onDeckEpisode: null);
   }
 
   @override
@@ -1093,5 +1367,23 @@ class _FakeMediaServerClient implements MediaServerClient {
   Future<List<MediaHub>> fetchRelatedHubs(String id, {int count = 10}) async => const [];
 
   @override
+  Future<void> setFavorite(MediaItem item, bool isFavorite) async {
+    favoriteValues.add(isFavorite);
+    await favoriteGate?.future;
+  }
+
+  @override
+  void close() {}
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingCatalogSourcesProvider extends CatalogSourcesProvider {
+  final favoriteChanges = <MediaItem>[];
+
+  @override
+  void notifyServerFavoriteChanged(MediaItem item) {
+    favoriteChanges.add(item);
+  }
 }

--- a/test/services/catalog/jellyfin_favorites_catalog_source_test.dart
+++ b/test/services/catalog/jellyfin_favorites_catalog_source_test.dart
@@ -1,0 +1,136 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/media/catalog_item_ref.dart';
+import 'package:plezy/services/catalog/catalog_source.dart';
+import 'package:plezy/services/catalog/jellyfin_favorites_catalog_source.dart';
+import 'package:plezy/services/jellyfin_client.dart';
+
+import '../../test_helpers/backend_client_fixtures.dart';
+
+void main() {
+  setUpAll(() => LocaleSettings.setLocaleSync(AppLocale.en));
+
+  test('pages favorite videos across Jellyfin servers while retaining server identity', () async {
+    final requests = <String, List<Uri>>{'server-a': [], 'server-b': []};
+
+    JellyfinClient buildClient(String machineId, List<Map<String, Object?>> items) {
+      return testJellyfinClient(
+        connection: testJellyfinConnection(machineId: machineId, serverName: machineId),
+        httpClient: MockClient((request) async {
+          requests[machineId]!.add(request.url);
+          if (request.url.path == '/Users/user-1/Views') {
+            return http.Response(
+              jsonEncode({
+                'Items': [
+                  {'Id': 'lib-$machineId', 'Name': 'Videos', 'CollectionType': 'movies', 'Type': 'CollectionFolder'},
+                ],
+              }),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          if (request.url.path == '/Items') {
+            final limit = int.parse(request.url.queryParameters['Limit']!);
+            return http.Response(
+              jsonEncode({'Items': items.take(limit).toList(), 'TotalRecordCount': items.length}),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('not found', 404);
+        }),
+      );
+    }
+
+    final first = buildClient('server-a', [
+      {'Id': 'alpha', 'Type': 'Movie', 'Name': 'Alpha'},
+      {'Id': 'delta', 'Type': 'Series', 'Name': 'Delta'},
+      {'Id': 'song', 'Type': 'Audio', 'Name': 'Song'},
+    ]);
+    final second = buildClient('server-b', [
+      {'Id': 'bravo', 'Type': 'Movie', 'Name': 'Bravo'},
+      {'Id': 'charlie', 'Type': 'Episode', 'Name': 'Charlie'},
+    ]);
+    addTearDown(first.close);
+    addTearDown(second.close);
+
+    final source = JellyfinFavoritesCatalogSource([first, second]);
+    addTearDown(source.dispose);
+
+    final pageOne = await source.fetchMediaRow(CatalogRowId.favorites, page: 1, limit: 2);
+    final pageTwo = await source.fetchMediaRow(CatalogRowId.favorites, page: 2, limit: 2);
+
+    expect(pageOne.items.map((item) => item.title), ['Alpha', 'Bravo']);
+    expect(pageOne.hasMore, isTrue);
+    expect(pageTwo.items.map((item) => item.title), ['Charlie', 'Delta']);
+    expect(pageTwo.hasMore, isFalse);
+    expect([...pageOne.items, ...pageTwo.items].map((item) => item.serverId), [
+      'server-a',
+      'server-b',
+      'server-b',
+      'server-a',
+    ]);
+    expect([...pageOne.items, ...pageTwo.items].every((item) => !item.isCatalogItem), isTrue);
+
+    for (final serverRequests in requests.values) {
+      final itemRequests = serverRequests.where((uri) => uri.path == '/Items').toList();
+      expect(itemRequests.map((uri) => uri.queryParameters['Limit']), ['2', '4']);
+      for (final uri in itemRequests) {
+        expect(uri.queryParameters['ParentId'], startsWith('lib-server-'));
+        expect(uri.queryParameters['StartIndex'], '0');
+        expect(uri.queryParameters['Filters'], 'IsFavorite');
+        expect(uri.queryParameters['SortBy'], 'SortName');
+        expect(uri.queryParameters['SortOrder'], 'Ascending');
+      }
+    }
+  });
+
+  test('excludes libraries hidden by the active profile', () async {
+    final requestedLibraryIds = <String>[];
+    final client = testJellyfinClient(
+      connection: testJellyfinConnection(machineId: 'server-1'),
+      httpClient: MockClient((request) async {
+        if (request.url.path == '/Users/user-1/Views') {
+          return http.Response(
+            jsonEncode({
+              'Items': [
+                {'Id': 'visible', 'Name': 'Visible', 'CollectionType': 'movies', 'Type': 'CollectionFolder'},
+                {'Id': 'hidden', 'Name': 'Hidden', 'CollectionType': 'movies', 'Type': 'CollectionFolder'},
+              ],
+            }),
+            200,
+            headers: const {'content-type': 'application/json'},
+          );
+        }
+        if (request.url.path == '/Items') {
+          final libraryId = request.url.queryParameters['ParentId']!;
+          requestedLibraryIds.add(libraryId);
+          return http.Response(
+            jsonEncode({
+              'Items': [
+                {'Id': 'favorite-$libraryId', 'Type': 'Movie', 'Name': 'Favorite from $libraryId'},
+              ],
+              'TotalRecordCount': 1,
+            }),
+            200,
+            headers: const {'content-type': 'application/json'},
+          );
+        }
+        return http.Response('not found', 404);
+      }),
+    );
+    addTearDown(client.close);
+
+    final source = JellyfinFavoritesCatalogSource([client], hiddenLibraryKeys: const {'server-1:hidden'});
+    addTearDown(source.dispose);
+
+    final page = await source.fetchMediaRow(CatalogRowId.favorites);
+
+    expect(page.items.map((item) => item.title), ['Favorite from visible']);
+    expect(requestedLibraryIds, ['visible']);
+  });
+}

--- a/test/services/data_aggregation_bridge_test.dart
+++ b/test/services/data_aggregation_bridge_test.dart
@@ -9,6 +9,7 @@ import 'package:plezy/connection/connection.dart';
 import 'package:plezy/database/app_database.dart';
 import 'package:plezy/exceptions/media_server_exceptions.dart';
 import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/media/media_library.dart';
 import 'package:plezy/media/media_server_client.dart';
@@ -19,8 +20,10 @@ import 'package:plezy/services/multi_server_manager.dart';
 import 'package:plezy/services/plex_api_cache.dart';
 import 'package:plezy/services/plex_client.dart';
 import 'package:plezy/services/settings_service.dart';
+import 'package:plezy/utils/external_ids.dart';
 
 import '../test_helpers/backend_client_fixtures.dart';
+import '../test_helpers/media_items.dart';
 import '../test_helpers/prefs.dart';
 
 JellyfinConnection _conn() => testJellyfinConnection(
@@ -60,6 +63,34 @@ class _LibrariesClient implements MediaServerClient {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+class _NextUpClient implements MediaServerClient {
+  _NextUpClient(String id, this.items) : serverId = ServerId(id);
+
+  @override
+  final ServerId serverId;
+
+  @override
+  String get serverName => serverId;
+
+  final List<MediaItem> items;
+  int? lastCount;
+
+  @override
+  Future<List<MediaItem>> fetchNextUp({int? count = 20}) async {
+    lastCount = count;
+    return items;
+  }
+
+  @override
+  Future<ExternalIds> fetchExternalIds(String id) async => const ExternalIds();
+
+  @override
+  void close() {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 /// Smoke tests for the surviving cross-server aggregation surface on
 /// [DataAggregationService]. Single-server passthroughs were removed in
 /// favour of `context.tryGetMediaClientForServer(...).<method>()`; what's
@@ -91,11 +122,14 @@ void main() {
       expect(result.succeededServerIds, isEmpty);
     });
 
-    test('searchAcrossServers and getOnDeckFromAllServers return empty when no clients', () async {
+    test('search and both playback aggregations return empty when no clients', () async {
       expect(await service.searchAcrossServers('hello'), isEmpty);
       final onDeck = await service.getOnDeckFromAllServers();
       expect(onDeck.items, isEmpty);
       expect(onDeck.succeededServerIds, isEmpty);
+      final nextUp = await service.getNextUpFromAllServers();
+      expect(nextUp.items, isEmpty);
+      expect(nextUp.succeededServerIds, isEmpty);
     });
 
     test('classifies cancelled per-server failures apart from settled ones', () async {
@@ -238,6 +272,83 @@ void main() {
       expect(result.succeededServerIds, {'plex-1'});
       expect(captured.single.path, '/hubs');
       expect(captured.single.queryParameters['count'], '21');
+    });
+
+    test('getNextUpFromAllServers filters, sorts, and deduplicates across servers', () async {
+      MediaItem episode({
+        required String id,
+        required String serverId,
+        required int lastViewedAt,
+        required String libraryId,
+        String? guid,
+        String showTitle = 'Show',
+      }) => testMediaItem(
+        id: id,
+        backend: MediaBackend.plex,
+        kind: MediaKind.episode,
+        title: id,
+        guid: guid,
+        grandparentId: '$serverId-$showTitle',
+        grandparentTitle: showTitle,
+        lastViewedAt: lastViewedAt,
+        libraryId: libraryId,
+        serverId: serverId,
+      );
+
+      final first = _NextUpClient('first', [
+        episode(id: 'hidden', serverId: 'first', lastViewedAt: 400, libraryId: 'hidden'),
+        episode(
+          id: 'duplicate-old',
+          serverId: 'first',
+          lastViewedAt: 100,
+          libraryId: 'shows',
+          guid: 'plex://episode/shared',
+          showTitle: 'Shared Show',
+        ),
+      ]);
+      final second = _NextUpClient('second', [
+        episode(
+          id: 'duplicate-new',
+          serverId: 'second',
+          lastViewedAt: 300,
+          libraryId: 'shows',
+          guid: 'plex://episode/shared',
+          showTitle: 'Shared Show',
+        ),
+        episode(id: 'unique', serverId: 'second', lastViewedAt: 200, libraryId: 'shows', showTitle: 'Unique Show'),
+      ]);
+      manager.debugRegisterClientForTesting(first);
+      manager.debugRegisterClientForTesting(second);
+
+      final result = await service.getNextUpFromAllServers(limit: 10, hiddenLibraryKeys: {'first:hidden'});
+
+      expect(result.items.map((item) => item.id), ['duplicate-new', 'unique']);
+      expect(result.succeededServerIds, {'first', 'second'});
+      expect(first.lastCount, 10);
+      expect(second.lastCount, 10);
+    });
+
+    test('backends without Next Up use the default empty implementation', () async {
+      var requests = 0;
+      final client = PlexClient.forTesting(
+        config: PlexConfig(
+          baseUrl: 'https://plex.example.com',
+          token: 'token',
+          clientIdentifier: 'client-id',
+          product: 'Plezy',
+          version: 'test',
+        ),
+        serverId: ServerId('plex-1'),
+        serverName: 'Plex',
+        httpClient: MockClient((_) async {
+          requests++;
+          return http.Response('unexpected request', 500);
+        }),
+      );
+      addTearDown(client.close);
+
+      expect(await client.fetchNextUp(), isEmpty);
+      expect(requests, 0);
     });
 
     test('getOnDeckFromAllServers filters hidden Plex continue-watching libraries', () async {

--- a/test/services/jellyfin_api_cache_test.dart
+++ b/test/services/jellyfin_api_cache_test.dart
@@ -1,13 +1,19 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:plezy/media/ids.dart';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:plezy/database/app_database.dart';
+import 'package:plezy/exceptions/media_server_exceptions.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/services/credential_vault.dart';
 import 'package:plezy/services/jellyfin_api_cache.dart';
 
+import '../test_helpers/backend_client_fixtures.dart';
 import '../test_helpers/prefs.dart';
 
 void main() {
@@ -353,6 +359,359 @@ void main() {
       for (final row in rows) {
         expect((jsonDecode(row.data)['UserData'] as Map)['Played'], isFalse);
       }
+    });
+  });
+
+  group('applyFavoriteState', () {
+    test('concurrent favorite and watch-state patches preserve both fields', () async {
+      const scopeId = 'jf-machine/user-a';
+      await putItemRow(
+        serverId: ServerId(scopeId),
+        userId: 'user-a',
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false, 'Played': false, 'PlayCount': 0},
+        },
+        pinned: true,
+      );
+      final start = Completer<void>();
+
+      final watchPatch = () async {
+        await start.future;
+        await cache.applyWatchState(serverId: ServerId(scopeId), itemId: 'item-1', isWatched: true);
+      }();
+      final favoritePatch = () async {
+        await start.future;
+        await cache.applyFavoriteState(serverId: ServerId(scopeId), itemId: 'item-1', isFavorite: true);
+      }();
+      start.complete();
+      await Future.wait([watchPatch, favoritePatch]);
+
+      final row = await db.select(db.apiCache).getSingle();
+      final userData = jsonDecode(row.data)['UserData'] as Map<String, dynamic>;
+      expect(userData['Played'], isTrue);
+      expect(userData['IsFavorite'], isTrue);
+      expect(row.pinned, isTrue);
+    });
+
+    test('fetch commit ordering accepts older-first and ignores an uncommitted newer fetch', () async {
+      final serverId = ServerId('jf-machine/user-a');
+      const orderedItemId = 'ordered-item';
+      const orderedEndpoint = '/Users/user-a/Items/$orderedItemId';
+      final older = cache.beginItemFetch(serverId, orderedItemId);
+      final newer = cache.beginItemFetch(serverId, orderedItemId);
+
+      await cache.putFetchedItem(
+        serverId: serverId,
+        itemId: orderedItemId,
+        endpoint: orderedEndpoint,
+        favoriteGenerationAtStart: older.favoriteGeneration,
+        fetchSequence: older.fetchSequence,
+        data: {
+          ...jellyfinItem(id: orderedItemId),
+          'UserData': {'IsFavorite': true},
+        },
+      );
+      await cache.putFetchedItem(
+        serverId: serverId,
+        itemId: orderedItemId,
+        endpoint: orderedEndpoint,
+        favoriteGenerationAtStart: newer.favoriteGeneration,
+        fetchSequence: newer.fetchSequence,
+        data: {
+          ...jellyfinItem(id: orderedItemId),
+          'UserData': {'IsFavorite': false},
+        },
+      );
+
+      var cached = await cache.get(serverId, orderedEndpoint);
+      expect((cached!['UserData'] as Map)['IsFavorite'], isFalse);
+
+      const failedNewerItemId = 'failed-newer-item';
+      const failedNewerEndpoint = '/Users/user-a/Items/$failedNewerItemId';
+      final usableOlder = cache.beginItemFetch(serverId, failedNewerItemId);
+      cache.beginItemFetch(serverId, failedNewerItemId); // This newer request fails before committing.
+      await cache.putFetchedItem(
+        serverId: serverId,
+        itemId: failedNewerItemId,
+        endpoint: failedNewerEndpoint,
+        favoriteGenerationAtStart: usableOlder.favoriteGeneration,
+        fetchSequence: usableOlder.fetchSequence,
+        data: {
+          ...jellyfinItem(id: failedNewerItemId),
+          'UserData': {'IsFavorite': true},
+        },
+      );
+
+      cached = await cache.get(serverId, failedNewerEndpoint);
+      expect((cached!['UserData'] as Map)['IsFavorite'], isTrue);
+    });
+
+    test('mutates only the requested user while preserving pinned metadata and other UserData', () async {
+      const machineId = 'jf-machine';
+      await putItemRow(
+        serverId: ServerId('$machineId/user-a'),
+        userId: 'user-a',
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false, 'Played': true},
+        },
+        pinned: true,
+      );
+      await putItemRow(
+        serverId: ServerId('$machineId/user-b'),
+        userId: 'user-b',
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false, 'Played': false},
+        },
+      );
+
+      await cache.applyFavoriteState(serverId: ServerId('$machineId/user-a'), itemId: 'item-1', isFavorite: true);
+
+      var rows = await db.select(db.apiCache).get();
+      var byKey = {for (final row in rows) row.cacheKey: row};
+      final aKey = '$machineId/user-a:/Users/user-a/Items/item-1';
+      final bKey = '$machineId/user-b:/Users/user-b/Items/item-1';
+      var aUserData = jsonDecode(byKey[aKey]!.data)['UserData'] as Map<String, dynamic>;
+      var bUserData = jsonDecode(byKey[bKey]!.data)['UserData'] as Map<String, dynamic>;
+      expect(aUserData['IsFavorite'], isTrue);
+      expect(aUserData['Played'], isTrue);
+      expect(byKey[aKey]!.pinned, isTrue);
+      expect(bUserData['IsFavorite'], isFalse);
+
+      await cache.applyFavoriteState(serverId: ServerId('$machineId/user-a'), itemId: 'item-1', isFavorite: false);
+
+      rows = await db.select(db.apiCache).get();
+      byKey = {for (final row in rows) row.cacheKey: row};
+      aUserData = jsonDecode(byKey[aKey]!.data)['UserData'] as Map<String, dynamic>;
+      bUserData = jsonDecode(byKey[bKey]!.data)['UserData'] as Map<String, dynamic>;
+      expect(aUserData['IsFavorite'], isFalse);
+      expect(byKey[aKey]!.pinned, isTrue);
+      expect(bUserData['IsFavorite'], isFalse);
+    });
+
+    test('bare Jellyfin server id skips ambiguous multi-user cache updates', () async {
+      const machineId = 'jf-machine';
+      for (final userId in ['user-a', 'user-b']) {
+        await putItemRow(
+          serverId: ServerId(machineId),
+          userId: userId,
+          itemId: 'item-1',
+          data: {
+            ...jellyfinItem(id: 'item-1'),
+            'UserData': {'IsFavorite': false},
+          },
+        );
+      }
+
+      await cache.applyFavoriteState(serverId: ServerId(machineId), itemId: 'item-1', isFavorite: true);
+
+      final rows = await db.select(db.apiCache).get();
+      for (final row in rows) {
+        expect((jsonDecode(row.data)['UserData'] as Map)['IsFavorite'], isFalse);
+      }
+    });
+
+    test('malformed cached rows are skipped without throwing', () async {
+      await db
+          .into(db.apiCache)
+          .insert(
+            ApiCacheCompanion.insert(
+              cacheKey: 'jf-machine/user-a:/Users/user-a/Items/item-1',
+              data: 'not json',
+              pinned: const Value(true),
+            ),
+          );
+
+      await cache.applyFavoriteState(serverId: ServerId('jf-machine/user-a'), itemId: 'item-1', isFavorite: true);
+
+      final row = await db.select(db.apiCache).getSingle();
+      expect(row.data, 'not json');
+      expect(row.pinned, isTrue);
+    });
+  });
+
+  group('JellyfinClient favorite cache synchronization', () {
+    test('an older same-generation GET cannot replace a newer committed response', () async {
+      const machineId = 'jf-machine';
+      const userId = 'user-a';
+      const scopeId = '$machineId/$userId';
+      await insertJellyfinConnection(machineId: machineId, userId: userId, serverName: 'Shared JF');
+      await putItemRow(
+        serverId: ServerId(scopeId),
+        userId: userId,
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false},
+        },
+        pinned: true,
+      );
+      await cache.applyFavoriteState(serverId: ServerId(scopeId), itemId: 'item-1', isFavorite: true);
+      final olderStarted = Completer<void>();
+      final releaseOlder = Completer<void>();
+      var getCount = 0;
+      final client = testJellyfinClient(
+        connection: testJellyfinConnection(machineId: machineId, userId: userId),
+        handler: (_) async {
+          getCount++;
+          if (getCount == 1) {
+            olderStarted.complete();
+            await releaseOlder.future;
+            return http.Response(
+              jsonEncode({
+                ...jellyfinItem(id: 'item-1'),
+                'UserData': {'IsFavorite': true},
+              }),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response(
+            jsonEncode({
+              ...jellyfinItem(id: 'item-1'),
+              'UserData': {'IsFavorite': false},
+            }),
+            200,
+            headers: const {'content-type': 'application/json'},
+          );
+        },
+      );
+      addTearDown(() {
+        if (!releaseOlder.isCompleted) releaseOlder.complete();
+        client.close();
+      });
+
+      final olderFetch = client.fetchItem('item-1');
+      await olderStarted.future;
+      final newer = await client.fetchItem('item-1');
+      releaseOlder.complete();
+      final older = await olderFetch;
+
+      final offline = await cache.getMetadata(ServerId(scopeId), 'item-1');
+      expect(newer!.isFavorite, isFalse);
+      expect(older!.isFavorite, isFalse);
+      expect(offline!.isFavorite, isFalse);
+      expect((await db.select(db.apiCache).getSingle()).pinned, isTrue);
+    });
+
+    test('a GET started before the mutation cannot overwrite the favorite cache patch', () async {
+      const machineId = 'jf-machine';
+      const userId = 'user-a';
+      const scopeId = '$machineId/$userId';
+      await insertJellyfinConnection(machineId: machineId, userId: userId, serverName: 'Shared JF');
+      await putItemRow(
+        serverId: ServerId(scopeId),
+        userId: userId,
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false},
+        },
+        pinned: true,
+      );
+      final getStarted = Completer<void>();
+      final releaseGet = Completer<void>();
+      final client = testJellyfinClient(
+        connection: testJellyfinConnection(machineId: machineId, userId: userId),
+        handler: (request) async {
+          if (request.method == 'GET') {
+            getStarted.complete();
+            await releaseGet.future;
+            return http.Response(
+              jsonEncode({
+                ...jellyfinItem(id: 'item-1'),
+                'UserData': {'IsFavorite': false},
+              }),
+              200,
+              headers: const {'content-type': 'application/json'},
+            );
+          }
+          return http.Response('', 204);
+        },
+      );
+      addTearDown(() {
+        if (!releaseGet.isCompleted) releaseGet.complete();
+        client.close();
+      });
+      const item = MediaItem.jellyfin(id: 'item-1', kind: MediaKind.movie, serverId: machineId);
+
+      final staleFetch = client.fetchItem(item.id);
+      await getStarted.future;
+      await client.setFavorite(item, true);
+      releaseGet.complete();
+
+      final fetched = await staleFetch;
+      final offline = await cache.getMetadata(ServerId(scopeId), item.id);
+      expect(fetched!.isFavorite, isTrue);
+      expect(offline!.isFavorite, isTrue);
+      expect((await db.select(db.apiCache).getSingle()).pinned, isTrue);
+    });
+
+    test('successful favorite changes update pinned cached metadata in place', () async {
+      const machineId = 'jf-machine';
+      const userId = 'user-a';
+      await insertJellyfinConnection(machineId: machineId, userId: userId, serverName: 'Shared JF');
+      await putItemRow(
+        serverId: ServerId('$machineId/$userId'),
+        userId: userId,
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false, 'Played': true},
+        },
+        pinned: true,
+      );
+      final client = testJellyfinClient(
+        connection: testJellyfinConnection(machineId: machineId, userId: userId),
+        handler: (_) async => http.Response('', 204),
+      );
+      addTearDown(client.close);
+      const item = MediaItem.jellyfin(id: 'item-1', kind: MediaKind.movie, serverId: machineId);
+
+      await client.setFavorite(item, true);
+
+      var cached = await cache.getMetadata(ServerId('$machineId/$userId'), 'item-1');
+      expect(cached!.isFavorite, isTrue);
+      expect(cached.isWatched, isTrue);
+      expect((await db.select(db.apiCache).getSingle()).pinned, isTrue);
+
+      await client.setFavorite(item, false);
+
+      cached = await cache.getMetadata(ServerId('$machineId/$userId'), 'item-1');
+      expect(cached!.isFavorite, isFalse);
+      expect((await db.select(db.apiCache).getSingle()).pinned, isTrue);
+    });
+
+    test('failed favorite requests leave cached metadata unchanged', () async {
+      const machineId = 'jf-machine';
+      const userId = 'user-a';
+      await putItemRow(
+        serverId: ServerId('$machineId/$userId'),
+        userId: userId,
+        itemId: 'item-1',
+        data: {
+          ...jellyfinItem(id: 'item-1'),
+          'UserData': {'IsFavorite': false},
+        },
+        pinned: true,
+      );
+      final client = testJellyfinClient(
+        connection: testJellyfinConnection(machineId: machineId, userId: userId),
+        handler: (_) async => http.Response('server error', 500),
+      );
+      addTearDown(client.close);
+      const item = MediaItem.jellyfin(id: 'item-1', kind: MediaKind.movie, serverId: machineId);
+
+      await expectLater(client.setFavorite(item, true), throwsA(isA<MediaServerHttpException>()));
+
+      final row = await db.select(db.apiCache).getSingle();
+      expect((jsonDecode(row.data)['UserData'] as Map)['IsFavorite'], isFalse);
+      expect(row.pinned, isTrue);
     });
   });
 }

--- a/test/services/jellyfin_client_failures_test.dart
+++ b/test/services/jellyfin_client_failures_test.dart
@@ -231,16 +231,14 @@ void main() {
   });
 
   group('cancellation vs treat-as-empty', () {
-    // The hub/next-up fetch helpers swallow per-endpoint failures into empty
-    // lists so one broken endpoint doesn't sink a whole row. A *cancelled*
+    // Hub preview helpers can swallow ordinary endpoint failures into empty
+    // lists so one broken preview does not sink a whole screen. A *cancelled*
     // request is different: it means our own client was torn down mid-fetch
-    // and says nothing about the server's content, so it must propagate —
-    // otherwise a disrupted server counts as "succeeded with partial data"
-    // and aborted sign-in fetches flash an empty home screen.
+    // and says nothing about the server's content, so it must propagate.
     MediaServerHttpException cancelled() =>
         MediaServerHttpException(type: MediaServerHttpErrorType.cancelled, message: 'HTTP client is closing');
 
-    test('fetchContinueWatching propagates a cancelled NextUp sub-fetch', () async {
+    test('fetchNextUp propagates a cancelled request', () async {
       final client = _withMock(
         MockClient((req) async {
           if (req.url.path == '/Shows/NextUp') throw cancelled();
@@ -250,14 +248,16 @@ void main() {
       addTearDown(client.close);
 
       await expectLater(
-        client.fetchContinueWatching(),
+        client.fetchNextUp(),
         throwsA(isA<MediaServerHttpException>().having((e) => e.isCancellation, 'isCancellation', isTrue)),
       );
     });
 
-    test('fetchContinueWatching still treats a NextUp server error as empty', () async {
+    test('fetchContinueWatching stays isolated from the Next Up endpoint', () async {
+      final requestedPaths = <String>[];
       final client = _withMock(
         MockClient((req) async {
+          requestedPaths.add(req.url.path);
           if (req.url.path == '/Shows/NextUp') return http.Response('Internal error', 500);
           return http.Response(
             jsonEncode({
@@ -275,6 +275,7 @@ void main() {
       final items = await client.fetchContinueWatching();
 
       expect(items.map((i) => i.id), ['ep-1']);
+      expect(requestedPaths, ['/UserItems/Resume']);
     });
 
     test('fetchMoreHubItems propagates a cancellation and swallows server errors', () async {

--- a/test/services/jellyfin_client_urls_test.dart
+++ b/test/services/jellyfin_client_urls_test.dart
@@ -1306,11 +1306,11 @@ void main() {
     });
 
     test('path-encodes reserved ids for browse and watch-state endpoints', () async {
-      final captured = <Uri>[];
+      final captured = <({String method, Uri url})>[];
       final scoped = JellyfinClient.forTesting(
         connection: _conn(),
         httpClient: MockClient((request) async {
-          captured.add(request.url);
+          captured.add((method: request.method, url: request.url));
           return http.Response(jsonEncode({'Items': <Object>[]}), 200, headers: {'content-type': 'application/json'});
         }),
       );
@@ -1334,13 +1334,20 @@ void main() {
       await scoped.markUnwatched(item);
       await scoped.rate(item, 7);
       await scoped.rate(item, -1);
+      await scoped.setFavorite(item, true);
+      await scoped.setFavorite(item, false);
 
-      final paths = captured.map((u) => u.path).toList();
+      final paths = captured.map((request) => request.url.path).toList();
       expect(paths, contains('/Shows/folder%2Fshow%20%231%3Fx/Seasons'));
       expect(paths, contains('/Shows/folder%2Fshow%20%231%3Fx/Episodes'));
       expect(paths, contains('/UserPlayedItems/folder%2Fitem%20%231%3Fx'));
       expect(paths.where((p) => p == '/UserPlayedItems/folder%2Fitem%20%231%3Fx'), hasLength(2));
       expect(paths.where((p) => p == '/UserItems/folder%2Fitem%20%231%3Fx/Rating'), hasLength(2));
+      final favoriteRequests = captured
+          .where((request) => request.url.path == '/UserFavoriteItems/folder%2Fitem%20%231%3Fx')
+          .toList();
+      expect(favoriteRequests.map((request) => request.method), ['POST', 'DELETE']);
+      expect(favoriteRequests.map((request) => request.url.queryParameters['userId']), ['user-1', 'user-1']);
     });
 
     test('removeFromContinueWatching is unsupported for Jellyfin and does not call the server', () async {

--- a/test/services/jellyfin_client_urls_test.dart
+++ b/test/services/jellyfin_client_urls_test.dart
@@ -1791,6 +1791,38 @@ void main() {
       expect(captured!.queryParameters['ImageTypeLimit'], '3');
     });
 
+    test('fetchLibraryContent sends the Jellyfin favorite filter', () async {
+      Uri? captured;
+      final scoped = JellyfinClient.forTesting(
+        connection: _conn(),
+        httpClient: MockClient((request) async {
+          captured = request.url;
+          return http.Response(
+            jsonEncode({'Items': const [], 'TotalRecordCount': 0}),
+            200,
+            headers: const {'content-type': 'application/json'},
+          );
+        }),
+      );
+      addTearDown(scoped.close);
+
+      await scoped.fetchLibraryContent(
+        'lib-1',
+        const LibraryQuery(
+          limit: 40,
+          sort: LibrarySort(field: 'title', direction: LibrarySortDirection.ascending),
+          favoritesOnly: true,
+        ),
+      );
+
+      expect(captured?.path, '/Items');
+      expect(captured?.queryParameters['ParentId'], 'lib-1');
+      expect(captured?.queryParameters['Limit'], '40');
+      expect(captured?.queryParameters['Filters'], 'IsFavorite');
+      expect(captured?.queryParameters['SortBy'], 'SortName');
+      expect(captured?.queryParameters['SortOrder'], 'Ascending');
+    });
+
     test('music browse and detail requests use leaf-appropriate fields', () async {
       final captured = <Uri>[];
       final scoped = JellyfinClient.forTesting(
@@ -2261,7 +2293,7 @@ void main() {
       expect(extras.markers.last.endTimeOffset, 120000);
     });
 
-    test('fetchContinueWatching merges resume with non-resumable Next Up', () async {
+    test('fetchContinueWatching uses Resume only and fetchNextUp uses non-resumable NextUp', () async {
       final requests = <Uri>[];
       final scoped = JellyfinClient.forTesting(
         connection: _conn(),
@@ -2296,9 +2328,10 @@ void main() {
       );
       addTearDown(scoped.close);
 
-      final items = await scoped.fetchContinueWatching(count: 3);
+      final resumeItems = await scoped.fetchContinueWatching(count: 3);
 
-      expect(items.map((item) => item.id), ['resume-show-1', 'resume-movie-1', 'next-show-2']);
+      expect(resumeItems.map((item) => item.id), ['resume-show-1', 'resume-movie-1']);
+      expect(requests.where((uri) => uri.path == '/Shows/NextUp'), isEmpty);
       final resume = requests.singleWhere((uri) => uri.path == '/UserItems/Resume');
       expect(resume.queryParameters['userId'], 'user-1');
       expect(resume.queryParameters['Limit'], '3');
@@ -2307,6 +2340,10 @@ void main() {
       expect(resume.queryParameters['EnableTotalRecordCount'], 'false');
       expect(resume.queryParameters['EnableImageTypes'], 'Primary,Backdrop,Thumb,Logo');
       expect(resume.queryParameters['ImageTypeLimit'], '3');
+
+      final nextItems = await scoped.fetchNextUp(count: 3);
+
+      expect(nextItems.map((item) => item.id), ['next-show-1', 'next-show-2']);
       final nextUp = requests.singleWhere((uri) => uri.path == '/Shows/NextUp');
       expect(nextUp.queryParameters['userId'], 'user-1');
       expect(nextUp.queryParameters['Limit'], '3');
@@ -2317,7 +2354,7 @@ void main() {
       expect(nextUp.queryParameters.containsKey('NextUpDateCutoff'), isFalse);
     });
 
-    test('fetchContinueWatching orders a recently watched series Next Up above an older resume item', () async {
+    test('fetchNextUp stamps rows with their series last-played date', () async {
       final requests = <Uri>[];
       final scoped = JellyfinClient.forTesting(
         connection: _conn(),
@@ -2371,11 +2408,11 @@ void main() {
       );
       addTearDown(scoped.close);
 
-      final items = await scoped.fetchContinueWatching(count: 10);
+      final items = await scoped.fetchNextUp(count: 10);
 
-      // The Next Up episode inherits its series' recent last-played date, so it
-      // sorts above the older resume item (issue #1266).
-      expect(items.map((item) => item.id), ['next-recent', 'resume-old']);
+      expect(items.map((item) => item.id), ['next-recent']);
+      expect(items.single.lastViewedAt, isNotNull);
+      expect(requests.where((uri) => uri.path == '/UserItems/Resume'), isEmpty);
 
       final lookup = requests.singleWhere((uri) => uri.path == '/Items');
       expect(lookup.queryParameters['userId'], 'user-1');
@@ -2389,7 +2426,7 @@ void main() {
       expect(lookup.queryParameters.containsKey('Filters'), isFalse);
     });
 
-    test('fetchContinueWatching does not let resume items starve Next Up under the limit', () async {
+    test('fetchNextUp has its own limit independent of Resume', () async {
       final scoped = JellyfinClient.forTesting(
         connection: _conn(),
         httpClient: MockClient((req) async {
@@ -2447,17 +2484,17 @@ void main() {
       );
       addTearDown(scoped.close);
 
-      // count equals the number of resume items: the old resume-first merge would
-      // have filled the limit and dropped Next Up entirely.
-      final items = await scoped.fetchContinueWatching(count: 2);
+      final items = await scoped.fetchNextUp(count: 2);
 
-      expect(items.map((item) => item.id), ['next-recent', 'resume-old-2']);
+      expect(items.map((item) => item.id), ['next-recent']);
     });
 
-    test('fetchContinueWatching keeps resume items when Next Up fails', () async {
+    test('fetchContinueWatching is independent when Next Up is unavailable', () async {
+      final requests = <Uri>[];
       final scoped = JellyfinClient.forTesting(
         connection: _conn(),
         httpClient: MockClient((req) async {
+          requests.add(req.url);
           if (req.url.path == '/UserItems/Resume') {
             return http.Response(
               jsonEncode({
@@ -2480,6 +2517,7 @@ void main() {
       final items = await scoped.fetchContinueWatching();
 
       expect(items.map((item) => item.id), ['resume-movie-1']);
+      expect(requests.where((uri) => uri.path == '/Shows/NextUp'), isEmpty);
     });
 
     test('fetchContinueWatching omits Limit when count is null', () async {
@@ -2517,9 +2555,11 @@ void main() {
       );
       addTearDown(scoped.close);
 
-      final items = await scoped.fetchContinueWatching(count: null);
+      final resumeItems = await scoped.fetchContinueWatching(count: null);
+      final nextUpItems = await scoped.fetchNextUp(count: null);
 
-      expect(items.map((item) => item.id), ['resume-movie-1', 'resume-movie-2', 'next-show-1', 'next-show-2']);
+      expect(resumeItems.map((item) => item.id), ['resume-movie-1', 'resume-movie-2']);
+      expect(nextUpItems.map((item) => item.id), ['next-show-1', 'next-show-2']);
       final resume = requests.singleWhere((uri) => uri.path == '/UserItems/Resume');
       expect(resume.queryParameters.containsKey('Limit'), isFalse);
       final nextUp = requests.singleWhere((uri) => uri.path == '/Shows/NextUp');

--- a/test/widgets/media_context_menu_test.dart
+++ b/test/widgets/media_context_menu_test.dart
@@ -29,6 +29,7 @@ import 'package:plezy/profiles/active_profile_provider.dart';
 import 'package:plezy/profiles/plex_home_service.dart';
 import 'package:plezy/profiles/profile_connection_registry.dart';
 import 'package:plezy/profiles/profile_registry.dart';
+import 'package:plezy/providers/catalog_sources_provider.dart';
 import 'package:plezy/providers/download_provider.dart';
 import 'package:plezy/providers/multi_server_provider.dart';
 import 'package:plezy/screens/music/album_detail_screen.dart';
@@ -102,6 +103,144 @@ void main() {
   });
 
   group('MediaContextMenu actions', () {
+    testWidgets('Jellyfin movie context menu adds then removes the item from Favorites', (tester) async {
+      final movie = testMediaItem(
+        id: 'favorite-movie',
+        backend: MediaBackend.jellyfin,
+        kind: MediaKind.movie,
+        title: 'Favorite Movie',
+        serverId: 'srv-1',
+        isFavorite: false,
+      );
+      final harness = await _pumpSiblingMusicMenu(tester, item: movie, relatedItems: const []);
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.mediaMenu.addToFavorites));
+      await tester.pumpAndSettle();
+
+      expect(harness.client.favoriteValues, [true]);
+      expect(find.text(t.mediaMenu.addedToFavorites), findsOneWidget);
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+      expect(find.text(t.mediaMenu.removeFromFavorites), findsOneWidget);
+      await tester.tap(find.text(t.mediaMenu.removeFromFavorites));
+      await tester.pumpAndSettle();
+
+      expect(harness.client.favoriteValues, [true, false]);
+    });
+
+    testWidgets('favorite override expires so a later authoritative state is visible', (tester) async {
+      final movie = testMediaItem(
+        id: 'favorite-expiry',
+        backend: MediaBackend.jellyfin,
+        kind: MediaKind.movie,
+        title: 'Favorite Expiry',
+        serverId: 'srv-1',
+        isFavorite: false,
+      );
+      final harness = await _pumpSiblingMusicMenu(tester, item: movie, relatedItems: const []);
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.mediaMenu.addToFavorites));
+      await tester.pumpAndSettle();
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+      expect(find.text(t.mediaMenu.removeFromFavorites), findsOneWidget);
+      Navigator.of(tester.element(find.text(t.mediaMenu.removeFromFavorites))).pop();
+      await tester.pumpAndSettle();
+
+      await tester.pump(const Duration(seconds: 16));
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.mediaMenu.addToFavorites), findsOneWidget);
+    });
+
+    testWidgets('Jellyfin show context menu removes the item from Favorites', (tester) async {
+      final show = testMediaItem(
+        id: 'favorite-show',
+        backend: MediaBackend.jellyfin,
+        kind: MediaKind.show,
+        title: 'Favorite Show',
+        serverId: 'srv-1',
+        isFavorite: true,
+      );
+      final harness = await _pumpSiblingMusicMenu(tester, item: show, relatedItems: const []);
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.mediaMenu.removeFromFavorites));
+      await tester.pumpAndSettle();
+
+      expect(harness.client.favoriteValues, [false]);
+      expect(find.text(t.mediaMenu.removedFromFavorites), findsOneWidget);
+    });
+
+    testWidgets('favorite action is hidden for Jellyfin episodes', (tester) async {
+      final episode = testMediaItem(
+        id: 'episode-1',
+        backend: MediaBackend.jellyfin,
+        kind: MediaKind.episode,
+        title: 'Episode',
+        serverId: 'srv-1',
+      );
+      final harness = await _pumpSiblingMusicMenu(tester, item: episode, relatedItems: const []);
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.mediaMenu.addToFavorites), findsNothing);
+      expect(find.text(t.mediaMenu.removeFromFavorites), findsNothing);
+    });
+
+    testWidgets('favorite action is hidden when the server does not support favorites', (tester) async {
+      final menuKey = await _pumpPlexMovieMenu(tester, const []);
+
+      menuKey.currentState!.showContextMenu(tester.element(find.text('picker target')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(t.mediaMenu.addToFavorites), findsNothing);
+      expect(find.text(t.mediaMenu.removeFromFavorites), findsNothing);
+    });
+
+    testWidgets('successful favorite mutation invalidates Explore after the menu is disposed', (tester) async {
+      final movie = testMediaItem(
+        id: 'favorite-dispose',
+        backend: MediaBackend.jellyfin,
+        kind: MediaKind.movie,
+        title: 'Favorite Dispose',
+        serverId: 'srv-1',
+      );
+      final catalogSources = _RecordingCatalogSourcesProvider();
+      addTearDown(catalogSources.dispose);
+      final harness = await _pumpSiblingMusicMenu(
+        tester,
+        item: movie,
+        relatedItems: const [],
+        catalogSources: catalogSources,
+      );
+      final favoriteGate = Completer<void>();
+      harness.client.favoriteGate = favoriteGate;
+
+      harness.menuKey.currentState!.showContextMenu(tester.element(find.text('mini-player menu target')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(t.mediaMenu.addToFavorites));
+      await tester.pump();
+      expect(harness.client.favoriteValues, [true]);
+
+      await tester.pumpWidget(const SizedBox());
+      favoriteGate.complete();
+      await tester.pump();
+      await tester.pump();
+
+      expect(catalogSources.favoriteChanges.map((item) => item.id), ['favorite-dispose']);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('audio playlist play and shuffle actions use music playback', (tester) async {
       LocaleSettings.setLocaleSync(AppLocale.en);
       TvDetectionService.debugSetAppleTVOverride(true);
@@ -657,6 +796,8 @@ class _RelatedMusicClient implements MediaServerClient {
   final Map<String, MediaItem> _items;
   final List<MediaItem> albumTracks;
   Completer<void>? albumTracksGate;
+  Completer<void>? favoriteGate;
+  final favoriteValues = <bool>[];
 
   @override
   ServerId get serverId => ServerId('srv-1');
@@ -683,10 +824,25 @@ class _RelatedMusicClient implements MediaServerClient {
   Future<List<MediaItem>> fetchArtistAlbums(MediaItem artist) async => const [];
 
   @override
+  Future<void> setFavorite(MediaItem item, bool isFavorite) async {
+    favoriteValues.add(isFavorite);
+    await favoriteGate?.future;
+  }
+
+  @override
   void close() {}
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingCatalogSourcesProvider extends CatalogSourcesProvider {
+  final favoriteChanges = <MediaItem>[];
+
+  @override
+  void notifyServerFavoriteChanged(MediaItem item) {
+    favoriteChanges.add(item);
+  }
 }
 
 class _SiblingMusicMenuHarness {
@@ -709,6 +865,7 @@ Future<_SiblingMusicMenuHarness> _pumpSiblingMusicMenu(
   WidgetTester tester, {
   required MediaItem item,
   required List<MediaItem> relatedItems,
+  CatalogSourcesProvider? catalogSources,
 }) async {
   resetSharedPreferencesForTest();
   SettingsService.resetForTesting();
@@ -767,6 +924,7 @@ Future<_SiblingMusicMenuHarness> _pumpSiblingMusicMenu(
             ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
             ChangeNotifierProvider<ActiveProfileProvider>.value(value: activeProfileProvider),
             ChangeNotifierProvider<MusicPlaybackService>.value(value: music),
+            if (catalogSources != null) ChangeNotifierProvider<CatalogSourcesProvider>.value(value: catalogSources),
           ],
           child: ProfileNavigationScope(
             navigatorKey: profileNavigatorKey,


### PR DESCRIPTION
## Summary

This changeset adds dedicated Jellyfin discovery surfaces and makes per-user Favorites directly manageable throughout the media UI.

- Adds a standalone Jellyfin Next Up hub to Home directly after Continue Watching.
- Keeps Continue Watching backed only by Jellyfin Resume results so episodes do not appear in both rows.
- Adds Jellyfin Favorites as a selectable Explore catalog alongside Trakt and MyAnimeList.
- Adds movie and show favorite controls to detail pages and right-click or long-press context menus.
- Keeps the discovery and favorite flows independent of playback-source selection.

## Home: Next Up

Jellyfin Resume and Next Up are fetched and presented independently:

- Continue Watching uses the Jellyfin Resume endpoint.
- Next Up uses the Jellyfin Next Up endpoint with non-resumable filtering.
- The neutral media-server interface provides an empty fallback for backends without a dedicated Next Up concept.
- Home aggregation, delta loads, refreshes, watch and deletion events, server changes, and stale-result handling all understand the new hub.
- Hub ordering places Next Up immediately after Continue Watching.

## Explore: Jellyfin Favorites

- Adds a Jellyfin Favorites catalog source backed by the existing server favorite filter.
- Aggregates favorites from eligible Jellyfin libraries while respecting hidden-library settings.
- Registers the source in the catalog selector and persists its enabled state with the other Explore sources.
- Keeps Trakt and MyAnimeList available as independent toggleable sources.
- Refreshes the Favorites row after successful mutations with debounce, coalescing, source-generation guards, and stale-load protection.

## Favorite actions

- Movie and show detail pages expose a heart action on layouts with room for the full action row.
- Compact layouts preserve the existing play, watched, and more-action priority; Favorites remains available from More.
- Right-click and long-press menus expose Add to Favorites or Remove from Favorites with the current state and matching icon.
- Actions appear only when the owning online backend advertises per-user Favorites support.
- Successful mutations update detail views, cards, context menus, and Explore immediately.
- Failed mutations roll back local state and show a localized error.
- Favorite changes made through the existing rating sheet use the same synchronization path.

## Profile and cache safety

- Favorite events are scoped to the exact Jellyfin connection identity, preventing an in-flight request from leaking state across profile switches.
- Optimistic detail, card, and context-menu state reconciles with settled server data and has bounded expiry.
- Cached UserData.IsFavorite is updated in place without evicting pinned offline metadata.
- Cache read-modify-write operations are transactional so favorite and watch-state patches do not overwrite each other.
- Item fetch generations and commit ordering prevent older in-flight responses from replacing newer favorite state.
- The Jellyfin client uses POST to add a favorite and DELETE to remove it, with the active user id included in both requests.

## Validation

- Full test suite: **3,435 tests passed**
- Focused favorite, Explore, provider, request, cache, profile-switch, and race coverage: **195 tests passed**
- Full analysis reports no code issues from this changeset. The repository still has its existing missing mgenware_dart_lints include warning.
- The branch is based directly on upstream main at 0707d4d9.

## Upstream compatibility

The branch remains directly based on upstream main at 0707d4d9 and is mergeable without rebasing.