### PR TITLE
Add dynamic system language support for Trakt and Plex Discover watchlists

### DIFF
--- a/lib/services/plex_discover_client.dart
+++ b/lib/services/plex_discover_client.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import '../utils/app_logger.dart';
 import '../utils/external_ids.dart';
 import '../utils/json_utils.dart';
+import 'dart:io';
 
 /// Credentials for Plex's cloud Discover provider. The access token is scoped
 /// to the active Plex/Home profile; it must never be logged or persisted here.
@@ -337,6 +338,9 @@ class PlexDiscoverClient {
       'X-Plex-Client-Identifier': session.clientIdentifier,
       'X-Plex-Product': 'Plezy',
       'X-Plex-Version': '2',
+      'X-Plex-Language': Platform.localeName.split('_')[0],
+      'Accept-Language': Platform.localeName.split('_')[0],
+      // ---------------------------------------------
     };
     final request = switch (method) {
       'GET' => _http.get(uri, headers: headers),

--- a/lib/services/trackers/trakt/trakt_client.dart
+++ b/lib/services/trackers/trakt/trakt_client.dart
@@ -17,6 +17,7 @@ import '../tracker_http_client.dart';
 import '../tracker_session.dart';
 import 'trakt_constants.dart';
 import '../tracker_page.dart';
+import 'dart:io';
 
 /// HTTP wrapper for the Trakt REST API.
 ///
@@ -346,6 +347,9 @@ class TraktClient implements DisposableTrackerClient {
   Future<http.Response> _send(String method, String path, {Map<String, dynamic>? body}) async {
     final uri = Uri.parse('${TraktConstants.apiBase}$path');
     final headers = TraktConstants.headers(accessToken: _session.accessToken);
+
+    headers['Accept-Language'] = Platform.localeName.split('_')[0];
+
     return _http.sendJson(
       method,
       uri,


### PR DESCRIPTION
Currently, when loading the Watchlist from Trakt or Plex Discover, the initial metadata (synopses, titles, etc.) defaults to English. This forces non-English users to read the Explore tab in English, and the UI only switches to their native language after they click "Play" and the app reads the local Plex metadata.

Solution:
I added dynamic language headers to the API requests. The app now uses Platform.localeName to detect the OS language on the fly.

In trakt_client.dart: Added Accept-Language header.

In plex_discover_client.dart: Added X-Plex-Language and Accept-Language headers.

Now, when a user opens their Watchlist, Trakt and Plex Discover will return the metadata in the user's native system language right from the start, improving the initial user experience.