### PR TITLE
fix(jellyfin): stop mixed libraries expanding every episode

### DIFF
--- a/lib/services/library_query_translator.dart
+++ b/lib/services/library_query_translator.dart
@@ -276,7 +276,15 @@ class JellyfinLibraryQueryTranslator implements LibraryQueryTranslator {
       MediaKind.playlist => 'Playlist',
       MediaKind.clip => 'Video,MusicVideo',
       MediaKind.photo => 'Photo',
-      _ => 'Movie,Series,Episode,Audio',
+      // Kind-less browse is a mixed library (CollectionType `mixed` maps to
+      // [MediaKind.unknown], which [libraryQueryFromPlexMap] folds to a null
+      // kind). Ask for the top-level rows Jellyfin's own client shows there —
+      // one entry per series, not its episodes. `Recursive=true` would
+      // otherwise expand every episode into the grid, and because Jellyfin
+      // sorts episodes by index their sort names all land before "A" and
+      // swamp the alpha bar's `#` bucket (#1675). Episodes stay reachable by
+      // opening the series, and global search queries their type directly.
+      _ => 'Movie,Series,Audio',
     };
   }
 

--- a/test/services/library_query_translator_test.dart
+++ b/test/services/library_query_translator_test.dart
@@ -111,9 +111,35 @@ void main() {
       expect(translator.toQueryParameters(const LibraryQuery(kind: MediaKind.photo))['IncludeItemTypes'], 'Photo');
     });
 
-    test('null kind falls back to multi-type include', () {
+    test('null kind falls back to top-level types without Episode', () {
       final params = translator.toQueryParameters(const LibraryQuery());
-      expect(params['IncludeItemTypes'], 'Movie,Series,Episode,Audio');
+      expect(params['IncludeItemTypes'], 'Movie,Series,Audio');
+    });
+
+    test('mixed-library browse never expands episodes into the grid', () {
+      // A mixed library reaches the translator with a null kind. Recursive
+      // browse must still return one row per series rather than every
+      // episode (#1675).
+      final params = translator.toQueryParameters(const LibraryQuery());
+      expect(params['Recursive'], 'true');
+      expect((params['IncludeItemTypes'] as String).split(','), isNot(contains('Episode')));
+    });
+
+    test('# alpha bucket on a mixed library asks for non-alphabetic top-level rows', () {
+      // Jellyfin sorts episodes by index, so their sort names all precede "A".
+      // With Episode in the type set, NameLessThan=A returned every episode of
+      // every series instead of just numerically-titled movies/series (#1675).
+      final params = translator.toQueryParameters(const LibraryQuery(nameStartsWith: '#'));
+      expect(params['NameLessThan'], 'A');
+      expect(params['NameStartsWith'], isNull);
+      expect((params['IncludeItemTypes'] as String).split(','), isNot(contains('Episode')));
+    });
+
+    test('explicit episode grouping still requests episodes', () {
+      // Dropping Episode from the fallback must not affect a Shows library
+      // browsed with the Episodes grouping, which pins the kind explicitly.
+      final params = translator.toQueryParameters(const LibraryQuery(kind: MediaKind.episode));
+      expect(params['IncludeItemTypes'], 'Episode');
     });
 
     test('genres joined with pipe separator', () {


### PR DESCRIPTION
Fixes #1675. Context in #1672.

## The problem

A mixed Jellyfin library reports `CollectionType: "mixed"`, which maps to `MediaKind.unknown`:

```dart
// jellyfin_mappers.dart
'mixed' => MediaKind.unknown,
```

…and `libraryQueryFromPlexMap` folds that to a null kind:

```dart
kind: (kind == null || kind == MediaKind.unknown) ? null : kind,
```

With the `All` grouping there is no `type` filter either, so the query reaches `JellyfinLibraryQueryTranslator` with `kind == null` and lands on the fallback:

```dart
_ => 'Movie,Series,Episode,Audio',
```

Combined with `Recursive=true`, that returns every episode of every series as its own grid row, alongside the series entries.

The alpha bar makes it visible: Jellyfin sorts episodes by index, so their sort names all precede `"A"`, and the `#` bucket (`NameLessThan=A`) fills with the entire episode catalogue instead of the numerically-titled movies and series it should hold. Jellyfin's own web client and the Jellyfin desktop client both show one row per series here.

## The change

Drop `Episode` from that fallback so a kind-less browse asks for the top-level rows Jellyfin itself shows for a mixed library.

Scope — I checked each way this fallback can be reached:

- `fetchLibraryContent` is called only from `fetchLibraryPagedContent`, so this is exclusively the library-browse path.
- `isShared` is hardcoded `false` in the Jellyfin mapper, so the `browseGroupingAll` + shared branch that forces `type=videoCsv` is Plex-only and can't reach here.
- Groupings that pin a kind resolve before the fallback: a Shows library browsed by **Episodes** still sends `IncludeItemTypes=Episode`. Covered by a new test.
- Episodes stay reachable by opening the series, and global search is a separate query (`Movie,Series,Episode,Video,MusicVideo,Photo`), so searching for an episode still finds it.

### One thing I deliberately did not change

`Audio` is still in the fallback, so individual tracks can appear in a mixed library that also holds music — arguably the same shape of bug as `Episode`, with `MusicAlbum` being the analogous top-level row. I left it alone: it isn't part of this report, I have no mixed music library to verify against, and it felt like the wrong thing to bundle in. Happy to fold it in here if you want it, or leave it for a separate issue.

## Testing

`test/services/library_query_translator_test.dart` — updated the fallback expectation and added three cases:

- mixed-library browse is `Recursive=true` but never includes `Episode`
- the `#` bucket maps to `NameLessThan=A` and excludes `Episode`
- an explicit episode grouping still requests `IncludeItemTypes=Episode`

Local run against Flutter 3.44.0:

- `flutter test` — 4259 passed
- `dart run scripts/check_analyzer.dart` — passed
- `dart format --set-exit-if-changed` — clean
- `check-unused-code` / `check-unused-files` — none

No Maestro fixture builds a mixed library, so the E2E suites don't encode the old behaviour.

I don't have a mixed Jellyfin library to verify against end-to-end — the reasoning above is from the query path and the reporter's description in #1672, so a sanity check against a real mixed library before merging would be worth it.
