### PR TITLE
feat(playlist): Add reliable repeat for video playlists

### DIFF
--- a/lib/providers/playback_state_provider.dart
+++ b/lib/providers/playback_state_provider.dart
@@ -76,12 +76,27 @@ class PlaybackStateProvider with ChangeNotifier, DisposableChangeNotifierMixin {
   // Client reference for loading more items
   PlayQueueWindowFetcher? _windowFetcher;
 
+  // Repeat-all is scoped to one video-playlist context. The setting survives
+  // queue teardown, but it is active only while that playlist owns the queue.
+  bool _repeatQueueEnabled = false;
+  String? _repeatContextKey;
+
   /// Returns the queue id for [item] within the current queue. For Plex
   /// items this is the server's `playQueueItemID`; for client-side queues
   /// (Jellyfin) it's a synthetic index assigned in [setPlaybackFromLocalQueue].
   /// Returns null when [item] isn't in the current loaded window.
   int? playQueueItemIdFor(MediaItem item) {
     if (!_isQueueMode) return null;
+
+    // A repeat-enabled Plex playlist deliberately uses LocalPlayQueue. Prefer
+    // its synthetic identity even if a fetched Plex item happens to retain a
+    // stale server playQueueItemId from an earlier response.
+    if (_playQueueId == -1) {
+      final idx = _loadedItems.indexOf(item);
+      if (idx < 0 || idx >= _syntheticIds.length) return null;
+      return _syntheticIds[idx];
+    }
+
     if (item is PlexMediaItem && item.playQueueItemId != null) {
       final id = item.playQueueItemId!;
       final loadedIndex = _findLoadedIndex(id);
@@ -90,9 +105,7 @@ class PlaybackStateProvider with ChangeNotifier, DisposableChangeNotifierMixin {
       }
       return id;
     }
-    final idx = _loadedItems.indexOf(item);
-    if (idx < 0 || idx >= _syntheticIds.length) return null;
-    return _syntheticIds[idx];
+    return null;
   }
 
   /// Whether shuffle mode is currently active
@@ -103,6 +116,34 @@ class PlaybackStateProvider with ChangeNotifier, DisposableChangeNotifierMixin {
 
   /// Whether any queue-based playback is active
   bool get isQueueActive => _playQueueId != null && _isQueueMode;
+
+  /// True when repeat is enabled for the currently active video queue.
+  bool get isRepeatActive =>
+      _repeatQueueEnabled &&
+      _repeatContextKey != null &&
+      _repeatContextKey == _contextKey &&
+      _isQueueMode &&
+      _playQueueId == -1;
+
+  /// Returns whether repeat is enabled for a particular playlist.
+  bool isRepeatEnabledFor(String contextKey) => _repeatQueueEnabled && _repeatContextKey == contextKey;
+
+  /// Enables or disables repeat for a particular video playlist.
+  void setRepeatForContext(String contextKey, bool enabled) {
+    final alreadySet = enabled
+        ? _repeatQueueEnabled && _repeatContextKey == contextKey
+        : !_repeatQueueEnabled || _repeatContextKey != contextKey;
+    if (alreadySet) return;
+
+    if (enabled) {
+      _repeatQueueEnabled = true;
+      _repeatContextKey = contextKey;
+    } else {
+      _repeatQueueEnabled = false;
+      _repeatContextKey = null;
+    }
+    safeNotifyListeners();
+  }
 
   /// Whether [item] belongs to the currently active queue. Plex membership
   /// requires both the server queue id and media identity to match a loaded
@@ -268,12 +309,13 @@ class PlaybackStateProvider with ChangeNotifier, DisposableChangeNotifierMixin {
   /// or -1 if absent. Bridges Plex (real id on [PlexMediaItem]) and
   /// client-side (synthetic id in [_syntheticIds]) queues.
   int _findLoadedIndex(int playQueueItemId) {
+    if (_playQueueId == -1) {
+      return _syntheticIds.indexOf(playQueueItemId);
+    }
+
     for (var i = 0; i < _loadedItems.length; i++) {
       final item = _loadedItems[i];
       if (item is PlexMediaItem && item.playQueueItemId == playQueueItemId) {
-        return i;
-      }
-      if (i < _syntheticIds.length && _syntheticIds[i] == playQueueItemId) {
         return i;
       }
     }
@@ -294,7 +336,11 @@ class PlaybackStateProvider with ChangeNotifier, DisposableChangeNotifierMixin {
   /// would replay the file from the start (#1500). [playedPartId] pins the
   /// comparison to the file of the part actually playing when known;
   /// otherwise any file overlap with the current item counts.
-  Future<QueueNavigationResult> getNextEpisode(String currentItemKey, {String? playedPartId}) async {
+  Future<QueueNavigationResult> getNextEpisode(
+    String currentItemKey, {
+    bool loopQueue = false,
+    String? playedPartId,
+  }) async {
     if (!_isQueueMode) return const QueueNavigationResult.unavailable();
 
     final indexResult = await _getCurrentIndex(currentItemKey, loadIfMissing: true);
@@ -306,11 +352,30 @@ class PlaybackStateProvider with ChangeNotifier, DisposableChangeNotifierMixin {
     var anchor = current;
     // Bounded so a pathological all-same-file queue cannot spin.
     for (var steps = 0; steps <= _playQueueTotalCount; steps++) {
-      final result = await _itemAtOffset(anchor, 1);
+      var result = await _itemAtOffset(anchor, 1);
+
+      if (result.status == QueueNavigationStatus.boundary && loopQueue) {
+        // Repeat-enabled playlists are intentionally launched as fully
+        // resident local queues. Never pretend the first item in a Plex
+        // server window is the first item in the playlist.
+        if (_playQueueId != -1 || _loadedItems.isEmpty) {
+          return const QueueNavigationResult.failed();
+        }
+        result = QueueNavigationResult.found(_loadedItems.first);
+      }
+
       final candidate = result.item;
       if (result.status != QueueNavigationStatus.found || candidate == null) {
         return result;
       }
+
+      // A one-item playlist legitimately wraps to itself. Do not use
+      // identity alone here: a larger playlist can intentionally contain the
+      // same media item more than once.
+      if (loopQueue && _playQueueTotalCount == 1 && candidate.globalKey == current.globalKey) {
+        return result;
+      }
+
       if (!current.sharesFileWith(candidate, playedPartId: playedPartId)) {
         return result;
       }

--- a/lib/screens/playlist/playlist_detail_screen.dart
+++ b/lib/screens/playlist/playlist_detail_screen.dart
@@ -11,6 +11,7 @@ import '../../media/media_playlist.dart';
 import '../../services/media_list_playback_launcher.dart';
 import '../../services/music/music_playback_service.dart';
 import '../../services/playlist_items_loader.dart';
+import '../../services/repeating_playlist_launcher.dart';
 import '../../utils/app_logger.dart';
 import '../../utils/content_utils.dart';
 import '../../utils/error_message_utils.dart';
@@ -25,6 +26,7 @@ import 'package:provider/provider.dart';
 import 'playlist_item_card.dart';
 import '../../i18n/strings.g.dart';
 import '../../providers/download_provider.dart';
+import '../../providers/playback_state_provider.dart';
 import '../../utils/platform_detector.dart';
 import '../../utils/dialogs.dart';
 import '../../utils/download_utils.dart';
@@ -71,18 +73,30 @@ class _PlaylistDetailScreenState extends BaseMediaListDetailScreen<PlaylistDetai
   /// filter rules, not direct edits). Jellyfin has no equivalent concept.
   bool get _isReadOnly => widget.playlist.smart;
 
+  String get _normalizedPlaylistType => widget.playlist.playlistType.trim().toLowerCase();
+
   /// Audio playlists play through the music session (mini-player /
   /// now-playing) instead of the video play-queue launcher.
-  bool get _isAudioPlaylist => widget.playlist.playlistType == 'audio';
+  bool get _isAudioPlaylist => _normalizedPlaylistType == 'audio';
+
+  bool get _supportsVideoRepeat {
+    if (_normalizedPlaylistType == 'video') return true;
+    if (_normalizedPlaylistType == 'audio' || _normalizedPlaylistType == 'photo') {
+      return false;
+    }
+    return items.any((item) => item.kind.isVideo);
+  }
 
   MusicPlayContext get _musicPlayContext =>
       MusicPlayContext(id: widget.playlist.id, title: widget.playlist.title, kind: MusicPlayContextKind.playlist);
 
   @override
-  Future<void> playItems() => _isAudioPlaylist ? _playAudioPlaylist(shuffle: false) : super.playItems();
+  Future<void> playItems() =>
+      _isAudioPlaylist ? _playAudioPlaylist(shuffle: false) : _playVideoPlaylist(shuffle: false);
 
   @override
-  Future<void> shufflePlayItems() => _isAudioPlaylist ? _playAudioPlaylist(shuffle: true) : super.shufflePlayItems();
+  Future<void> shufflePlayItems() =>
+      _isAudioPlaylist ? _playAudioPlaylist(shuffle: true) : _playVideoPlaylist(shuffle: true);
 
   /// Uses the already-loaded items when the playlist is fully paged in;
   /// otherwise fetches the full item list (one loader round-trip) so the
@@ -103,20 +117,106 @@ class _PlaylistDetailScreenState extends BaseMediaListDetailScreen<PlaylistDetai
     );
   }
 
+  /// Starts a video playlist. Repeat-enabled playback uses a fully resident
+  /// client-side queue on both Plex and Jellyfin. This makes the final-item to
+  /// first-item transition index-based instead of depending on a Plex server
+  /// window and opaque playQueueItemID values.
+  Future<void> _playVideoPlaylist({required bool shuffle, int? startIndex}) async {
+    if (items.isEmpty) {
+      showAppSnackBar(context, emptyMessage);
+      return;
+    }
+
+    final playbackState = context.read<PlaybackStateProvider>();
+    final repeatEnabled = playbackState.isRepeatEnabledFor(widget.playlist.globalKey);
+
+    if (!repeatEnabled) {
+      if (startIndex == null) {
+        if (shuffle) {
+          await super.shufflePlayItems();
+        } else {
+          await super.playItems();
+        }
+        return;
+      }
+
+      if (startIndex < 0 || startIndex >= items.length) return;
+      final launcher = MediaListPlaybackLauncher.forItem(context, widget.playlist);
+      await launcher.launchFromCollectionOrPlaylist(
+        item: widget.playlist,
+        shuffle: false,
+        startItem: items[startIndex],
+        showLoadingIndicator: true,
+      );
+      return;
+    }
+
+    try {
+      final allItems = _isPlaylistFullyLoaded
+          ? List<MediaItem>.of(items)
+          : await fetchAllPlaylistItems(mediaClient, widget.playlist.id);
+      if (!mounted) return;
+      if (allItems.isEmpty) {
+        showAppSnackBar(context, emptyMessage);
+        return;
+      }
+
+      await launchRepeatingVideoPlaylist(
+        context: context,
+        playlistContextKey: widget.playlist.globalKey,
+        items: allItems,
+        shuffle: shuffle,
+        startIndex: startIndex,
+      );
+    } catch (e, stackTrace) {
+      appLogger.e('Failed to launch repeating video playlist', error: e, stackTrace: stackTrace);
+      if (mounted) {
+        showErrorSnackBar(context, localizedLoadErrorMessage(e, stackTrace, context: widget.playlist.title));
+      }
+    }
+  }
+
+  void _toggleVideoPlaylistRepeat() {
+    final playbackState = context.read<PlaybackStateProvider>();
+    final playlistContextKey = widget.playlist.globalKey;
+    playbackState.setRepeatForContext(playlistContextKey, !playbackState.isRepeatEnabledFor(playlistContextKey));
+  }
+
   @override
   List<FocusableAction> getAppBarActions() {
     // Video AND audio playlists download (tracks queue through the same list
     // pipeline); photo/mixed playlists keep the affordance hidden.
-    final isDownloadablePlaylist = widget.playlist.playlistType == 'video' || _isAudioPlaylist;
+    final isDownloadablePlaylist = _normalizedPlaylistType == 'video' || _isAudioPlaylist;
     final ruleKey = syncRuleKey;
     // Select the specific bool we care about so unrelated DownloadProvider
     // ticks (e.g. active download progress) don't rebuild the app bar.
     final hasRule = isDownloadablePlaylist && context.select<DownloadProvider, bool>((p) => p.hasSyncRule(ruleKey));
 
+    final repeatEnabled = context.select<PlaybackStateProvider, bool>(
+      (provider) => provider.isRepeatEnabledFor(widget.playlist.globalKey),
+    );
     return [
       if (items.isNotEmpty) ...[
-        FocusableAction(icon: Symbols.play_arrow_rounded, tooltip: t.common.play, onPressed: playItems),
-        FocusableAction(icon: Symbols.shuffle_rounded, tooltip: t.common.shuffle, onPressed: shufflePlayItems),
+        FocusableAction(
+          debugLabel: 'playlist_play',
+          icon: Symbols.play_arrow_rounded,
+          tooltip: t.common.play,
+          onPressed: playItems,
+        ),
+        FocusableAction(
+          debugLabel: 'playlist_shuffle',
+          icon: Symbols.shuffle_rounded,
+          tooltip: t.common.shuffle,
+          onPressed: shufflePlayItems,
+        ),
+        if (_supportsVideoRepeat)
+          FocusableAction(
+            debugLabel: 'playlist_repeat',
+            icon: repeatEnabled ? Symbols.repeat_on_rounded : Symbols.repeat_rounded,
+            tooltip: repeatEnabled ? t.music.repeatAll : t.music.repeat,
+            onPressed: _toggleVideoPlaylistRepeat,
+            iconColor: repeatEnabled ? Theme.of(context).colorScheme.primary : null,
+          ),
       ],
       ...buildSyncRuleActions(
         context,
@@ -491,13 +591,7 @@ class _PlaylistDetailScreenState extends BaseMediaListDetailScreen<PlaylistDetai
       await _playAudioPlaylist(shuffle: false, startTrack: selectedItem);
       return;
     }
-    final launcher = MediaListPlaybackLauncher.forItem(context, widget.playlist);
-    await launcher.launchFromCollectionOrPlaylist(
-      item: widget.playlist,
-      shuffle: false,
-      startItem: selectedItem,
-      showLoadingIndicator: true,
-    );
+    await _playVideoPlaylist(shuffle: false, startIndex: index);
   }
 
   /// Ensure the focused item is visible in the list using scroll arithmetic.

--- a/lib/screens/video_player/parts/playback_prompts.dart
+++ b/lib/screens/video_player/parts/playback_prompts.dart
@@ -75,6 +75,14 @@ extension _VideoPlayerPlaybackPromptMethods on VideoPlayerScreenState {
         !_completionLatch.triggered) {
       _completionLatch.latch();
 
+      // Repeat-all is an explicit continuous playback request. Do not make it
+      // depend on the global autoplay-next setting or show the Play Next UI.
+      final playbackState = context.read<PlaybackStateProvider>();
+      if (playbackState.isRepeatActive) {
+        unawaited(_playNext());
+        return;
+      }
+
       // PiP: skip dialog (user can't interact), auto-play immediately
       if (PipService().isPipActive.value) {
         unawaited(_playNext());

--- a/lib/services/episode_navigation_service.dart
+++ b/lib/services/episode_navigation_service.dart
@@ -103,7 +103,11 @@ class EpisodeNavigationService {
         return const AdjacentEpisodes.failed();
       }
 
-      final nextResult = await playbackState.getNextEpisode(metadata.id, playedPartId: playedPartId);
+      final nextResult = await playbackState.getNextEpisode(
+        metadata.id,
+        loopQueue: playbackState.isRepeatActive,
+        playedPartId: playedPartId,
+      );
       final previousResult = await playbackState.getPreviousEpisode(metadata.id, playedPartId: playedPartId);
       final nextStatus = nextResult.status == QueueNavigationStatus.unavailable
           ? QueueNavigationStatus.failed
@@ -113,7 +117,9 @@ class EpisodeNavigationService {
           : previousResult.status;
       final mode = playbackState.isShuffleActive ? 'Shuffle' : 'Sequential';
       appLogger.d(
-        '$mode mode - Next: ${nextResult.item?.title} ($nextStatus), '
+        '$mode mode'
+        '${playbackState.isRepeatActive ? ' with repeat' : ''}'
+        ' - Next: ${nextResult.item?.title} ($nextStatus), '
         'Previous: ${previousResult.item?.title} ($previousStatus)',
       );
       return AdjacentEpisodes(

--- a/lib/services/repeating_playlist_launcher.dart
+++ b/lib/services/repeating_playlist_launcher.dart
@@ -1,0 +1,99 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../media/media_item.dart';
+import '../media/play_queue.dart';
+import '../providers/playback_state_provider.dart';
+import '../utils/app_logger.dart';
+import '../utils/video_player_navigation.dart';
+
+/// Builds the fully resident queue used by video-playlist repeat.
+///
+/// Plex normally uses a server-side, windowed play queue. That is efficient
+/// for ordinary playback, but it makes repeat-all fragile for long playlists:
+/// queue item IDs are opaque and the first item may no longer be present in the
+/// final 50-item window. A [LocalPlayQueue] gives repeat playback a stable,
+/// deterministic index zero on both Plex and Jellyfin.
+LocalPlayQueue buildRepeatingVideoPlaylistQueue({
+  required String playlistContextKey,
+  required List<MediaItem> items,
+  required bool shuffle,
+  int? startIndex,
+  Random? random,
+}) {
+  if (items.isEmpty) {
+    throw StateError('Cannot launch an empty video playlist');
+  }
+
+  final queueItems = List<MediaItem>.of(items);
+  var selectedIndex = startIndex ?? 0;
+
+  if (shuffle) {
+    queueItems.shuffle(random);
+    selectedIndex = 0;
+  } else if (selectedIndex < 0 || selectedIndex >= queueItems.length) {
+    throw RangeError.index(selectedIndex, queueItems, 'startIndex');
+  }
+
+  // A playlist is server-scoped. Reject an accidental mixed-backend or
+  // mixed-server list rather than publishing a queue that cannot be navigated
+  // consistently.
+  final backendId = queueItems.first.backend.id;
+  final serverId = queueItems.first.serverId;
+  if (queueItems.any((item) => item.backend.id != backendId)) {
+    throw StateError('A repeating playlist cannot mix media backends');
+  }
+  if (queueItems.any((item) => item.serverId != serverId)) {
+    throw StateError('A repeating playlist cannot mix media servers');
+  }
+
+  return LocalPlayQueue(
+    id: '$backendId:playlist:$playlistContextKey:${Uuid().v4()}',
+    items: queueItems,
+    currentIndex: selectedIndex,
+    backendId: backendId,
+    shuffled: shuffle,
+  );
+}
+
+/// Launches a repeat-enabled video playlist through a fully resident queue.
+Future<void> launchRepeatingVideoPlaylist({
+  required BuildContext context,
+  required String playlistContextKey,
+  required List<MediaItem> items,
+  required bool shuffle,
+  int? startIndex,
+  Random? random,
+}) async {
+  final queue = buildRepeatingVideoPlaylistQueue(
+    playlistContextKey: playlistContextKey,
+    items: items,
+    shuffle: shuffle,
+    startIndex: startIndex,
+    random: random,
+  );
+
+  final playbackState = context.read<PlaybackStateProvider>();
+  playbackState.setPlaybackFromLocalQueue(queue, contextKey: playlistContextKey);
+
+  final selectedIndex = queue.currentIndex ?? 0;
+  final itemToPlay = queue.items[selectedIndex];
+  appLogger.d(
+    'Repeating local playlist queue created '
+    '(${queue.items.length} items, start: $selectedIndex, '
+    'shuffle: ${queue.shuffled})',
+  );
+
+  if (!context.mounted) {
+    playbackState.clearShuffle();
+    return;
+  }
+
+  // Preserve the exact queue object. Resolving a watch-state clone here would
+  // break identity-based membership and cause VideoPlayerScreen to discard the
+  // queue on entry.
+  await navigateToVideoPlayer(context, metadata: itemToPlay, resolveWatchState: false);
+}

--- a/test/providers/playback_state_provider_repeat_test.dart
+++ b/test/providers/playback_state_provider_repeat_test.dart
@@ -1,0 +1,207 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/media/media_kind.dart';
+import 'package:plezy/media/play_queue.dart';
+import 'package:plezy/models/plex/play_queue_response.dart';
+import 'package:plezy/providers/playback_state_provider.dart';
+import 'package:plezy/services/repeating_playlist_launcher.dart';
+
+MediaItem _item(String id) =>
+    MediaItem(id: id, backend: MediaBackend.plex, kind: MediaKind.episode, title: 'Episode $id', serverId: 'server-1');
+
+void main() {
+  group('video playlist repeat', () {
+    test('the launcher queue keeps all 184 items and the selected index', () {
+      final items = List<MediaItem>.generate(184, (index) => _item('$index'));
+
+      final queue = buildRepeatingVideoPlaylistQueue(
+        playlistContextKey: 'playlist-200546',
+        items: items,
+        shuffle: false,
+        startIndex: 183,
+      );
+
+      expect(queue.items, hasLength(184));
+      expect(queue.items.first, same(items.first));
+      expect(queue.items.last, same(items.last));
+      expect(queue.currentIndex, 183);
+      expect(queue.shuffled, isFalse);
+    });
+
+    test('shuffle keeps every queue item in a fully resident queue', () {
+      final items = List<MediaItem>.generate(184, (index) => _item('$index'));
+
+      final queue = buildRepeatingVideoPlaylistQueue(
+        playlistContextKey: 'server-1:playlist-200546',
+        items: items,
+        shuffle: true,
+        random: Random(7),
+      );
+
+      expect(queue.items, hasLength(184));
+      expect(queue.items, unorderedEquals(items));
+      expect(queue.currentIndex, 0);
+      expect(queue.shuffled, isTrue);
+    });
+
+    test('a 184-item local queue wraps from its final item to index zero', () async {
+      final items = List<MediaItem>.generate(184, (index) => _item('$index'));
+      final provider = PlaybackStateProvider();
+      addTearDown(provider.dispose);
+
+      const playlistId = 'playlist-200546';
+      provider.setRepeatForContext(playlistId, true);
+      provider.setPlaybackFromLocalQueue(
+        LocalPlayQueue(
+          id: 'plex:playlist:$playlistId:test',
+          items: items,
+          backendId: MediaBackend.plex.id,
+          currentIndex: items.length - 1,
+        ),
+        contextKey: playlistId,
+      );
+
+      expect(provider.isRepeatActive, isTrue);
+      final result = await provider.getNextEpisode(items.last.id, loopQueue: provider.isRepeatActive);
+
+      expect(result.status, QueueNavigationStatus.found);
+      expect(result.item, same(items.first));
+    });
+
+    test('a one-item local queue repeats the same queue entry', () async {
+      final item = _item('only');
+      final provider = PlaybackStateProvider();
+      addTearDown(provider.dispose);
+
+      const playlistId = 'one-item-playlist';
+      provider.setRepeatForContext(playlistId, true);
+      provider.setPlaybackFromLocalQueue(
+        LocalPlayQueue(
+          id: 'plex:playlist:$playlistId:test',
+          items: [item],
+          backendId: MediaBackend.plex.id,
+          currentIndex: 0,
+        ),
+        contextKey: playlistId,
+      );
+
+      final result = await provider.getNextEpisode(item.id, loopQueue: provider.isRepeatActive);
+
+      expect(result.status, QueueNavigationStatus.found);
+      expect(result.item, same(item));
+    });
+
+    test('local Plex queues ignore stale server queue ids', () {
+      final first = PlexMediaItem(
+        id: 'first',
+        kind: MediaKind.episode,
+        playQueueItemId: 1,
+        title: 'First',
+        serverId: 'server-1',
+      );
+      final second = PlexMediaItem(
+        id: 'second',
+        kind: MediaKind.episode,
+        playQueueItemId: 0,
+        title: 'Second',
+        serverId: 'server-1',
+      );
+      final provider = PlaybackStateProvider();
+      addTearDown(provider.dispose);
+
+      provider.setPlaybackFromLocalQueue(
+        LocalPlayQueue(
+          id: 'plex:playlist:stale-id-test',
+          items: [first, second],
+          backendId: MediaBackend.plex.id,
+          currentIndex: 1,
+        ),
+        contextKey: 'server-1:stale-id-test',
+      );
+
+      expect(provider.playQueueItemIdFor(first), 0);
+      expect(provider.playQueueItemIdFor(second), 1);
+      expect(provider.currentQueueItem, same(second));
+      provider.setCurrentItem(first);
+      expect(provider.currentPlayQueueItemID, 0);
+      expect(provider.currentQueueItem, same(first));
+    });
+
+    test('a windowed Plex server queue is never fake-wrapped', () async {
+      final first = PlexMediaItem(id: 'first', kind: MediaKind.episode, playQueueItemId: 1001, title: 'First');
+      final last = PlexMediaItem(id: 'last', kind: MediaKind.episode, playQueueItemId: 9007, title: 'Last');
+      final provider = PlaybackStateProvider();
+      addTearDown(provider.dispose);
+
+      const playlistId = 'server-window-playlist';
+      provider.setRepeatForContext(playlistId, true);
+      await provider.setPlaybackFromPlayQueue(
+        PlayQueueResponse(
+          playQueueID: 77,
+          playQueueSelectedItemID: 9007,
+          playQueueShuffled: false,
+          playQueueTotalCount: 184,
+          playQueueVersion: 1,
+          size: 2,
+          items: [first, last],
+        ),
+        playlistId,
+      );
+
+      expect(provider.isRepeatActive, isFalse);
+      final result = await provider.getNextEpisode(last.id, loopQueue: true);
+
+      expect(result.status, QueueNavigationStatus.failed);
+      expect(result.item, isNull);
+    });
+
+    test('the same local queue reports a boundary when repeat is off', () async {
+      final items = <MediaItem>[_item('first'), _item('last')];
+      final provider = PlaybackStateProvider();
+      addTearDown(provider.dispose);
+
+      provider.setPlaybackFromLocalQueue(
+        LocalPlayQueue(
+          id: 'plex:playlist:no-repeat:test',
+          items: items,
+          backendId: MediaBackend.plex.id,
+          currentIndex: 1,
+        ),
+        contextKey: 'no-repeat',
+      );
+
+      final result = await provider.getNextEpisode(items.last.id, loopQueue: false);
+
+      expect(result.status, QueueNavigationStatus.boundary);
+      expect(result.item, isNull);
+    });
+
+    test('repeat is active only for its fully resident local playlist queue', () {
+      final items = <MediaItem>[_item('first'), _item('last')];
+      final provider = PlaybackStateProvider();
+      addTearDown(provider.dispose);
+
+      const playlistId = 'playlist-local-only';
+      provider.setRepeatForContext(playlistId, true);
+      expect(provider.isRepeatActive, isFalse);
+
+      provider.setPlaybackFromLocalQueue(
+        LocalPlayQueue(
+          id: 'plex:playlist:$playlistId:test',
+          items: items,
+          backendId: MediaBackend.plex.id,
+          currentIndex: 0,
+        ),
+        contextKey: playlistId,
+      );
+      expect(provider.isRepeatActive, isTrue);
+
+      provider.clearShuffle();
+      expect(provider.isRepeatActive, isFalse);
+      expect(provider.isRepeatEnabledFor(playlistId), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Adds Repeat button between Shuffle and Download.
Uses a complete local queue for repeat-enabled playlists.
Wraps the final item to the actual first item (uses true 0)
Supports normal Play, Shuffle, and selected-item playback.
Preserves the existing behavior when Repeat is off.