### PR TITLE
fix(linux): do not schedule audio recovery after playback resume

### DIFF
--- a/linux/runner/mpv/mpv_player.cc
+++ b/linux/runner/mpv/mpv_player.cc
@@ -641,17 +641,6 @@ void MpvPlayer::SetPropertyAsync(const std::string& name, const std::string& val
     SetHDREnabled(plezy::mpv_common::ParseEnabledFlag(value), std::move(callback));
     return;
   }
-
-  if (name == "pause" && !plezy::mpv_common::ParseEnabledFlag(value)) {
-    auto completion = std::move(callback);
-    callback = [this, completion = std::move(completion)](int error) {
-      if (error >= 0 && !disposed_) {
-        audio_recovery_.RequestResume();
-        EnsureAudioRecoveryTimer();
-      }
-      if (completion) completion(error);
-    };
-  }
   plezy::mpv_common::SubmitSetPropertyAsync(mpv_, pending_requests_, name, value, std::move(callback));
 }
 


### PR DESCRIPTION
This was resulting in two audio stutters per playback resume.

Regression originates in 9f2e05079 (release 2.10.0).