### PR TITLE
fix(discover): page hub View All on TV

### DIFF
--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -1048,8 +1048,11 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       onRemoveFromContinueWatching: _discover.refreshContinueWatching,
       isContinueWatchingHub: (hub) => hub.isContinueWatchingHub,
       usesContinueWatchingAction: (hub) => hub.usesContinueWatchingAction,
-      loadMoreItems: (hub) =>
-          hub.id == 'continue_watching' ? _discover.loadAllContinueWatching() : Future.value(hub.items),
+      // Only Continue Watching needs a custom loader — it is synthesized
+      // client-side and cannot be paged from the server. Every other hub
+      // returns null so HubDetailScreen pages it itself; handing one back the
+      // preview items it already had capped View All at the preview limit.
+      loaderForHub: (hub) => hub.id == 'continue_watching' ? _discover.loadAllContinueWatching : null,
       onNavigateUp: _focusTopActions,
       onNavigateToSidebar: _navigateToSidebar,
       tallPosterScale: TvBrowseRailLayout.compactTallPosterScale,

--- a/lib/screens/explore_screen.dart
+++ b/lib/screens/explore_screen.dart
@@ -538,9 +538,9 @@ class ExploreScreenState extends State<ExploreScreen>
                 focusMemory: _hubFocusMemory,
                 iconForHub: (hub, _) => _rowIcon(_rowForHub(hub)?.row),
                 onFocusedItemChanged: _setSpotlightItem,
