### PR TITLE
fix(macos): keep window events reaching other plugins

### DIFF
--- a/macos/Runner/WindowDelegate.swift
+++ b/macos/Runner/WindowDelegate.swift
@@ -5,6 +5,19 @@ class WindowDelegate: NSObject, NSWindowDelegate {
   weak var channel: FlutterMethodChannel?
   weak var window: NSWindow?
 
+  /// The delegate this one displaced, kept so plugins that read window events
+  /// through their own delegate keep receiving them.
+  ///
+  /// A window has exactly one delegate, so installing ours silently cut off
+  /// every plugin that installs its own — window_manager sources all of its
+  /// Dart-side events (focus, blur, move, resize, maximize, minimize) from
+  /// `NSWindowDelegate` callbacks and claims the slot when it initialises. It
+  /// happens to initialise just before us, so its events stopped arriving
+  /// entirely: `onWindowFocus` never fired, and the player's handler for it was
+  /// dead code on macOS. Unimplemented callbacks reach it by message
+  /// forwarding; the ones implemented below chain explicitly.
+  weak var previousDelegate: NSWindowDelegate?
+
   // Hardcoded presentation options for fullscreen mode
   // Auto-hide toolbar, menu bar, and dock when in fullscreen
   private let fullScreenPresentationOptions: NSApplication.PresentationOptions = [
@@ -50,12 +63,32 @@ class WindowDelegate: NSObject, NSWindowDelegate {
     WindowUtilsPlugin.setTrafficLightPositions(custom: true, window: window)
   }
 
+  // MARK: - Delegate chaining
+
+  // Everything this class does not implement is handed to the displaced
+  // delegate by the runtime: `responds(to:)` claims its selectors so the
+  // message is dispatched, and `forwardingTarget(for:)` then routes it there.
+  // Callbacks implemented below are chained by hand instead, since claiming
+  // them here would stop at this object.
+
+  override func responds(to aSelector: Selector!) -> Bool {
+    if super.responds(to: aSelector) { return true }
+    return previousDelegate?.responds(to: aSelector) ?? false
+  }
+
+  override func forwardingTarget(for aSelector: Selector!) -> Any? {
+    if super.responds(to: aSelector) { return nil }
+    return previousDelegate
+  }
+
   // MARK: - NSWindowDelegate
 
   func window(
     _ window: NSWindow,
     willUseFullScreenPresentationOptions proposedOptions: NSApplication.PresentationOptions
   ) -> NSApplication.PresentationOptions {
+    // Not chained: these options are this app's own fullscreen presentation
+    // choice, and only one answer can win.
     return fullScreenPresentationOptions
   }
 
@@ -64,10 +97,12 @@ class WindowDelegate: NSObject, NSWindowDelegate {
     applyFullScreenChrome(to: window)
     // Notify Dart for state management only
     emit("windowWillEnterFullScreen")
+    previousDelegate?.windowWillEnterFullScreen?(notification)
   }
 
   func windowDidEnterFullScreen(_ notification: Notification) {
     emit("windowDidEnterFullScreen")
+    previousDelegate?.windowDidEnterFullScreen?(notification)
   }
 
   func windowWillExitFullScreen(_ notification: Notification) {
@@ -76,11 +111,13 @@ class WindowDelegate: NSObject, NSWindowDelegate {
     window.titleVisibility = .hidden
     window.titlebarAppearsTransparent = true
     emit("windowWillExitFullScreen")
+    previousDelegate?.windowWillExitFullScreen?(notification)
   }
 
   func windowDidExitFullScreen(_ notification: Notification) {
     guard let window = window else { return }
     applyWindowedChrome(to: window)
     emit("windowDidExitFullScreen")
+    previousDelegate?.windowDidExitFullScreen?(notification)
   }
 }

--- a/macos/Runner/WindowUtilsPlugin.swift
+++ b/macos/Runner/WindowUtilsPlugin.swift
@@ -182,6 +182,13 @@ class WindowUtilsPlugin: NSObject, FlutterPlugin {
     let delegate = windowDelegate ?? WindowDelegate()
     delegate.channel = channel
     delegate.window = window
+    // Keep whoever held the slot so their callbacks survive ours. This runs
+    // both from `awakeFromNib` (nothing to displace yet) and again from Dart
+    // once plugins have registered, which is when window_manager's delegate is
+    // the one being replaced. Re-installing must never chain to ourselves.
+    if let displaced = window.delegate, !(displaced === delegate) {
+      delegate.previousDelegate = displaced
+    }
     windowDelegate = delegate
     window.delegate = delegate
   }


### PR DESCRIPTION
#1797 is still reproducible on macOS, and the fix for it cannot run there.

A window has one `NSWindowDelegate`. The runner takes it in
`MainFlutterWindow.awakeFromNib`, and `MacOSWindowService.setupCustomTitlebar()`
takes it again from Dart — on the line straight after
`windowManager.ensureInitialized()` has claimed it:

```dart
await windowManager.ensureInitialized();
if (Platform.isMacOS) await MacOSWindowService.setupCustomTitlebar();
```

window_manager reads every one of its Dart-side events off that delegate
(`windowDidBecomeMain`/`windowDidResignMain` for focus and blur, plus move,
resize, maximize, minimize, fullscreen). `WindowDelegate` implements the five
fullscreen callbacks and forwards nothing, so from the moment the titlebar is
set up none of those events arrive. Every `WindowListener` override in the app
is dead code on macOS — nothing errors, the callbacks are simply never called.

That is why #1797 still reproduces here. `onWindowFocus` is what hands the
remote back to the player surface after a window switch, and it has never fired
on macOS: measured on a debug build, zero focus callbacks across six real
window focus transitions. Flutter drops primary focus to the root scope on
re-activation, the player screen's self-heal takes it onto its own node, and the
first arrow key reaches that node and raises the OSD instead of seeking.

This keeps the displaced delegate and passes callbacks on to it. Ones we do not
implement reach it by message forwarding; the five fullscreen ones chain
explicitly, since implementing a selector stops forwarding from firing for it.
`window(_:willUseFullScreenPresentationOptions:)` stays unchained — it returns a
value and the presentation options are ours. Re-installing will not chain to
itself.

No Dart changes: `onWindowFocus` fires again and the existing
`_claimPlayerSurfaceFocus()` does what it was written to do.

Verified on a real macOS build. Before: 0 focus callbacks in 6 window switches,
first arrow raised the OSD 3/3. After: 3/3 callbacks, first arrow seeks 3/3, in
both windowed and native-fullscreen. Full Dart suite green (5637 passed, 5
skipped), `scripts/format_native.sh` clean.

Worth a second look: this also revives the overrides that were equally inert —
`onWindowClose`, the gamepad service's blur/focus input-state reset,
enter/leave fullscreen, and maximize/unmaximize. All are idempotent state
setters, and fullscreen state has an independent source through this plugin's
own method channel, so the two agree rather than compete. I re-tested fullscreen
enter/exit after the change. It is still code that has not executed on macOS for
as long as the delegate has been overwritten.

`onWindowMaximize` treats a macOS maximize as fullscreen, per the existing
comment. That is now reachable where it was not before; I have left the
behaviour as written rather than change intent here.

The existing `video_controls_window_focus_test.dart` suite is untouched and
passed throughout, including while this was broken — it invokes
`onWindowFocus()` directly, which is why the platform-level breakage was
invisible to it.
