### PR TITLE
Guard linux is available around actually installed linux commands.

### DIFF
--- a/lib/models/external_player_models.dart
+++ b/lib/models/external_player_models.dart
@@ -204,6 +204,19 @@ class KnownPlayers {
     return _androidPackageMap[id] ?? const [];
   }
 
+  static bool _isLinuxCommandAvailable(String command) {
+    if (!Platform.isLinux) {
+      return false;
+    }
+
+    try {
+      final result = Process.runSync('sh', ['-c', r'command -v "$1" >/dev/null 2>&1', 'plezy-command-probe', command]);
+      return result.exitCode == 0;
+    } on ProcessException {
+      return false;
+    }
+  }
+
   static List<String> androidPackageCandidates(ExternalPlayer player) {
     final knownPackages = _androidPackageCandidatesForId(player.id);
     if (knownPackages.isNotEmpty) return knownPackages;
@@ -220,7 +233,12 @@ class KnownPlayers {
       id: 'vlc',
       name: 'VLC',
       iconAsset: 'assets/player_icons/vlc.svg',
-      isAvailable: Platform.isAndroid || Platform.isIOS || Platform.isMacOS || Platform.isLinux || Platform.isWindows,
+      isAvailable:
+          Platform.isAndroid ||
+          Platform.isIOS ||
+          Platform.isMacOS ||
+          _isLinuxCommandAvailable('vlc') ||
+          Platform.isWindows,
       launch: (url) {
         if (Platform.isAndroid) return _launchAndroidIntentCandidates(url, _androidPackageCandidatesForId('vlc'));
         if (Platform.isIOS) return _launchUrlScheme('vlc://', url);
@@ -233,7 +251,7 @@ class KnownPlayers {
       id: 'mpv',
       name: 'mpv',
       iconAsset: 'assets/player_icons/mpv.svg',
-      isAvailable: Platform.isAndroid || Platform.isMacOS || Platform.isLinux || Platform.isWindows,
+      isAvailable: Platform.isAndroid || Platform.isMacOS || _isLinuxCommandAvailable('mpv') || Platform.isWindows,
       launch: (url) {
         if (Platform.isAndroid) return _launchAndroidIntentCandidates(url, _androidPackageCandidatesForId('mpv'));
         return _launchCommand('mpv', url);
@@ -281,7 +299,7 @@ class KnownPlayers {
       id: 'celluloid',
       name: 'Celluloid',
       iconAsset: 'assets/player_icons/celluloid.svg',
-      isAvailable: Platform.isLinux,
+      isAvailable: _isLinuxCommandAvailable('celluloid'),
       launch: (url) => _launchCommand('celluloid', url),
     ),
   ];

--- a/test/models/external_player_models_test.dart
+++ b/test/models/external_player_models_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/models/external_player_models.dart';
+
+void main() {
+  test('Linux exposes only known players whose commands are available', () {
+    final players = KnownPlayers.getForCurrentPlatform();
+
+    expect(players.map((player) => player.id), [
+      'system_default',
+      if (_commandIsAvailable('vlc')) 'vlc',
+      if (_commandIsAvailable('mpv')) 'mpv',
+      if (_commandIsAvailable('celluloid')) 'celluloid',
+    ]);
+  }, skip: !Platform.isLinux);
+}
+
+bool _commandIsAvailable(String command) {
+  final result = Process.runSync('sh', ['-c', r'command -v "$1" >/dev/null 2>&1', 'plezy-test-command-probe', command]);
+  return result.exitCode == 0;
+}


### PR DESCRIPTION
Currently on linux the app lists all of the linux supported player options even if they're not actually installed.

This adds a small helper to check if a player is actually available before listing it to the user.