-                loadMoreItems: (hub) {
+                loaderForHub: (hub) {
                   final rowHub = _rowForHub(hub);
-                  return rowHub == null ? Future.value(hub.items) : _explore.loadAllForHub(rowHub);
+                  return rowHub == null ? null : () => _explore.loadAllForHub(rowHub);
                 },
                 onNavigateUp: _actionBarKey.currentState?.requestFocusOnFirst,
                 onNavigateToSidebar: _navigateToSidebar,

--- a/lib/widgets/tv_browse_rail.dart
+++ b/lib/widgets/tv_browse_rail.dart
@@ -306,6 +306,10 @@ class TvBrowseRailLayout {
 /// What [TvBrowseRail] renders in a hub's trailing slot (after the last item).
 enum TvRailTrailing { none, loading, error, viewAll }
 
+/// Loads a hub's complete item list in one shot, bypassing [HubDetailScreen]'s
+/// server-side pagination. See [TvBrowseRail.loaderForHub].
+typedef HubItemsLoader = Future<List<MediaItem>> Function();
+
 class TvBrowseRail extends StatefulWidget {
   final List<MediaHub> hubs;
   final HubFocusMemory focusMemory;
@@ -321,7 +325,15 @@ class TvBrowseRail extends StatefulWidget {
   final VoidCallback? onRemoveFromContinueWatching;
   final bool Function(MediaHub hub)? isContinueWatchingHub;
   final bool Function(MediaHub hub)? usesContinueWatchingAction;
-  final Future<List<MediaItem>> Function(MediaHub hub)? loadMoreItems;
+
+  /// Resolves the one-shot loader for [hub]'s View All screen, or `null` when
+  /// the hub has no custom loader.
+  ///
+  /// Supplying a loader *disables* [HubDetailScreen]'s server-side pagination,
+  /// so only return one for hubs the server cannot page — e.g. the synthesized
+  /// Continue Watching hub. Returning `null` lets the detail screen page the
+  /// hub itself, which is what every server-backed hub wants.
+  final HubItemsLoader? Function(MediaHub hub)? loaderForHub;
 
   /// Optional per-hub trailing-slot state (loading/error/viewAll). When null the
   /// rail keeps the legacy "[MediaHub.more] → View All" behavior.
@@ -359,7 +371,7 @@ class TvBrowseRail extends StatefulWidget {
     this.onRemoveFromContinueWatching,
     this.isContinueWatchingHub,
     this.usesContinueWatchingAction,
-    this.loadMoreItems,
+    this.loaderForHub,
     this.trailingForHub,
     this.onRetryHub,
     this.onActiveHubChanged,
@@ -976,7 +988,7 @@ class TvBrowseRailState extends State<TvBrowseRail> with TickerProviderStateMixi
       MaterialPageRoute(
         builder: (context) => HubDetailScreen(
           hub: hub,
-          loadItems: widget.loadMoreItems == null ? null : () => widget.loadMoreItems!(hub),
+          loadItems: widget.loaderForHub?.call(hub),
           isInContinueWatching: _isContinueWatchingHub(hub),
           usesContinueWatchingAction: _usesContinueWatchingAction(hub),
           onRemoveFromContinueWatching: widget.onRemoveFromContinueWatching,

--- a/test/screens/discover_screen_test.dart
+++ b/test/screens/discover_screen_test.dart
@@ -486,6 +486,143 @@ void main() {
     expect(tester.widget<TvSpotlightBackground>(find.byType(TvSpotlightBackground)).item?.id, continueItem.id);
   });
 
+  testWidgets('TV View All keeps a one-shot loader only for Continue Watching', (tester) async {
+    await SettingsService.getInstance();
+    tester.view.devicePixelRatio = 1.0;
+    tester.view.physicalSize = const Size(1280, 720);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    final item = testMediaItem(
+      id: 'movie_1',
+      backend: MediaBackend.plex,
+      kind: MediaKind.movie,
+      title: 'Movie 1',
+      serverId: 'server_1',
+      serverName: 'Server',
+    );
+    final resumeItem = testMediaItem(
+      id: 'episode_1',
+      backend: MediaBackend.plex,
+      kind: MediaKind.episode,
+      title: 'Episode 1',
+      serverId: 'server_1',
+      serverName: 'Server',
+    );
+    // `more: true` is what surfaces the View All tile the user activates.
+    final hub = MediaHub(
+      id: 'hub_1',
+      title: 'Recently Added',
+      type: 'movie',
+      items: [item],
+      size: 40,
+      more: true,
+      serverId: 'server_1',
+    );
+    final client = _FakeMediaServerClient(hubs: [hub], continueWatching: [resumeItem]);
+    final manager = MultiServerManager()..debugRegisterClientForTesting(client);
+    final multiServerProvider = MultiServerProvider(manager, DataAggregationService(manager));
+    final hiddenLibrariesProvider = HiddenLibrariesProvider();
+    final librariesProvider = LibrariesProvider();
+    final watchTogetherProvider = WatchTogetherProvider();
+    final companionRemoteProvider = CompanionRemoteProvider();
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    final profileRegistry = _FakeProfileRegistry(db);
+    final connectionRegistry = _FakeConnectionRegistry(db);
+    final profileConnectionRegistry = _FakeProfileConnectionRegistry(db);
+    final storage = await StorageService.getInstance();
+    final plexHome = PlexHomeService(
+      connections: connectionRegistry,
+      profileConnections: profileConnectionRegistry,
+      storage: storage,
+      plexHomeUserFetcher: (_) async => const [],
+    );
+    final activeProfileProvider = ActiveProfileProvider(
+      registry: profileRegistry,
+      plexHome: plexHome,
+      connections: connectionRegistry,
+      profileConnections: profileConnectionRegistry,
+      storage: storage,
+    );
+    final discoverProvider = DiscoverProvider(
+      multiServerProvider,
+      hiddenLibrariesProvider,
+      librariesProvider,
+      profileId: null,
+      isProfileBinding: () => activeProfileProvider.isBinding,
+    );
+
+    addTearDown(() async {
+      discoverProvider.dispose();
+      activeProfileProvider.dispose();
+      companionRemoteProvider.dispose();
+      watchTogetherProvider.dispose();
+      librariesProvider.dispose();
+      hiddenLibrariesProvider.dispose();
+      multiServerProvider.dispose();
+      await plexHome.dispose();
+      await db.close();
+    });
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ChangeNotifierProvider<HiddenLibrariesProvider>.value(value: hiddenLibrariesProvider),
+            ChangeNotifierProvider<LibrariesProvider>.value(value: librariesProvider),
+            ChangeNotifierProvider<WatchTogetherProvider>.value(value: watchTogetherProvider),
+            ChangeNotifierProvider<CompanionRemoteProvider>.value(value: companionRemoteProvider),
+            ChangeNotifierProvider<ActiveProfileProvider>.value(value: activeProfileProvider),
+            ChangeNotifierProvider<DiscoverProvider>.value(value: discoverProvider),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: MainScreenFocusScope(
+              focusSidebar: () {},
+              focusContent: () {},
+              isSidebarFocused: false,
+              sideNavigationWidth: SideNavigationRailState.expandedWidth,
+              reservedSideNavigationWidth: SideNavigationRailState.tvCollapsedWidth,
+              foregroundLeft: 120.0,
+              foregroundWidth: 1280 - SideNavigationRailState.tvCollapsedWidth,
+              viewportWidth: 1280,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: SizedBox(
+                  width: 1280 - SideNavigationRailState.tvCollapsedWidth,
+                  height: 720,
+                  child: const DiscoverScreen(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final rail = tester.widget<TvBrowseRail>(find.byType(TvBrowseRail));
+    final loaderForHub = rail.loaderForHub;
+    expect(loaderForHub, isNotNull);
+
+    final continueWatchingHub = rail.hubs.firstWhere((h) => h.isContinueWatchingHub);
+    final serverHub = rail.hubs.firstWhere((h) => !h.isContinueWatchingHub);
+
+    // Continue Watching is synthesized client-side and cannot be paged from the
+    // server, so it keeps its one-shot loader.
+    expect(loaderForHub!(continueWatchingHub), isNotNull);
+
+    // Server-backed hubs must resolve to null. Supplying a loader disables
+    // HubDetailScreen's pagination, which capped View All at the preview items
+    // the rail already had (#1456).
+    expect(loaderForHub(serverHub), isNull);
+  });
+
   testWidgets('non-TV hero keeps indicators visible in keyboard mode and fades to solid bg', (tester) async {
     TvDetectionService.debugSetAppleTVOverride(false);
     await SettingsService.getInstance();


### PR DESCRIPTION
Fixes #1456.

## The problem

On TV, `TvBrowseRail` handed `HubDetailScreen` a custom `loadItems` callback for **every** hub. A custom loader disables the detail screen's server-side pagination:

```dart
// hub_detail_screen.dart
final usesCustomLoader = loader != null;
_usesPaginatedLoader = !usesCustomLoader && client != null && _shouldUsePaginatedLoader(client);
```

…and for every hub except Continue Watching, that loader returned the preview items the rail already had:

```dart
// discover_screen.dart
loadMoreItems: (hub) =>
    hub.id == 'continue_watching' ? _discover.loadAllContinueWatching() : Future.value(hub.items),
```

So View All rendered exactly the ~20 rows the home screen already showed. Mobile and desktop pass no loader for these hubs (`HubSection` simply omits it), fall through to `client.fetchMoreHubItemsPage`, and page correctly — which is why this reproduced only on TV, as the reporter noted.

The type is what forced the bug: `Future<List<MediaItem>> Function(MediaHub)?` is a nullable *function* with a non-nullable *result*, so there was no way to express "no custom loader for this hub" and the call site invented a filler.

## The change

`TvBrowseRail.loadMoreItems` becomes `loaderForHub`, a per-hub resolver that may return `null`:

```dart
final HubItemsLoader? Function(MediaHub hub)? loaderForHub;
...
loadItems: widget.loaderForHub?.call(hub),
```

Continue Watching is synthesized client-side and cannot be paged from the server, so it keeps its one-shot loader. Every server-backed hub resolves to `null` and pages itself.

Naming follows the widget's existing `…ForHub` resolver convention (`trailingForHub`, `iconForHub`, `episodePosterModeForHub`).

Hubs with `more == false` are unaffected: `HubDetailScreen.initState` only calls `_loadMoreItems()` when `hub.more` is true, so those keep showing exactly the items they were built with.

### Note on `explore_screen.dart`

Its rail is adapted to the new type. It had the same `Future.value(hub.items)` filler, but on a branch that is unreachable — `tvHubs` is built from the same `_explore.rowHubs` list that `_rowForHub` searches by `hub.id`, so the lookup can't miss. Rather than carry the filler forward I mapped that branch to `null`. Explore's live path is unchanged. Happy to restore the literal old expression there if you'd rather keep this PR strictly to Discover.

## Testing

New test in `test/screens/discover_screen_test.dart` asserts the resolver contract off the mounted rail:

```dart
expect(loaderForHub!(continueWatchingHub), isNotNull);
expect(loaderForHub(serverHub), isNull);
```

Verified it catches the regression by reverting the fix — fails with `Expected: null / Actual: <Closure: () => Future<List<MediaItem>>>`.

Local run against Flutter 3.44.0:

- `flutter test` — 4256 passed
- `dart run scripts/check_analyzer.dart` — passed
- `dart format --set-exit-if-changed` — clean
- `check-unused-code` / `check-unused-files` — none
- `scripts/codegen.sh --check` — current
- `clean_translations.py --check --strict` — 0 unused keys
- `check_icon_consistency.dart` — passed

I could not run the native formatting or Android JVM test steps locally (no clang-format toolchain, no Java/Android SDK); no native code is touched.
