### PR TITLE
Add existing Jellyfin servers to discovered servers

### DIFF
--- a/lib/screens/settings/add_jellyfin_screen.dart
+++ b/lib/screens/settings/add_jellyfin_screen.dart
@@ -8,6 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../connection/connection.dart';
+import '../../connection/connection_registry.dart';
 import '../../exceptions/media_server_exceptions.dart';
 import '../../focus/card_focus_scope.dart';
 import '../../focus/focusable_button.dart';
@@ -136,11 +137,21 @@ class _AddJellyfinScreenState extends State<AddJellyfinScreen> with AsyncFormSta
   Future<void> _discoverLocalServers() async {
     final attemptId = ++_localDiscoveryAttemptId;
     try {
+      final existingConnections = await context.read<ConnectionRegistry>().list();
+      final existing = existingConnections
+          .whereType<JellyfinConnection>()
+          .map((c) => DiscoveredJellyfinServer(address: c.baseUrl, id: c.serverMachineId, name: c.serverName));
+
       final factory = widget._localDiscoveryFactory;
-      final servers = factory != null
+      final lanServers = factory != null
           ? await factory()
           : await JellyfinLanDiscoveryService().discover(responseWindow: const Duration(milliseconds: 1300));
       if (!mounted || attemptId != _localDiscoveryAttemptId) return;
+
+      // Deduplicate by machine ID
+      final combined = [...existing, ...lanServers];
+      final seen = <String>{};
+      final servers = combined.where((s) => seen.add(s.id)).toList();
       setState(() {
         _localServers = servers;
         _isDiscoveringLocalServers = false;

--- a/lib/screens/settings/add_jellyfin_screen.dart
+++ b/lib/screens/settings/add_jellyfin_screen.dart
@@ -137,8 +137,13 @@ class _AddJellyfinScreenState extends State<AddJellyfinScreen> with AsyncFormSta
   Future<void> _discoverLocalServers() async {
     final attemptId = ++_localDiscoveryAttemptId;
     try {
-      final existingConnections = await context.read<ConnectionRegistry>().list();
-      final existing = existingConnections
+       List<Connection> existingConnections = const <Connection>[];
+       try {
+         existingConnections = await context.read<ConnectionRegistry>().list();
+       } on ProviderNotFoundException {
+         // No ConnectionRegistry in the tree (tests / isolated subtrees).
+       }
+       final existing = existingConnections
           .whereType<JellyfinConnection>()
           .map((c) => DiscoveredJellyfinServer(address: c.baseUrl, id: c.serverMachineId, name: c.serverName));
 
@@ -151,7 +156,7 @@ class _AddJellyfinScreenState extends State<AddJellyfinScreen> with AsyncFormSta
       // Deduplicate by machine ID
       final combined = [...existing, ...lanServers];
       final seen = <String>{};
-      final servers = combined.where((s) => seen.add(s.id)).toList();
+      final servers = JellyfinLanDiscoveryService.sortDiscoveredServers(combined.where((s) => seen.add(s.id)));
       setState(() {
         _localServers = servers;
         _isDiscoveringLocalServers = false;


### PR DESCRIPTION
It's a bit tedious to add multiple accounts to plexy from my Jellyfin remote instance (type the URL with a TV remote). With this change, Plexy suggest already existing connections.

<img width="1419" height="547" alt="image" src="https://github.com/user-attachments/assets/a3149f76-399e-48cb-a7ce-a2f19ae9cfc2" />
