### PR TITLE
feat: Add Director to Media Info Rows

### DIFF
--- a/lib/i18n/bg.i18n.json
+++ b/lib/i18n/bg.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Трейлъри и екстри",
     "studio": "Студио",
     "rating": "Рейтинг",
+    "director": "Режисьор",
+    "directors": "Режисьори",
     "movie": "Филм",
     "tvShow": "ТВ сериал",
     "minutesLeft": "Остават ${minutes} мин",

--- a/lib/i18n/da.i18n.json
+++ b/lib/i18n/da.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailere og ekstra",
     "studio": "Studie",
     "rating": "Bedømmelse",
+    "director": "Instruktør",
+    "directors": "Instruktører",
     "movie": "Film",
     "tvShow": "TV-serie",
     "minutesLeft": "${minutes} min tilbage",

--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailer & Extras",
     "studio": "Studio",
     "rating": "Altersfreigabe",
+    "director": "Regisseur",
+    "directors": "Regisseure",
     "movie": "Film",
     "tvShow": "Serie",
     "minutesLeft": "${minutes} Min übrig",

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailers & Extras",
     "studio": "Studio",
     "rating": "Rating",
+    "director": "Director",
+    "directors": "Directors",
     "movie": "Movie",
     "tvShow": "TV Show",
     "minutesLeft": "${minutes} min left",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -715,6 +715,8 @@
     "cast": "Reparto",
     "extras": "Tráilers y Extras",
     "studio": "Estudio",
+    "director": "Director",
+    "directors": "Directores",
     "rating": "Calificación",
     "movie": "Película",
     "tvShow": "Serie de TV",

--- a/lib/i18n/fr.i18n.json
+++ b/lib/i18n/fr.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Bandes-annonces et Extras",
     "studio": "Studio",
     "rating": "Évaluation",
+    "director": "Réalisateur",
+    "directors": "Réalisateurs",
     "movie": "Film",
     "tvShow": "Show TV",
     "minutesLeft": "${minutes} min restantes",

--- a/lib/i18n/it.i18n.json
+++ b/lib/i18n/it.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailer ed Extra",
     "studio": "Studio",
     "rating": "Classificazione",
+    "director": "Regista",
+    "directors": "Registi",
     "movie": "Film",
     "tvShow": "Serie TV",
     "minutesLeft": "${minutes} minuti rimanenti",

--- a/lib/i18n/ja.i18n.json
+++ b/lib/i18n/ja.i18n.json
@@ -715,6 +715,8 @@
     "extras": "予告編とエクストラ",
     "studio": "スタジオ",
     "rating": "評価",
+    "director": "監督",
+    "directors": "監督",
     "movie": "映画",
     "tvShow": "テレビ番組",
     "minutesLeft": "残り${minutes}分",

--- a/lib/i18n/ko.i18n.json
+++ b/lib/i18n/ko.i18n.json
@@ -715,6 +715,8 @@
     "extras": "예고편 및 부가영상",
     "studio": "제작사",
     "rating": "연령 등급",
+    "director": "감독",
+    "directors": "감독",
     "movie": "영화",
     "tvShow": "TV 시리즈",
     "minutesLeft": "${minutes}분 남음",

--- a/lib/i18n/nb.i18n.json
+++ b/lib/i18n/nb.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailere og ekstra",
     "studio": "Studio",
     "rating": "Vurdering",
+    "director": "Regissør",
+    "directors": "Regissører",
     "movie": "Film",
     "tvShow": "TV-serie",
     "minutesLeft": "${minutes} min igjen",

--- a/lib/i18n/nl.i18n.json
+++ b/lib/i18n/nl.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailers & Extra's",
     "studio": "Studio",
     "rating": "Leeftijd",
+    "director": "Regisseur",
+    "directors": "Regisseurs",
     "movie": "Film",
     "tvShow": "TV Serie",
     "minutesLeft": "${minutes} min over",

--- a/lib/i18n/pl.i18n.json
+++ b/lib/i18n/pl.i18n.json
@@ -718,6 +718,8 @@
     "extras": "Zwiastuny i dodatki",
     "studio": "Studio",
     "rating": "Ocena",
