### PR TITLE
fix(auth): fall back to xdg-open when gio launch fails on Linux

### DIFF
--- a/lib/screens/auth/plex_pin_auth_flow.dart
+++ b/lib/screens/auth/plex_pin_auth_flow.dart
@@ -10,6 +10,7 @@ import '../../services/plex_auth_service.dart';
 import '../../focus/focusable_button.dart';
 import '../../theme/mono_tokens.dart';
 import '../../utils/app_logger.dart';
+import '../../utils/external_url_launcher.dart';
 import '../../utils/platform_detector.dart';
 
 /// Whether the Plex PIN hand-off must stay in-app as a QR code instead of
@@ -158,9 +159,11 @@ class _PlexPinAuthFlowState extends State<PlexPinAuthFlow> {
           final mode = PlatformDetector.isTV() ? LaunchMode.inAppWebView : LaunchMode.inAppBrowserView;
           await launchUrl(uri, mode: mode);
         } catch (_) {
-          // Chrome Custom Tabs may not be available — fall back to default
-          // external browser.
-          await launchUrl(uri, mode: LaunchMode.externalApplication);
+          // Chrome Custom Tabs / the in-app browser may be unavailable — fall
+          // back to the system browser. launchExternalUrl adds a Linux
+          // xdg-open fallback for desktops where url_launcher's gio path is
+          // missing (#1477).
+          await launchExternalUrl(uri);
         }
       }
 

--- a/lib/utils/external_url_launcher.dart
+++ b/lib/utils/external_url_launcher.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:url_launcher/url_launcher.dart';
+
+import 'app_logger.dart';
+
+/// Opens [uri] in the system's external handler, with a Linux fallback.
+///
+/// On Linux, `url_launcher` opens URLs through GLib, which execs the
+/// `gio-launch-desktop` helper. That helper is absent on some desktops (seen
+/// on Fedora/KDE that don't pull in the GTK stack), so `launchUrl` throws
+/// `Failed to execute child process "gio-launch-desktop"`. For the Plex PIN
+/// sign-in that surfaced as an unrecoverable "Plex PIN auth failed" error
+/// (#1477). When the primary launch fails on Linux, fall back to `xdg-open`,
+/// which is desktop-agnostic and shipped by xdg-utils.
+///
+/// Returns `true` when either the primary launcher or the fallback reports the
+/// URL was handled. On non-Linux platforms a thrown primary launch is
+/// rethrown, matching `launchUrl`'s own contract; on Linux the throw is
+/// swallowed in favour of the fallback.
+///
+/// The [launcher], [fallback] and [isLinuxOverride] parameters exist as
+/// injection seams for tests; production callers pass a [uri] and, optionally,
+/// a [mode].
+Future<bool> launchExternalUrl(
+  Uri uri, {
+  LaunchMode mode = LaunchMode.externalApplication,
+  UrlLauncher launcher = _launchViaUrlLauncher,
+  FallbackLauncher fallback = _launchViaXdgOpen,
+  bool? isLinuxOverride,
+}) async {
+  final isLinux = isLinuxOverride ?? Platform.isLinux;
+  try {
+    if (await launcher(uri, mode: mode)) return true;
+    // launchUrl returned false rather than throwing (no handler); on Linux the
+    // gio path may simply have declined, so still try xdg-open below.
+  } catch (e, st) {
+    appLogger.w('launchUrl failed for $uri', error: e, stackTrace: st);
+    if (!isLinux) rethrow;
+  }
+  if (isLinux) return fallback(uri.toString());
+  return false;
+}
+
+typedef UrlLauncher = Future<bool> Function(Uri uri, {LaunchMode mode});
+typedef FallbackLauncher = Future<bool> Function(String url);
+
+Future<bool> _launchViaUrlLauncher(Uri uri, {LaunchMode mode = LaunchMode.externalApplication}) {
+  return launchUrl(uri, mode: mode);
+}
+
+Future<bool> _launchViaXdgOpen(String url) async {
+  try {
+    final result = await Process.start('xdg-open', [url], mode: ProcessStartMode.detached);
+    appLogger.d('Launched xdg-open for $url with PID: ${result.pid}');
+    return true;
+  } catch (e) {
+    appLogger.w('xdg-open fallback failed for $url', error: e);
+    return false;
+  }
+}

