### PR TITLE
Preserve Jellyfin source subtitle selection

### DIFF
--- a/lib/screens/video_player/parts/playback_services.dart
+++ b/lib/screens/video_player/parts/playback_services.dart
@@ -267,6 +267,18 @@ extension _VideoPlayerPlaybackServiceMethods on VideoPlayerScreenState {
         playMethod: effectivePlayMethod,
         playSessionId: playSessionId,
         mediaInfo: mediaInfo,
+        resolveSourceSubtitleChoice: metadata.backend == MediaBackend.jellyfin
+            ? () {
+                final session = _playbackSession;
+                if (session == null || session.metadata.globalKey != metadata.globalKey) return null;
+                if (session.mediaInfo?.mediaSourceId != mediaInfo?.mediaSourceId) return null;
+
+                final selection = session.subtitleSelection;
+                if (selection.isOff) return const PlaybackSourceSubtitleChoice.off();
+                final sourceStreamId = selection.primarySourceStreamId;
+                return sourceStreamId == null ? null : PlaybackSourceSubtitleChoice.source(sourceStreamId);
+              }
+            : null,
         onPausedKeepalive: mediaClient is PlexClient && effectivePlayMethod == 'Transcode'
             ? () => mediaClient.pingTranscodeSession(_playbackTranscodeSessionId)
             : null,

--- a/lib/services/playback_progress_tracker.dart
+++ b/lib/services/playback_progress_tracker.dart
@@ -10,6 +10,7 @@ import '../media/media_source_info.dart';
 import '../media/watch_progress.dart';
 import 'offline_watch_sync_service.dart';
 import 'playback_report_session.dart';
+import 'playback_subtitle_resolver.dart';
 import 'settings_service.dart';
 import 'track_selection_service.dart';
 import '../utils/app_logger.dart';
@@ -55,6 +56,10 @@ class PlaybackProgressTracker {
   /// Source-level stream metadata for mapping local player track ids back to
   /// Jellyfin stream indexes in playback-progress reports.
   final MediaSourceInfo? mediaInfo;
+
+  /// Resolves the current source subtitle choice for backends that keep an
+  /// authoritative source-stream identity outside the player track list.
+  final PlaybackSourceSubtitleChoice? Function()? resolveSourceSubtitleChoice;
 
   /// Invoked once after the item is successfully scrobbled. The player wires
   /// this to mark same-file sibling episodes of a Plex multi-episode file
@@ -109,6 +114,7 @@ class PlaybackProgressTracker {
     this.playMethod,
     this.playSessionId,
     this.mediaInfo,
+    this.resolveSourceSubtitleChoice,
     this.onScrobbled,
     this.onPausedKeepalive,
     this.updateInterval = const Duration(seconds: 10),
@@ -384,8 +390,18 @@ class PlaybackProgressTracker {
     return PlaybackStreamSelection(
       mediaSourceId: info.mediaSourceId,
       audioStreamIndex: _currentAudioStreamIndex(info),
-      subtitleStreamIndex: _currentSubtitleStreamIndex(info),
+      subtitleStreamIndex: _currentSubtitleStreamIndexForProgress(info),
     );
+  }
+
+  int? _currentSubtitleStreamIndexForProgress(MediaSourceInfo info) {
+    final resolveSourceChoice = resolveSourceSubtitleChoice;
+    if (resolveSourceChoice == null) return _currentSubtitleStreamIndex(info);
+
+    final choice = resolveSourceChoice();
+    if (choice == null) return null;
+    if (choice.isOff) return -1;
+    return choice.sourceStreamId;
   }
 
   Future<bool> _shouldReportTrackSelections() async {

--- a/test/services/playback_progress_tracker_test.dart
+++ b/test/services/playback_progress_tracker_test.dart
@@ -14,6 +14,8 @@ import 'package:plezy/services/multi_server_manager.dart';
 import 'package:plezy/services/offline_watch_sync_service.dart';
 import 'package:plezy/services/playback_progress_tracker.dart';
 import 'package:plezy/services/plex_client.dart';
+import 'package:plezy/services/playback_subtitle_resolver.dart';
+import 'package:plezy/services/settings_service.dart';
 import 'package:plezy/utils/watch_state_notifier.dart';
 
 import '../test_helpers/prefs.dart';
@@ -601,8 +603,164 @@ void main() {
       expect(progressSelection.subtitleStreamIndex, -1);
     });
 
+    test('uses the authoritative source subtitle id when player and source orders differ', () async {
+      final client = _FakePlexClient();
+      var choice = const PlaybackSourceSubtitleChoice.source(8);
+      const selectedSubtitle = SubtitleTrack(id: 'text_ko', language: 'kor');
+      final player = _FakePlayer(
+        position: const Duration(seconds: 5),
+        duration: const Duration(seconds: 100),
+        tracks: const Tracks(
+          audio: [AudioTrack(id: 'audio_0', language: 'eng')],
+          subtitle: [
+            selectedSubtitle,
+            SubtitleTrack(id: 'text_en', language: 'eng'),
+          ],
+        ),
+        track: const TrackSelection(
+          audio: AudioTrack(id: 'audio_0', language: 'eng'),
+          subtitle: selectedSubtitle,
+        ),
+      );
+      final mediaInfo = MediaSourceInfo(
+        videoUrl: '',
+        audioTracks: [MediaAudioTrack(id: 1, languageCode: 'eng', selected: true)],
+        // Jellyfin order is English=3, Korean=8; MPV order above is Korean,
+        // English. The old ordinal mapping would incorrectly report 3.
+        subtitleTracks: [
+          MediaSubtitleTrack(id: 3, languageCode: 'eng', selected: false, forced: false),
+          MediaSubtitleTrack(id: 8, languageCode: 'kor', selected: true, forced: false),
+        ],
+        chapters: const [],
+        mediaSourceId: 'source-1',
+      );
+      final tracker = PlaybackProgressTracker(
+        client: client,
+        metadata: _meta(),
+        player: player,
+        isOffline: false,
+        mediaInfo: mediaInfo,
+        resolveSourceSubtitleChoice: () => choice,
+      );
+      addTearDown(tracker.dispose);
+
+      await tracker.sendProgress('playing');
+      await Future<void>.delayed(Duration.zero);
+      expect(client.playbackStreamSelections.last.subtitleStreamIndex, 8);
+
+      choice = const PlaybackSourceSubtitleChoice.source(3);
+      await tracker.sendProgress('playing');
+      await Future<void>.delayed(Duration.zero);
+      expect(client.playbackStreamSelections.last.subtitleStreamIndex, 3);
+    });
+
+    test('reports Off and source stream id zero distinctly', () async {
+      final client = _FakePlexClient();
+      var choice = const PlaybackSourceSubtitleChoice.source(0);
+      final player = _FakePlayer(position: const Duration(seconds: 5), duration: const Duration(seconds: 100));
+      final mediaInfo = MediaSourceInfo(
+        videoUrl: '',
+        audioTracks: const [],
+        subtitleTracks: const [],
+        chapters: const [],
+        mediaSourceId: 'source-1',
+      );
+      final tracker = PlaybackProgressTracker(
+        client: client,
+        metadata: _meta(),
+        player: player,
+        isOffline: false,
+        mediaInfo: mediaInfo,
+        resolveSourceSubtitleChoice: () => choice,
+      );
+      addTearDown(tracker.dispose);
+
+      await tracker.sendProgress('playing');
+      await Future<void>.delayed(Duration.zero);
+      expect(client.playbackStreamSelections.last.subtitleStreamIndex, 0);
+
+      choice = const PlaybackSourceSubtitleChoice.off();
+      await tracker.sendProgress('playing');
+      await Future<void>.delayed(Duration.zero);
+      expect(client.playbackStreamSelections.last.subtitleStreamIndex, -1);
+    });
+
+    test('does not guess an ordinal when the source subtitle choice is unknown', () async {
+      final client = _FakePlexClient();
+      var resolverCalls = 0;
+      final player = _FakePlayer(
+        position: const Duration(seconds: 5),
+        duration: const Duration(seconds: 100),
+        tracks: const Tracks(
+          audio: [AudioTrack(id: 'audio_0', language: 'eng')],
+          subtitle: [SubtitleTrack(id: 'text_0', language: 'eng')],
+        ),
+        track: const TrackSelection(
+          audio: AudioTrack(id: 'audio_0', language: 'eng'),
+          subtitle: SubtitleTrack(id: 'text_0', language: 'eng'),
+        ),
+      );
+      final mediaInfo = MediaSourceInfo(
+        videoUrl: '',
+        audioTracks: const [],
+        subtitleTracks: [MediaSubtitleTrack(id: 3, languageCode: 'eng', selected: true, forced: false)],
+        chapters: const [],
+        mediaSourceId: 'source-1',
+      );
+      final tracker = PlaybackProgressTracker(
+        client: client,
+        metadata: _meta(),
+        player: player,
+        isOffline: false,
+        mediaInfo: mediaInfo,
+        resolveSourceSubtitleChoice: () {
+          resolverCalls++;
+          return null;
+        },
+      );
+      addTearDown(tracker.dispose);
+
+      await tracker.sendProgress('playing');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(resolverCalls, 1);
+      expect(client.playbackStreamSelections.last.subtitleStreamIndex, isNull);
+    });
+
+    test('does not resolve source subtitles when track-selection persistence is disabled', () async {
+      final settings = await SettingsService.getInstance();
+      await settings.write(SettingsService.rememberTrackSelections, false);
+      final client = _FakePlexClient();
+      var resolverCalls = 0;
+      final tracker = PlaybackProgressTracker(
+        client: client,
+        metadata: _meta(),
+        player: _FakePlayer(position: const Duration(seconds: 5), duration: const Duration(seconds: 100)),
+        isOffline: false,
+        mediaInfo: MediaSourceInfo(
+          videoUrl: '',
+          audioTracks: const [],
+          subtitleTracks: const [],
+          chapters: const [],
+          mediaSourceId: 'source-1',
+        ),
+        resolveSourceSubtitleChoice: () {
+          resolverCalls++;
+          return const PlaybackSourceSubtitleChoice.source(8);
+        },
+      );
+      addTearDown(tracker.dispose);
+
+      await tracker.sendProgress('playing');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(resolverCalls, 0);
+      expect(client.playbackStreamSelections.last.subtitleStreamIndex, isNull);
+    });
+
     test('stopped reports only resolve media source and do not include selected streams', () async {
       final client = _FakePlexClient();
+      var resolverCalls = 0;
       const selectedAudio = AudioTrack(id: 'audio_1', language: 'jpn');
       final player = _FakePlayer(
         position: const Duration(seconds: 5),
@@ -629,6 +787,10 @@ void main() {
         player: player,
         isOffline: false,
         mediaInfo: mediaInfo,
+        resolveSourceSubtitleChoice: () {
+          resolverCalls++;
+          return const PlaybackSourceSubtitleChoice.source(8);
+        },
       );
       addTearDown(tracker.dispose);
 
@@ -638,6 +800,7 @@ void main() {
       expect(client.playbackStreamSelections.single.mediaSourceId, 'source-1');
       expect(client.playbackStreamSelections.single.audioStreamIndex, isNull);
       expect(client.playbackStreamSelections.single.subtitleStreamIndex, isNull);
+      expect(resolverCalls, 0);
     });
   });
 


### PR DESCRIPTION
## What changed

When playback progress is reported to Jellyfin, preserve the selected subtitle's authoritative source-stream ID instead of deriving it from the player's filtered/reordered track list.

The video player now supplies the current Jellyfin source subtitle choice to the progress tracker. The tracker reports:

- the source subtitle stream ID when a subtitle is selected
- `-1` when subtitles are explicitly off
- no guessed ordinal when the source selection is unknown

## Why

Jellyfin's source stream order and the player's track order can differ, especially with external SRT tracks and filtered tracks. Persisting the player ordinal can therefore restore the wrong language or turn the selected subtitle off on the next playback.

## Validation

- `flutter test test/services/playback_progress_tracker_test.dart`
- 38 tests passed
- Windows Release build was run directly and verified with Jellyfin playback, Korean SRT subtitle display, and controller show/hide/re-show behavior.