+    "director": "Reżyser",
+    "directors": "Reżyserzy",
     "movie": "Film",
     "tvShow": "Serial TV",
     "minutesLeft": "${minutes} min pozostało",

--- a/lib/i18n/pt.i18n.json
+++ b/lib/i18n/pt.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailers e Extras",
     "studio": "Estúdio",
     "rating": "Avaliação",
+    "director": "Diretor",
+    "directors": "Diretores",
     "movie": "Filme",
     "tvShow": "Série de TV",
     "minutesLeft": "${minutes} min restantes",

--- a/lib/i18n/ru.i18n.json
+++ b/lib/i18n/ru.i18n.json
@@ -718,6 +718,8 @@
     "extras": "Трейлеры и доп. материалы",
     "studio": "Студия",
     "rating": "Рейтинг",
+    "director": "Режиссёр",
+    "directors": "Режиссёры",
     "movie": "Фильм",
     "tvShow": "Сериал",
     "minutesLeft": "Осталось ${minutes} мин",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 16
-/// Strings: 22851 (1428 per locale)
+/// Strings: 22867 (1429 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_bg.g.dart
+++ b/lib/i18n/strings_bg.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverBg extends TranslationsDiscoverEn {
 	@override String get extras => 'Трейлъри и екстри';
 	@override String get studio => 'Студио';
 	@override String get rating => 'Рейтинг';
+	@override String get director => 'Режисьор';
+	@override String get directors => 'Режисьори';
 	@override String get movie => 'Филм';
 	@override String get tvShow => 'ТВ сериал';
 	@override String minutesLeft({required Object minutes}) => 'Остават ${minutes} мин';
@@ -2793,6 +2795,8 @@ extension on TranslationsBg {
 			'discover.extras' => 'Трейлъри и екстри',
 			'discover.studio' => 'Студио',
 			'discover.rating' => 'Рейтинг',
+			'discover.director' => 'Режисьор',
+			'discover.directors' => 'Режисьори',
 			'discover.movie' => 'Филм',
 			'discover.tvShow' => 'ТВ сериал',
 			'discover.minutesLeft' => ({required Object minutes}) => 'Остават ${minutes} мин',

--- a/lib/i18n/strings_da.g.dart
+++ b/lib/i18n/strings_da.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverDa extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailere og ekstra';
 	@override String get studio => 'Studie';
 	@override String get rating => 'Bedømmelse';
+	@override String get director => 'Instruktør';
+	@override String get directors => 'Instruktører';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'TV-serie';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min tilbage';
@@ -2793,6 +2795,8 @@ extension on TranslationsDa {
 			'discover.extras' => 'Trailere og ekstra',
 			'discover.studio' => 'Studie',
 			'discover.rating' => 'Bedømmelse',
+			'discover.director' => 'Instruktør',
+			'discover.directors' => 'Instruktører',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'TV-serie',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min tilbage',

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverDe extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailer & Extras';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Altersfreigabe';
+	@override String get director => 'Regisseur';
+	@override String get directors => 'Regisseure';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'Serie';
 	@override String minutesLeft({required Object minutes}) => '${minutes} Min übrig';
@@ -2793,6 +2795,8 @@ extension on TranslationsDe {
 			'discover.extras' => 'Trailer & Extras',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Altersfreigabe',
+			'discover.director' => 'Regisseur',
+			'discover.directors' => 'Regisseure',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'Serie',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} Min übrig',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -2193,6 +2193,12 @@ class TranslationsDiscoverEn {
 	/// en: 'Rating'
 	String get rating => 'Rating';
 
+	/// en: 'Director'
+	String get director => 'Director';
+
+	/// en: 'Directors'
+	String get directors => 'Directors';
+
 	/// en: 'Movie'
 	String get movie => 'Movie';
 
@@ -5650,6 +5656,8 @@ extension on Translations {
 			'discover.extras' => 'Trailers & Extras',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Rating',
+			'discover.director' => 'Director',
+			'discover.directors' => 'Directors',
 			'discover.movie' => 'Movie',
 			'discover.tvShow' => 'TV Show',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min left',

--- a/lib/i18n/strings_es.g.dart
+++ b/lib/i18n/strings_es.g.dart
@@ -916,6 +916,8 @@ class _TranslationsDiscoverEs extends TranslationsDiscoverEn {
 	@override String get cast => 'Reparto';
 	@override String get extras => 'Tráilers y Extras';
 	@override String get studio => 'Estudio';
+	@override String get director => 'Director';
+	@override String get directors => 'Directores';
 	@override String get rating => 'Calificación';
 	@override String get movie => 'Película';
 	@override String get tvShow => 'Serie de TV';
@@ -2792,6 +2794,8 @@ extension on TranslationsEs {
 			'discover.cast' => 'Reparto',
 			'discover.extras' => 'Tráilers y Extras',
 			'discover.studio' => 'Estudio',
+			'discover.director' => 'Director',
+			'discover.directors' => 'Directores',
 			'discover.rating' => 'Calificación',
 			'discover.movie' => 'Película',
 			'discover.tvShow' => 'Serie de TV',

--- a/lib/i18n/strings_fr.g.dart
+++ b/lib/i18n/strings_fr.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverFr extends TranslationsDiscoverEn {
 	@override String get extras => 'Bandes-annonces et Extras';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Évaluation';
+	@override String get director => 'Réalisateur';
+	@override String get directors => 'Réalisateurs';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'Show TV';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min restantes';
@@ -2793,6 +2795,8 @@ extension on TranslationsFr {
 			'discover.extras' => 'Bandes-annonces et Extras',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Évaluation',
+			'discover.director' => 'Réalisateur',
+			'discover.directors' => 'Réalisateurs',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'Show TV',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min restantes',

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverIt extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailer ed Extra';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Classificazione';
+	@override String get director => 'Regista';
+	@override String get directors => 'Registi';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'Serie TV';
 	@override String minutesLeft({required Object minutes}) => '${minutes} minuti rimanenti';
@@ -2793,6 +2795,8 @@ extension on TranslationsIt {
 			'discover.extras' => 'Trailer ed Extra',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Classificazione',
+			'discover.director' => 'Regista',
+			'discover.directors' => 'Registi',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'Serie TV',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} minuti rimanenti',

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -916,6 +916,8 @@ class _TranslationsDiscoverJa extends TranslationsDiscoverEn {
 	@override String get extras => '予告編とエクストラ';
 	@override String get studio => 'スタジオ';
 	@override String get rating => '評価';
+	@override String get director => '監督';
+	@override String get directors => '監督';
 	@override String get movie => '映画';
 	@override String get tvShow => 'テレビ番組';
 	@override String minutesLeft({required Object minutes}) => '残り${minutes}分';
@@ -2790,6 +2792,8 @@ extension on TranslationsJa {
 			'discover.extras' => '予告編とエクストラ',
 			'discover.studio' => 'スタジオ',
 			'discover.rating' => '評価',
+			'discover.director' => '監督',
+			'discover.directors' => '監督',
 			'discover.movie' => '映画',
 			'discover.tvShow' => 'テレビ番組',
 			'discover.minutesLeft' => ({required Object minutes}) => '残り${minutes}分',

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -916,6 +916,8 @@ class _TranslationsDiscoverKo extends TranslationsDiscoverEn {
 	@override String get extras => '예고편 및 부가영상';
 	@override String get studio => '제작사';
 	@override String get rating => '연령 등급';
+	@override String get director => '감독';
+	@override String get directors => '감독';
 	@override String get movie => '영화';
 	@override String get tvShow => 'TV 시리즈';
 	@override String minutesLeft({required Object minutes}) => '${minutes}분 남음';
@@ -2790,6 +2792,8 @@ extension on TranslationsKo {
 			'discover.extras' => '예고편 및 부가영상',
 			'discover.studio' => '제작사',
 			'discover.rating' => '연령 등급',
+			'discover.director' => '감독',
+			'discover.directors' => '감독',
 			'discover.movie' => '영화',
 			'discover.tvShow' => 'TV 시리즈',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes}분 남음',

--- a/lib/i18n/strings_nb.g.dart
+++ b/lib/i18n/strings_nb.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverNb extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailere og ekstra';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Vurdering';
+	@override String get director => 'Regissør';
+	@override String get directors => 'Regissører';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'TV-serie';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min igjen';
@@ -2793,6 +2795,8 @@ extension on TranslationsNb {
 			'discover.extras' => 'Trailere og ekstra',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Vurdering',
+			'discover.director' => 'Regissør',
+			'discover.directors' => 'Regissører',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'TV-serie',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min igjen',

--- a/lib/i18n/strings_nl.g.dart
+++ b/lib/i18n/strings_nl.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverNl extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailers & Extra\'s';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Leeftijd';
+	@override String get director => 'Regisseur';
+	@override String get directors => 'Regisseurs';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'TV Serie';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min over';
@@ -2793,6 +2795,8 @@ extension on TranslationsNl {
 			'discover.extras' => 'Trailers & Extra\'s',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Leeftijd',
+			'discover.director' => 'Regisseur',
+			'discover.directors' => 'Regisseurs',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'TV Serie',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min over',

--- a/lib/i18n/strings_pl.g.dart
+++ b/lib/i18n/strings_pl.g.dart
@@ -919,6 +919,8 @@ class _TranslationsDiscoverPl extends TranslationsDiscoverEn {
 	@override String get extras => 'Zwiastuny i dodatki';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Ocena';
+	@override String get director => 'Reżyser';
+	@override String get directors => 'Reżyserzy';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'Serial TV';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min pozostało';
@@ -2799,6 +2801,8 @@ extension on TranslationsPl {
 			'discover.extras' => 'Zwiastuny i dodatki',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Ocena',
+			'discover.director' => 'Reżyser',
+			'discover.directors' => 'Reżyserzy',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'Serial TV',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min pozostało',

--- a/lib/i18n/strings_pt.g.dart
+++ b/lib/i18n/strings_pt.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverPt extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailers e Extras';
 	@override String get studio => 'Estúdio';
 	@override String get rating => 'Avaliação';
+	@override String get director => 'Diretor';
+	@override String get directors => 'Diretores';
 	@override String get movie => 'Filme';
 	@override String get tvShow => 'Série de TV';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min restantes';
@@ -2793,6 +2795,8 @@ extension on TranslationsPt {
 			'discover.extras' => 'Trailers e Extras',
 			'discover.studio' => 'Estúdio',
 			'discover.rating' => 'Avaliação',
+			'discover.director' => 'Diretor',
+			'discover.directors' => 'Diretores',
 			'discover.movie' => 'Filme',
 			'discover.tvShow' => 'Série de TV',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min restantes',

--- a/lib/i18n/strings_ru.g.dart
+++ b/lib/i18n/strings_ru.g.dart
@@ -919,6 +919,8 @@ class _TranslationsDiscoverRu extends TranslationsDiscoverEn {
 	@override String get extras => 'Трейлеры и доп. материалы';
 	@override String get studio => 'Студия';
 	@override String get rating => 'Рейтинг';
+	@override String get director => 'Режиссёр';
+	@override String get directors => 'Режиссёры';
 	@override String get movie => 'Фильм';
 	@override String get tvShow => 'Сериал';
 	@override String minutesLeft({required Object minutes}) => 'Осталось ${minutes} мин';
@@ -2799,6 +2801,8 @@ extension on TranslationsRu {
 			'discover.extras' => 'Трейлеры и доп. материалы',
 			'discover.studio' => 'Студия',
 			'discover.rating' => 'Рейтинг',
+			'discover.director' => 'Режиссёр',
+			'discover.directors' => 'Режиссёры',
 			'discover.movie' => 'Фильм',
 			'discover.tvShow' => 'Сериал',
 			'discover.minutesLeft' => ({required Object minutes}) => 'Осталось ${minutes} мин',

--- a/lib/i18n/strings_sv.g.dart
+++ b/lib/i18n/strings_sv.g.dart
@@ -917,6 +917,8 @@ class _TranslationsDiscoverSv extends TranslationsDiscoverEn {
 	@override String get extras => 'Trailers och Extra';
 	@override String get studio => 'Studio';
 	@override String get rating => 'Åldersgräns';
+	@override String get director => 'Regissör';
+	@override String get directors => 'Regissörer';
 	@override String get movie => 'Film';
 	@override String get tvShow => 'TV-serie';
 	@override String minutesLeft({required Object minutes}) => '${minutes} min kvar';
@@ -2793,6 +2795,8 @@ extension on TranslationsSv {
 			'discover.extras' => 'Trailers och Extra',
 			'discover.studio' => 'Studio',
 			'discover.rating' => 'Åldersgräns',
+			'discover.director' => 'Regissör',
+			'discover.directors' => 'Regissörer',
 			'discover.movie' => 'Film',
 			'discover.tvShow' => 'TV-serie',
 			'discover.minutesLeft' => ({required Object minutes}) => '${minutes} min kvar',

--- a/lib/i18n/strings_zh.g.dart
+++ b/lib/i18n/strings_zh.g.dart
@@ -916,6 +916,8 @@ class _TranslationsDiscoverZh extends TranslationsDiscoverEn {
 	@override String get extras => '预告片与花絮';
 	@override String get studio => '制作公司';
 	@override String get rating => '年龄分级';
+	@override String get director => '导演';
+	@override String get directors => '导演';
 	@override String get movie => '电影';
 	@override String get tvShow => '电视剧';
 	@override String minutesLeft({required Object minutes}) => '剩余 ${minutes} 分钟';
@@ -2790,6 +2792,8 @@ extension on TranslationsZh {
 			'discover.extras' => '预告片与花絮',
 			'discover.studio' => '制作公司',
 			'discover.rating' => '年龄分级',
+			'discover.director' => '导演',
+			'discover.directors' => '导演',
 			'discover.movie' => '电影',
 			'discover.tvShow' => '电视剧',
 			'discover.minutesLeft' => ({required Object minutes}) => '剩余 ${minutes} 分钟',

--- a/lib/i18n/sv.i18n.json
+++ b/lib/i18n/sv.i18n.json
@@ -716,6 +716,8 @@
     "extras": "Trailers och Extra",
     "studio": "Studio",
     "rating": "Åldersgräns",
+    "director": "Regissör",
+    "directors": "Regissörer",
     "movie": "Film",
     "tvShow": "TV-serie",
     "minutesLeft": "${minutes} min kvar",

--- a/lib/i18n/zh.i18n.json
+++ b/lib/i18n/zh.i18n.json
@@ -715,6 +715,8 @@
     "extras": "预告片与花絮",
     "studio": "制作公司",
     "rating": "年龄分级",
+    "director": "导演",
+    "directors": "导演",
     "movie": "电影",
     "tvShow": "电视剧",
     "minutesLeft": "剩余 ${minutes} 分钟",

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -3232,6 +3232,13 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                                         _buildInfoRow(t.discover.studio, metadata.studio!),
                                         const SizedBox(height: 12),
                                       ],
+                                      if (metadata.directors != null) ...[
+                                        _buildInfoRow(
+                                          metadata.directors!.length > 1 ? t.discover.directors : t.discover.director,
+                                          metadata.directors!.join(', '),
+                                        ),
+                                        const SizedBox(height: 12),
+                                      ],
                                       if (metadata.contentRating != null) ...[
                                         _buildInfoRow(t.discover.rating, formatContentRating(metadata.contentRating!)),
                                         const SizedBox(height: 12),


### PR DESCRIPTION
This PR adds the `Director` that is already present in pulled metadata to the info rows. This includes an addition to all of the translation strings available. This handles the case of `Directors.length >= 2` and the case of no directors.

This somewhat addresses #1518 but is not present on TV view ports.
I am currently working on the TV view port and will address this in a separate PR.

**Documentation**

**Sahara (1943)**
<img width="1080" height="2424" alt="Screenshot_1784498925" src="https://github.com/user-attachments/assets/d37cbddc-280a-4121-a815-81dac04dc087" />

**No Country for Old Men (2007) -> the Cohen Brothers**
<img width="1080" height="2424" alt="Screenshot_1784499714" src="https://github.com/user-attachments/assets/874c7064-1a86-4d86-91e6-ea23b5836042" />