--- a/test/utils/external_url_launcher_test.dart
+++ b/test/utils/external_url_launcher_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/utils/external_url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void main() {
+  final uri = Uri.parse('https://plex.tv/link');
+
+  group('launchExternalUrl', () {
+    test('returns true and skips the fallback when the primary launch succeeds', () async {
+      var fallbackCalls = 0;
+      final result = await launchExternalUrl(
+        uri,
+        launcher: (uri, {mode = LaunchMode.externalApplication}) async => true,
+        fallback: (url) async {
+          fallbackCalls++;
+          return true;
+        },
+        isLinuxOverride: true,
+      );
+
+      expect(result, isTrue);
+      expect(fallbackCalls, 0);
+    });
+
+    test('forwards the requested mode to the primary launcher', () async {
+      LaunchMode? seenMode;
+      await launchExternalUrl(
+        uri,
+        mode: LaunchMode.inAppBrowserView,
+        launcher: (uri, {mode = LaunchMode.externalApplication}) async {
+          seenMode = mode;
+          return true;
+        },
+        fallback: (url) async => false,
+        isLinuxOverride: false,
+      );
+
+      expect(seenMode, LaunchMode.inAppBrowserView);
+    });
+
+    test('falls back to xdg-open on Linux when the primary launch throws (gio missing)', () async {
+      String? fallbackUrl;
+      final result = await launchExternalUrl(
+        uri,
+        launcher: (uri, {mode = LaunchMode.externalApplication}) async {
+          throw Exception('Failed to execute child process "gio-launch-desktop"');
+        },
+        fallback: (url) async {
+          fallbackUrl = url;
+          return true;
+        },
+        isLinuxOverride: true,
+      );
+
+      expect(result, isTrue);
+      expect(fallbackUrl, uri.toString());
+    });
+
+    test('falls back on Linux when the primary launch returns false', () async {
+      var fallbackCalls = 0;
+      final result = await launchExternalUrl(
+        uri,
+        launcher: (uri, {mode = LaunchMode.externalApplication}) async => false,
+        fallback: (url) async {
+          fallbackCalls++;
+          return true;
+        },
+        isLinuxOverride: true,
+      );
+
+      expect(result, isTrue);
+      expect(fallbackCalls, 1);
+    });
+
+    test('rethrows on non-Linux platforms without invoking the fallback', () async {
+      var fallbackCalls = 0;
+      await expectLater(
+        launchExternalUrl(
+          uri,
+          launcher: (uri, {mode = LaunchMode.externalApplication}) async {
+            throw Exception('custom tabs unavailable');
+          },
+          fallback: (url) async {
+            fallbackCalls++;
+            return true;
+          },
+          isLinuxOverride: false,
+        ),
+        throwsException,
+      );
+      expect(fallbackCalls, 0);
+    });
+
+    test('returns false on non-Linux when the primary launch returns false', () async {
+      final result = await launchExternalUrl(
+        uri,
+        launcher: (uri, {mode = LaunchMode.externalApplication}) async => false,
+        fallback: (url) async => true,
+        isLinuxOverride: false,
+      );
+
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Fixes #1477. On some Linux desktops, "Sign in with Plex" fails with:

```
Plex PIN auth failed  ERROR: PlatformException(Launch Error, Failed to launch URL:
Failed to execute child process "gio-launch-desktop" (No such file or directory), null, null)
```

## Why

`url_launcher` opens URLs on Linux through GLib, which execs the `gio-launch-desktop` helper. That helper is not present on every desktop (reported on Fedora/KDE without the GTK stack), so `launchUrl` throws. In the Plex PIN flow both the primary (`inAppBrowserView`) and the existing external-browser fallback route through the same gio path, so the error propagates to the flow's catch and shows an unrecoverable "Plex PIN auth failed" message — the user can never sign in.

## Change

- Add `lib/utils/external_url_launcher.dart` with `launchExternalUrl`, which retries via `xdg-open` (desktop-agnostic, shipped by xdg-utils) when the primary launch fails on Linux. On non-Linux a thrown launch is rethrown, preserving `launchUrl`'s existing contract.
- Route the sign-in's external-browser fallback in `plex_pin_auth_flow.dart` through it. Behavior on macOS/Windows/mobile/TV is unchanged.

The helper is written with injection seams so its branching is unit-tested without a real launcher.

## Tests

`test/utils/external_url_launcher_test.dart` covers: primary success skips the fallback; the requested `LaunchMode` is forwarded; a Linux throw (gio missing) and a Linux `false` return both fall back to xdg-open; non-Linux rethrows/returns false without invoking the fallback.

`flutter analyze`, `dart format`, the `dart_code_linter` unused-code/unused-files checks, and the existing `plex_pin_auth_flow` / `auth_screen` tests pass locally. I don't have a Fedora/KDE machine to reproduce the original gio failure end-to-end; the fallback path is covered by the injected-launcher tests.