### PR TITLE
fix(home): reload hubs when the "Use Home Layout" toggle changes

### DIFF
--- a/lib/providers/discover_provider.dart
+++ b/lib/providers/discover_provider.dart
@@ -58,6 +58,13 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     _hiddenLibraries.addListener(_onHiddenLibrariesChanged);
     _lastSeenLibraryOrderKeys = _libraryOrderKeys();
     _libraries.addListener(_onLibrariesChanged);
+    // The "Use Home Layout" toggle picks a different hub-fetch strategy (see
+    // getHubsFromAllServers), so it needs the same full-reload treatment as a
+    // hidden-library change — otherwise the setting silently does nothing
+    // until the next unrelated reload (e.g. app restart) picks it up (#1120,
+    // #1291, #1652).
+    _useGlobalHubsListenable = SettingsService.instance.listenable(SettingsService.useGlobalHubs);
+    _useGlobalHubsListenable.addListener(_onUseGlobalHubsChanged);
     _watchStateSubscription = subscribeToHierarchicalEvents<WatchStateEvent>(
       notifier: WatchStateNotifier(),
       mounted: () => !isDisposed,
@@ -105,6 +112,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
 
   Set<String> _lastSeenHiddenKeys = {};
   List<String> _lastSeenLibraryOrderKeys = const [];
+  late final ValueListenable<bool> _useGlobalHubsListenable;
 
   /// Online servers whose Continue Watching fetch succeeded in the current
   /// on-deck list. Tracked separately from hubs so a transient failure in one
@@ -534,6 +542,10 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     unawaited(refreshContinueWatching());
   }
 
+  void _onUseGlobalHubsChanged() {
+    unawaited(load());
+  }
+
   void _onHiddenLibrariesChanged() {
     final currentKeys = _hiddenLibraries.hiddenLibraryKeys;
     if (currentKeys.length == _lastSeenHiddenKeys.length && currentKeys.containsAll(_lastSeenHiddenKeys)) {
@@ -624,6 +636,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   @override
   void dispose() {
     _multiServer.removeOnlineServersListener(syncToOnlineServers);
+    _useGlobalHubsListenable.removeListener(_onUseGlobalHubsChanged);
     _hiddenLibraries.removeListener(_onHiddenLibrariesChanged);
     _libraries.removeListener(_onLibrariesChanged);
     _watchStateSubscription?.cancel();

--- a/test/providers/discover_provider_test.dart
+++ b/test/providers/discover_provider_test.dart
@@ -497,6 +497,37 @@ void main() {
     expect(aggregation.hubCalls, hubCallsBefore + 1);
   });
 
+  // Regression test for #1120/#1291: toggling "Use Home Layout" persisted the
+  // preference but never told an already-loaded DiscoverProvider to refetch,
+  // so the effect was invisible until the next unrelated reload (e.g. an app
+  // restart). Mirrors the hidden-library test above, which already covers the
+  // correct "one setting change, one full reload" contract.
+  test('useGlobalHubs change triggers exactly one full reload', () async {
+    await provider.load();
+    final onDeckCallsBefore = aggregation.onDeckCalls;
+    final hubCallsBefore = aggregation.hubCalls;
+
+    final current = SettingsService.instance.read(SettingsService.useGlobalHubs);
+    await SettingsService.instance.write(SettingsService.useGlobalHubs, !current);
+    await pumpEventQueue();
+
+    expect(aggregation.onDeckCalls, onDeckCallsBefore + 1);
+    expect(aggregation.hubCalls, hubCallsBefore + 1);
+  });
+
+  test('writing the same useGlobalHubs value again triggers no reload', () async {
+    await provider.load();
+    final onDeckCallsBefore = aggregation.onDeckCalls;
+    final hubCallsBefore = aggregation.hubCalls;
+
+    final current = SettingsService.instance.read(SettingsService.useGlobalHubs);
+    await SettingsService.instance.write(SettingsService.useGlobalHubs, current);
+    await pumpEventQueue();
+
+    expect(aggregation.onDeckCalls, onDeckCallsBefore);
+    expect(aggregation.hubCalls, hubCallsBefore);
+  });
+
   test('refreshContinueWatching never flips states or surfaces errors', () async {
     aggregation.onDeckResult = () => [_item('a')];
     await provider.load();


### PR DESCRIPTION
## What this fixes

Toggling "Use Home Layout" (`useGlobalHubs`) saves the setting but never tells an already-loaded home screen to refetch. The change stays invisible until the next unrelated reload, usually an app restart. Users hit this on iOS and Windows in #1291, and on Android in #1120: toggling it, even restarting, still showed no change.

## Root cause

`DiscoverProvider` reads `useGlobalHubs` fresh on every load. Nothing told it when to reload after the setting changed. The switch tile saves the value and stops there. Hidden libraries and library order both trigger a reload when they change. This setting never got that wiring.

## Fix

`DiscoverProvider` now listens to the pref's own `ValueNotifier` and triggers a full reload when it changes. This mirrors the existing hidden-library-change handler.

## Testing

- A new test toggles the setting and asserts exactly one reload fires. Reverting the fix makes this test fail, so it's a real regression test, not a tautology.
- A second test writes the same value again and asserts no reload fires.
- Full existing suite still passes (35/35). `flutter analyze` is clean.

## Scope / what this is not

This fixes the toggle failing without a restart. It doesn't guarantee a merged home layout on every server. When `useGlobalHubs` is on, Plezy defers to the Plex server's own global hub endpoint. If your Plex account never enabled Plex's "combine hubs of similar library type" setting, you'll still see one row per library after this fix, because Plezy relays what Plex sends back instead of merging client-side.

#1652 asks for the real fix: user-controlled merging that works the same way on Jellyfin, and doesn't depend on a Plex setting most people never find. That's a bigger feature. This PR is the focused piece first.

Refs #1120, #1291, #1652