### PR TITLE
fix(plex): carry embedded subtitles in the transcode

### DIFF
--- a/lib/screens/video_player/parts/build.dart
+++ b/lib/screens/video_player/parts/build.dart
@@ -293,6 +293,7 @@ extension _VideoPlayerBuildMethods on VideoPlayerScreenState {
                         selectedQualityPreset: _selectedQualityPreset,
                         serverSupportsTranscoding: _serverSupportsTranscoding,
                         isTranscoding: _isTranscoding,
+                        subtitleTimelineOffsetMs: _subtitleTimelineOffsetMs,
                         isOfflinePlayback: _isOfflinePlayback,
                         sourceAudioTracks: sourceAudioTracks,
                         selectedAudioStreamId: _selectedAudioStreamId,

--- a/lib/screens/video_player/parts/episode_navigation.dart
+++ b/lib/screens/video_player/parts/episode_navigation.dart
@@ -831,7 +831,10 @@ extension _VideoPlayerEpisodeNavigationMethods on VideoPlayerScreenState {
           preferredSubtitleTrack:
               subtitleSelection.declinedPreference ?? SubtitlePreference.trackOrNull(subtitleSelection.primaryTrack),
           preferredSecondarySubtitleTrack: SubtitlePreference.trackOrNull(subtitleSelection.secondaryTrack),
+          subtitleIsBurnedIn: result.burnedInSubtitleStreamId != null,
         );
+        _subtitleTimelineOffsetMs = result.subtitleTimelineOffsetMs;
+        await _applySubtitleSyncOffset(currentPlayer, settingsService);
         _trackManager = trackManager;
         trackManager.cacheExternalSubtitles(subtitleSelection.sidecarsAtOpen);
 

--- a/lib/screens/video_player/parts/playback_open.dart
+++ b/lib/screens/video_player/parts/playback_open.dart
@@ -66,6 +66,51 @@ class _MediaOpenResult {
   final bool sidecarFallbackUsed;
 }
 
+/// The mpv network/subtitle tuning every open writes, set or reset, so a
+/// reused player never carries one item's tuning into the next open. Pure so
+/// tests can pin the exact writes per mode; [_applyNetworkStreamTuning] is the
+/// only production caller.
+@visibleForTesting
+Map<String, String> networkStreamTuningProperties({required bool isNetworkVod, required bool isTranscoding}) {
+  return {
+    // Covers network drops up to 10 min; applies to transcode streams too.
+    //
+    // reconnect_on_http_error=503: without it, ffmpeg abandons a reconnect
+    // that gets an HTTP error and the truncated body surfaces as a clean
+    // mid-file EOF (#1520 — PMS answers 503 while restarting/maintenance).
+    // Deliberately 503 only: a persistent 500 must keep failing fast so the
+    // server-limit dialog (_httpStatusPattern) appears promptly, and a
+    // multi-code list would need mpv's %len% quoting to survive the
+    // comma-separated option string. While ffmpeg retries, mpv reports
+    // buffering, which also makes the server-online reconnect hook in
+    // _wirePlayerStreams reachable.
+    'stream-lavf-o': isNetworkVod
+        ? 'reconnect=1,reconnect_on_network_error=1,reconnect_on_http_error=503,'
+              'reconnect_streamed=1,reconnect_delay_max=600'
+        : '',
+    // `stream-lavf-o` only reaches the playlist fetch; ffmpeg's hls demuxer
+    // opens each segment itself and takes its options from here instead.
+    //
+    // Plex serves WebVTT subtitle segments with **no Content-Length**
+    // (measured: `declaredLen=null actualLen=126 encoding=Identity`), so
+    // ffmpeg cannot tell a complete body from a truncated one. Every clean EOF
+    // looked like an interrupted transfer, it re-requested at the byte offset,
+    // and PMS answered `416 Requested Range Not Satisfiable` on a doubling
+    // backoff that never resolved — playback never started (#1738). Segment
+    // retries belong to the hls demuxer, which re-reads the playlist, so the
+    // HTTP layer must not second-guess a finished segment.
+    'demuxer-lavf-o': isTranscoding ? 'reconnect=0,reconnect_streamed=0,reconnect_on_network_error=0' : '',
+    // A seek inside an HLS transcode makes ffmpeg re-deliver WebVTT cues and
+    // restart their ReadOrder numbering, so mpv's usual dedup by ReadOrder
+    // misses and identical cues render stacked on top of each other (#1738).
+    // Clearing cached subtitle events on seek is mpv's remedy for exactly
+    // this; the rendition is demuxed, so cues re-arrive after the seek and
+    // nothing is lost. Scoped to transcodes — for ordinary files the cache
+    // is correct and keeping it avoids re-reading sidecars on every seek.
+    'sub-clear-on-seek': isTranscoding ? 'yes' : 'no',
+  };
+}
+
 /// Shared building blocks for opening media on the live player.
 ///
 /// The initial start flow ([_startPlayback]) and in-place reload flow
@@ -76,7 +121,19 @@ class _MediaOpenResult {
 /// [SettingsService.displaySwitchDelay].
 extension _VideoPlayerOpenMethods on VideoPlayerScreenState {
   PlaybackSession _commitSidecarFallbackSession(PlaybackSession session) {
-    return _updatePlaybackSessionSubtitleSelection(session, const PlaybackSubtitleSelection.off());
+    return _updatePlaybackSessionSubtitleSelection(
+      session,
+      subtitleSelectionForSidecarFallback(session.subtitleSelection),
+    );
+  }
+
+  /// Push the effective subtitle delay for the source that just opened: the
+  /// viewer's own offset plus whatever timeline compensation the backend
+  /// forces on us (#1738). Runs after the playback result resolves, because
+  /// player configuration happens before the backend has told us anything.
+  Future<void> _applySubtitleSyncOffset(Player forPlayer, SettingsService settingsService) async {
+    final offsetMs = settingsService.read(SettingsService.subtitleSyncOffset) + _subtitleTimelineOffsetMs;
+    await forPlayer.setProperty('sub-delay', (offsetMs / 1000.0).toString());
   }
 
   Future<PlaybackSubtitleSelection> _resolveSubtitleSelectionForOpen({
@@ -467,6 +524,7 @@ extension _VideoPlayerOpenMethods on VideoPlayerScreenState {
     AudioTrack? preferredAudioTrack,
     SubtitlePreference? preferredSubtitleTrack,
     SubtitlePreference? preferredSecondarySubtitleTrack,
+    bool subtitleIsBurnedIn = false,
   }) {
     return TrackManager(
       player: forPlayer,
@@ -478,6 +536,7 @@ extension _VideoPlayerOpenMethods on VideoPlayerScreenState {
       waitForProfileSettings: _waitForProfileSettingsIfNeeded,
       metadata: metadata,
       mediaInfo: _currentMediaInfo,
+      subtitleIsBurnedIn: subtitleIsBurnedIn,
       preferredAudioTrack: preferredAudioTrack,
       preferredSubtitleTrack: preferredSubtitleTrack,
       preferredSecondarySubtitleTrack: preferredSecondarySubtitleTrack,
@@ -554,25 +613,11 @@ extension _VideoPlayerOpenMethods on VideoPlayerScreenState {
     required bool isTranscoding,
     required MediaVersion? selectedVersion,
   }) async {
-    if (isNetworkVod) {
-      // Covers network drops up to 10 min; applies to transcode streams too.
-      //
-      // reconnect_on_http_error=503: without it, ffmpeg abandons a reconnect
-      // that gets an HTTP error and the truncated body surfaces as a clean
-      // mid-file EOF (#1520 — PMS answers 503 while restarting/maintenance).
-      // Deliberately 503 only: a persistent 500 must keep failing fast so the
-      // server-limit dialog (_httpStatusPattern) appears promptly, and a
-      // multi-code list would need mpv's %len% quoting to survive the
-      // comma-separated option string. While ffmpeg retries, mpv reports
-      // buffering, which also makes the server-online reconnect hook in
-      // _wirePlayerStreams reachable.
-      await player.setProperty(
-        'stream-lavf-o',
-        'reconnect=1,reconnect_on_network_error=1,reconnect_on_http_error=503,'
-            'reconnect_streamed=1,reconnect_delay_max=600',
-      );
-    } else {
-      await player.setProperty('stream-lavf-o', '');
+    for (final entry in networkStreamTuningProperties(
+      isNetworkVod: isNetworkVod,
+      isTranscoding: isTranscoding,
+    ).entries) {
+      await player.setProperty(entry.key, entry.value);
     }
 
     int? ringBytes;

--- a/lib/screens/video_player/parts/playback_start.dart
+++ b/lib/screens/video_player/parts/playback_start.dart
@@ -355,7 +355,10 @@ extension _VideoPlayerPlaybackStartMethods on VideoPlayerScreenState {
           preferredSubtitleTrack:
               subtitleSelection.declinedPreference ?? SubtitlePreference.trackOrNull(subtitleSelection.primaryTrack),
           preferredSecondarySubtitleTrack: SubtitlePreference.trackOrNull(subtitleSelection.secondaryTrack),
+          subtitleIsBurnedIn: result.burnedInSubtitleStreamId != null,
         );
+        _subtitleTimelineOffsetMs = result.subtitleTimelineOffsetMs;
+        await _applySubtitleSyncOffset(currentPlayer, settingsService);
 
         // Store only the active sidecars for re-use after backend fallback.
         _trackManager!.cacheExternalSubtitles(subtitleSelection.sidecarsAtOpen);

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -233,6 +233,23 @@ PlaybackSubtitleSelection subtitleSelectionForUserPick({
   );
 }
 
+/// Builds the committed selection after a stalled subtitle sidecar forced a
+/// reopen without subtitles.
+///
+/// Nothing is attached after that reopen, so the selection goes off — but the
+/// viewer never asked for off. Recording the unserved choice as a declined
+/// carry keeps it out of `subtitleOffIsDeliberate`, so a sidecar the server
+/// was merely slow to produce cannot persist -1 over the viewer's stored
+/// choice, and it leaves a late native pass (or the next item) something to
+/// serve. A selection that was already off stays a deliberate off.
+PlaybackSubtitleSelection subtitleSelectionForSidecarFallback(PlaybackSubtitleSelection currentSelection) {
+  return PlaybackSubtitleSelection.off(
+    declinedPreference:
+        currentSelection.declinedPreference ??
+        (currentSelection.isOff ? null : SubtitlePreference.trackOrNull(currentSelection.primaryTrack)),
+  );
+}
+
 /// Session-preference form of a source-catalog subtitle choice that had to
 /// go through a reload instead of a local track switch.
 ///
@@ -825,6 +842,9 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
   // UI readiness may be forced true to hide the loading spinner after a
   // startup failure. Reporting readiness is stricter: only a renderer event
   // (or the established non-ExoPlayer position fallback) sets this latch.
+  /// Milliseconds the active source's subtitle timeline leads its video, which
+  /// the player adds to the viewer's own sync offset (#1738). Reset per open.
+  int _subtitleTimelineOffsetMs = 0;
   bool _hasRenderedFirstFrame = false;
   bool _hasFatalPlaybackError = false;
 
@@ -1409,11 +1429,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
         await currentPlayer.setProperty('audio-delay', offsetSeconds.toString());
       }
 
-      final subtitleSyncOffset = settingsService.read(SettingsService.subtitleSyncOffset);
-      if (subtitleSyncOffset != 0) {
-        final offsetSeconds = subtitleSyncOffset / 1000.0;
-        await currentPlayer.setProperty('sub-delay', offsetSeconds.toString());
-      }
+      await _applySubtitleSyncOffset(currentPlayer, settingsService);
 
       if (settingsService.read(SettingsService.audioNormalization)) {
         await currentPlayer.setAudioNormalization(true);

--- a/lib/services/playback_initialization_types.dart
+++ b/lib/services/playback_initialization_types.dart
@@ -115,6 +115,23 @@ class PlaybackInitializationResult {
   /// `true` when [videoUrl] points at a backend transcoding stream.
   final bool isTranscoding;
 
+  /// Milliseconds the backend's subtitle timeline leads the video timeline.
+  ///
+  /// Plex's HLS transcode starts its presentation clock at a fixed PTS base
+  /// and declares it in the WebVTT rendition as
+  /// `X-TIMESTAMP-MAP=LOCAL:00:00.000,MPEGTS:900000` (900000 / 90000 Hz =
+  /// 10s). mpv does not apply that map, so every cue lands that far early
+  /// (measured on iOS against PMS 1.43, #1738). Callers add this to the
+  /// viewer's own sync offset when setting `sub-delay`.
+  final int subtitleTimelineOffsetMs;
+
+  /// Source stream id of a subtitle the backend rendered into the video.
+  ///
+  /// A burned-in subtitle is pixels, not a track: nothing will ever appear in
+  /// the player's subtitle list for it, so the track layer must treat the
+  /// choice as already served instead of waiting for a native track (#1738).
+  final int? burnedInSubtitleStreamId;
+
   /// Non-null when a non-original preset was requested but fallback kicked in.
   final TranscodeFallbackReason? fallbackReason;
 
@@ -157,6 +174,8 @@ class PlaybackInitializationResult {
     this.videoUrl,
     this.mediaInfo,
     this.subtitleSidecars = const [],
+    this.burnedInSubtitleStreamId,
+    this.subtitleTimelineOffsetMs = 0,
     this.isOffline = false,
     this.isTranscoding = false,
     this.fallbackReason,

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import '../utils/isolate_helper.dart';
 import '../utils/json_utils.dart';
 import 'package:flutter/foundation.dart';
@@ -27,6 +28,7 @@ import 'bif_thumbnail_service.dart';
 import 'download_artwork_helpers.dart';
 import 'settings_service.dart';
 import 'library_query_translator.dart';
+import 'plex_hls_timestamp_map.dart';
 import 'scrub_preview_source.dart';
 import '../utils/media_server_http_client.dart';
 import '../utils/url_utils.dart';
@@ -73,6 +75,7 @@ import 'plex_lyrics_parser.dart';
 import 'plex_mappers.dart';
 import 'plex_playback_mapper.dart';
 import 'playback_initialization_types.dart';
+import 'subtitle_preference.dart';
 import 'track_selection_service.dart';
 
 part 'plex_client/parts/live_tv.dart';
@@ -88,6 +91,15 @@ const _plexHlsVideoTranscodeTarget =
     'add-transcode-target(type=videoProfile&context=streaming'
     '&protocol=hls&container=mpegts&videoCodec=h264%2Chevc%2Cmpeg2video'
     '&audioCodec=aac%2Cac3%2Ceac3%2Cmp3)';
+
+/// Plex's HLS presentation clock starts at PTS 900000 (90 kHz), i.e. 10s, and
+/// the WebVTT rendition declares it as `X-TIMESTAMP-MAP:MPEGTS:900000`. mpv
+/// does not apply that map, so segmented cues arrive exactly this early and the
+/// player compensates when it sets `sub-delay` (#1738). The live value is read
+/// from the transcode's own first WebVTT segment at open; this constant is the
+/// fallback when that probe cannot complete.
+const plexHlsSubtitleTimelineOffsetMs = 10000;
+
 const _plexHlsSubtitleTranscodeTarget =
     'add-transcode-target(type=subtitleProfile&context=streaming'
     '&protocol=hls&container=webvtt&subtitleCodec=webvtt)';
@@ -2617,6 +2629,7 @@ class PlexClient
     required String sessionIdentifier,
     required String transcodeSessionId,
     int? audioStreamId,
+    MediaSubtitleTrack? selectedSubtitleTrack,
   }) async {
     try {
       final allParams = _buildTranscodeParams(
@@ -2627,6 +2640,7 @@ class PlexClient
         sessionIdentifier: sessionIdentifier,
         transcodeSessionId: transcodeSessionId,
         audioStreamId: audioStreamId,
+        selectedSubtitleTrack: selectedSubtitleTrack,
       );
       return await _runTranscodeDecision(
         startEndpoint: _plexVideoHlsStartEndpoint,
@@ -2736,8 +2750,24 @@ class PlexClient
     required String sessionIdentifier,
     required String transcodeSessionId,
     int? audioStreamId,
+    MediaSubtitleTrack? selectedSubtitleTrack,
   }) {
     final isOriginal = preset.isOriginal;
+    // An embedded subtitle cannot be fetched alongside a transcode: Plex
+    // answers 501 for /library/streams on an embedded stream, and the raw part
+    // file is refused (503) precisely because direct play is off — which is why
+    // the transcode exists. So the server has to deliver it: text streams as a
+    // segmented subtitle rendition, image streams burned into the video (HLS
+    // has no bitmap subtitle rendition).
+    // Text streams ride a separate segmented WebVTT rendition, so the viewer
+    // keeps local subtitle styling and can switch track without reloading the
+    // transcode. Image streams have no HLS bitmap rendition and must be burned
+    // into the video. See `demuxer-lavf-o` in playback_open for the reconnect
+    // tuning the WebVTT rendition depends on (#1738).
+    final selectedInternalSubtitle = _selectedInternalSubtitleForHls(selectedSubtitleTrack);
+    final segmentSubtitle =
+        selectedInternalSubtitle != null && CodecUtils.isTextSubtitleCodec(selectedInternalSubtitle.codec);
+    final burnSubtitle = selectedInternalSubtitle != null && !segmentSubtitle;
     final clientProfileExtra = _buildPlexHlsClientProfileExtra(
       maxVideoBitrateKbps: !isOriginal ? preset.videoBitrateKbps : null,
     );
@@ -2760,7 +2790,13 @@ class PlexClient
       'directStreamAudio': '0',
       'mediaBufferSize': '102400',
       'session': transcodeSessionId,
-      'subtitles': 'none',
+      'subtitles': segmentSubtitle
+          ? 'segmented'
+          : burnSubtitle
+          ? 'burn'
+          : 'none',
+      if (selectedInternalSubtitle != null) 'subtitleStreamID': selectedInternalSubtitle.id.toString(),
+      if (segmentSubtitle) 'advancedSubtitles': 'text',
       if (audioStreamId != null) 'audioStreamID': audioStreamId.toString(),
       'Accept-Language': 'en',
       'X-Plex-Session-Identifier': sessionIdentifier,
@@ -2789,8 +2825,10 @@ class PlexClient
     required String sessionIdentifier,
     required String transcodeSessionId,
     int? audioStreamId,
+    MediaSubtitleTrack? selectedSubtitleTrack,
   }) {
     return _buildTranscodeParams(
+      selectedSubtitleTrack: selectedSubtitleTrack,
       ratingKey: ratingKey,
       mediaIndex: mediaIndex,
       partIndex: partIndex,
@@ -3322,6 +3360,7 @@ class PlexClient
         final resolvedAudioId = carriedAudioTrack == null
             ? _resolveAudioStreamId(options.selectedAudioStreamId, data.mediaInfo)
             : carriedAudioStreamId;
+        final selectedSubtitleTrack = _resolveTranscodeSubtitleTrack(data.mediaInfo, options.preferredSubtitleTrack);
         final result = await buildTranscodeStartPath(
           ratingKey: options.metadata.id,
           mediaIndex: data.selectedMediaIndex,
@@ -3330,16 +3369,24 @@ class PlexClient
           sessionIdentifier: options.sessionIdentifier!,
           transcodeSessionId: options.transcodeSessionId!,
           audioStreamId: resolvedAudioId,
+          selectedSubtitleTrack: selectedSubtitleTrack,
         );
 
         if (result.outcome == TranscodeDecisionOutcome.transcodeOk && result.startPath != null) {
           final transcodeUrl = '${config.baseUrl}${result.startPath}'.withPlexToken(config.token);
-          final subtitleSidecars = _buildTranscodeSidecarSubtitles(data.mediaInfo, data.videoUrl!);
+          final internal = _selectedInternalSubtitleForHls(selectedSubtitleTrack);
+          final burnedIn = internal != null && !CodecUtils.isTextSubtitleCodec(internal.codec) ? internal.id : null;
+          final subtitleSidecars = _buildTranscodeSidecarSubtitles(data.mediaInfo);
+          final subtitleTimelineOffsetMs = internal != null && burnedIn == null
+              ? await _probeHlsSubtitleTimelineOffsetMs(transcodeUrl)
+              : 0;
           return PlaybackInitializationResult(
             availableVersions: data.availableVersions,
             videoUrl: transcodeUrl,
             mediaInfo: data.mediaInfo,
             subtitleSidecars: subtitleSidecars,
+            burnedInSubtitleStreamId: burnedIn,
+            subtitleTimelineOffsetMs: subtitleTimelineOffsetMs,
             isOffline: false,
             isTranscoding: true,
             activeAudioStreamId: resolvedAudioId,
@@ -3427,6 +3474,57 @@ class PlexClient
     return '${config.baseUrl}${track.key}.$ext?encoding=utf-8&X-Plex-Token=$token';
   }
 
+  /// The embedded subtitle stream the HLS transcode must deliver itself, or
+  /// null when the choice is a real sidecar file (keyed, fetched directly) or
+  /// a codec Plex cannot transcode.
+  MediaSubtitleTrack? _selectedInternalSubtitleForHls(MediaSubtitleTrack? track) {
+    if (track == null) return null;
+    if (track.key != null && track.key!.isNotEmpty) return null;
+    return CodecUtils.isTranscodableSubtitleCodec(track.codec) ? track : null;
+  }
+
+  MediaSubtitleTrack? _selectedSubtitleTrack(MediaSourceInfo? info) {
+    if (info == null) return null;
+    for (final track in info.subtitleTracks) {
+      if (track.selected) return track;
+    }
+    return null;
+  }
+
+  /// Resolve which source subtitle row a transcode should carry, from the
+  /// viewer's carried preference. Falls back to the server-selected row so a
+  /// transcode never silently drops a subtitle the server already had on.
+  MediaSubtitleTrack? _resolveTranscodeSubtitleTrack(MediaSourceInfo? info, SubtitlePreference? preferred) {
+    if (info == null) return null;
+    if (preferred == null) return _selectedSubtitleTrack(info);
+    if (preferred is SubtitleOffPreference) return null;
+    if (preferred is SubtitleIntentPreference) {
+      return findSourceTrackForIntent(preferred.intent, info.subtitleTracks) ?? _selectedSubtitleTrack(info);
+    }
+    final track = (preferred as SubtitleTrackPreference).track;
+    if (track.id == SubtitleTrack.off.id) return null;
+
+    MediaSubtitleTrack? matched;
+    if (track.id.startsWith('source:')) {
+      final sourceId = int.tryParse(track.id.substring('source:'.length));
+      if (sourceId != null) {
+        for (final row in info.subtitleTracks) {
+          if (row.id == sourceId) {
+            matched = row;
+            break;
+          }
+        }
+      }
+    }
+    matched ??= findPlexTrackForMpvSubtitle(track, info.subtitleTracks);
+    return matched ?? _selectedSubtitleTrack(info);
+  }
+
+  @visibleForTesting
+  MediaSubtitleTrack? resolveTranscodeSubtitleTrackForTesting(MediaSourceInfo? info, SubtitlePreference? preferred) {
+    return _resolveTranscodeSubtitleTrack(info, preferred);
+  }
+
   /// Raw sidecar URL for real sidecar subtitle streams. Plex returns 501 for
   /// `/library/streams/{id}.{ext}` when the stream is embedded, so a Plex
   /// `Stream.key` is required here.
@@ -3451,41 +3549,24 @@ class PlexClient
     );
   }
 
-  SubtitleTrack _containerSubtitleTrackFromMediaTrack(MediaSubtitleTrack track, String url) {
-    return SubtitleTrack(
-      id: 'container:${track.id}',
-      title: track.displayTitle ?? track.title ?? track.language ?? 'Track ${track.id}',
-      language: track.languageCode,
-      codec: track.codec,
-      isDefault: track.selected,
-      isForced: track.forced,
-      isExternal: true,
-      isContainer: true,
-      uri: url,
-    );
-  }
-
-  /// Build the complete subtitle catalog for Plex transcode playback.
-  ///
-  /// Real sidecar files keep their direct stream URL. Embedded subtitle
-  /// streams share the original media container as a subtitle-only source;
-  /// player backends filter that source to text tracks. Every entry is
-  /// preloaded so changing subtitles is a local track selection.
-  List<PlaybackSubtitleSidecar> _buildTranscodeSidecarSubtitles(MediaSourceInfo? mediaInfo, String sourceUrl) {
+  /// Build subtitle sidecars for Plex transcode playback. Only real sidecar
+  /// files (keyed streams) are fetched directly; the selected embedded stream
+  /// rides the HLS transcode itself, because the raw part file it would
+  /// otherwise be read from is refused whenever direct play is off.
+  List<PlaybackSubtitleSidecar> _buildTranscodeSidecarSubtitles(MediaSourceInfo? mediaInfo) {
     if (mediaInfo == null) return const [];
+    if (config.token == null) {
+      appLogger.w('No auth token available for transcode sidecar subtitles');
+      return const [];
+    }
 
     final tracks = <PlaybackSubtitleSidecar>[];
     for (final sub in mediaInfo.subtitleTracks) {
       try {
-        final directUrl = _buildSidecarSubtitleUrl(sub);
+        final url = _buildSidecarSubtitleUrl(sub);
+        if (url == null) continue;
         tracks.add(
-          PlaybackSubtitleSidecar(
-            sourceStreamId: sub.id,
-            track: directUrl == null
-                ? _containerSubtitleTrackFromMediaTrack(sub, sourceUrl)
-                : _subtitleTrackFromMediaTrack(sub, directUrl),
-            preload: true,
-          ),
+          PlaybackSubtitleSidecar(sourceStreamId: sub.id, track: _subtitleTrackFromMediaTrack(sub, url), preload: true),
         );
       } catch (e) {
         appLogger.w('Failed to build sidecar subtitle for stream ${sub.id}', error: e);
@@ -3495,8 +3576,63 @@ class PlexClient
   }
 
   @visibleForTesting
-  List<PlaybackSubtitleSidecar> buildTranscodeSidecarSubtitlesForTesting(MediaSourceInfo? mediaInfo, String sourceUrl) {
-    return _buildTranscodeSidecarSubtitles(mediaInfo, sourceUrl);
+  List<PlaybackSubtitleSidecar> buildTranscodeSidecarSubtitlesForTesting(MediaSourceInfo? mediaInfo) {
+    return _buildTranscodeSidecarSubtitles(mediaInfo);
+  }
+
+  /// Best-effort read of the transcode's declared subtitle timeline offset
+  /// (#1738): walk master playlist → subtitle rendition → WebVTT segments and
+  /// parse `X-TIMESTAMP-MAP`, so the `sub-delay` compensation follows what
+  /// this server actually emits. Cue-less segments are bare `WEBVTT` stubs
+  /// with no map — and the opening seconds of most items have no dialogue —
+  /// so several segments are scanned, nearby ones first plus two deeper picks
+  /// for dialogue-free intros. Any break in the chain falls back to
+  /// [plexHlsSubtitleTimelineOffsetMs] — the value Plex has emitted
+  /// historically — so playback never fails on this. The first fetch is the
+  /// session's own start URL, which also warms the transcoder before mpv
+  /// opens the same playlist.
+  Future<int> _probeHlsSubtitleTimelineOffsetMs(String transcodeUrl) async {
+    const fetchTimeout = Duration(seconds: 4);
+    const scanIndices = [0, 1, 2, 3, 10, 20];
+    int fallback(String reason) {
+      appLogger.d('HLS subtitle offset probe fell back to ${plexHlsSubtitleTimelineOffsetMs}ms: $reason');
+      return plexHlsSubtitleTimelineOffsetMs;
+    }
+
+    try {
+      return await () async {
+        final master = utf8.decode(await _http.getBytes(transcodeUrl, timeout: fetchTimeout), allowMalformed: true);
+        final renditionUri = hlsSubtitleRenditionUri(master);
+        if (renditionUri == null) return fallback('master has no subtitle rendition');
+        final renditionUrl = Uri.parse(transcodeUrl).resolve(renditionUri);
+        final rendition = utf8.decode(
+          await _http.getBytes(renditionUrl.toString(), timeout: fetchTimeout),
+          allowMalformed: true,
+        );
+        final segments = hlsSegmentUris(rendition);
+        for (final index in scanIndices) {
+          if (index >= segments.length) break;
+          final segment = utf8.decode(
+            await _http.getBytes(renditionUrl.resolve(segments[index]).toString(), timeout: fetchTimeout),
+            allowMalformed: true,
+          );
+          final offsetMs = webVttTimestampMapOffsetMs(segment);
+          if (offsetMs == null) continue;
+          if (offsetMs != plexHlsSubtitleTimelineOffsetMs) {
+            appLogger.i('Plex HLS subtitle timeline offset from X-TIMESTAMP-MAP: ${offsetMs}ms (segment $index)');
+          }
+          return offsetMs;
+        }
+        return fallback('no scanned segment carried a timestamp map (${segments.length} listed)');
+      }().timeout(const Duration(seconds: 8));
+    } on MediaServerHttpException catch (e) {
+      // A cancelled fetch means the open is being torn down, not that the
+      // server said anything — return quietly, nothing will render the value.
+      if (e.isCancellation) return plexHlsSubtitleTimelineOffsetMs;
+      return fallback('$e');
+    } catch (e) {
+      return fallback('$e');
+    }
   }
 
   /// Build list of external subtitle tracks from media info

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -2784,10 +2784,16 @@ class PlexClient
       'subtitleSize': '100',
       'audioBoost': '100',
       'location': 'lan',
-      if (!isOriginal && preset.videoBitrateKbps != null) 'maxVideoBitrate': preset.videoBitrateKbps.toString(),
+      // The video quality cap rides the client-profile `add-limitation` (see
+      // [_buildPlexHlsClientProfileExtra]) rather than `maxVideoBitrate`:
+      // measured against Plex 1.43, `maxVideoBitrate` budgets the whole
+      // stream, which forces even profile-compatible audio down to low-rate
+      // AAC. With the profile limitation the video is capped on its own and
+      // `directStreamAudio=1` lets the audio codecs the profile declares
+      // (aac/ac3/eac3/mp3) copy through untouched.
       'addDebugOverlay': '0',
       'autoAdjustQuality': '0',
-      'directStreamAudio': '0',
+      'directStreamAudio': '1',
       'mediaBufferSize': '102400',
       'session': transcodeSessionId,
       'subtitles': segmentSubtitle

--- a/lib/services/plex_hls_timestamp_map.dart
+++ b/lib/services/plex_hls_timestamp_map.dart
@@ -1,0 +1,67 @@
+/// Parsers for deriving the segmented-subtitle timeline offset of a Plex HLS
+/// transcode from the stream itself (#1738).
+///
+/// Plex's transcoder starts the HLS presentation clock at a non-zero MPEG-TS
+/// PTS and declares the mapping in each WebVTT segment's `X-TIMESTAMP-MAP`
+/// header. ffmpeg's HLS demuxer never applies that map — `webvttdec.c` passes
+/// cue times straight through as packet timestamps and `hls.c` offers no
+/// option to compensate — so segmented cues reach mpv early by exactly the
+/// declared offset. The player closes the gap via `sub-delay`; these parsers
+/// recover the declared value so the compensation follows what the server
+/// actually emits instead of assuming Plex's historical 10s constant.
+library;
+
+/// URI of the first `TYPE=SUBTITLES` rendition in an HLS master playlist, or
+/// null when the playlist declares none (or [masterPlaylist] is not an HLS
+/// playlist at all).
+String? hlsSubtitleRenditionUri(String masterPlaylist) {
+  for (final line in masterPlaylist.split('\n')) {
+    final trimmed = line.trim();
+    if (!trimmed.startsWith('#EXT-X-MEDIA:') || !trimmed.contains('TYPE=SUBTITLES')) continue;
+    final uri = RegExp(r'URI="([^"]+)"').firstMatch(trimmed);
+    if (uri != null) return uri.group(1);
+  }
+  return null;
+}
+
+/// URIs of the media segments in an HLS media playlist, in order.
+List<String> hlsSegmentUris(String mediaPlaylist) {
+  final uris = <String>[];
+  for (final line in mediaPlaylist.split('\n')) {
+    final trimmed = line.trim();
+    if (trimmed.isNotEmpty && !trimmed.startsWith('#')) uris.add(trimmed);
+  }
+  return uris;
+}
+
+/// Cue-to-presentation offset in milliseconds declared by a WebVTT segment's
+/// `X-TIMESTAMP-MAP` header: `MPEGTS ÷ 90 − LOCAL` (the MPEG-TS clock runs at
+/// 90 kHz). Returns null when the segment declares no parseable map — which
+/// includes the bare `WEBVTT` stubs Plex serves for cue-less segments. A stub
+/// carries no timing evidence either way, so callers must keep looking rather
+/// than read it as "no offset".
+int? webVttTimestampMapOffsetMs(String segment) {
+  final body = segment.trimLeft();
+  if (!body.startsWith('WEBVTT')) return null;
+  final map = RegExp(r'X-TIMESTAMP-MAP=([^\r\n]+)').firstMatch(body);
+  if (map == null) return null;
+  final attributes = map.group(1)!;
+  final mpegTs = RegExp(r'MPEGTS:(\d+)').firstMatch(attributes);
+  final local = RegExp(r'LOCAL:([\d:.]+)').firstMatch(attributes);
+  if (mpegTs == null || local == null) return null;
+  final localMs = _webVttTimestampMs(local.group(1)!);
+  if (localMs == null) return null;
+  return (int.parse(mpegTs.group(1)!) / 90).round() - localMs;
+}
+
+/// Milliseconds for a WebVTT timestamp (`HH:MM:SS.mmm` or `MM:SS.mmm`).
+int? _webVttTimestampMs(String value) {
+  final match = RegExp(r'^(?:(\d+):)?(\d{1,2}):(\d{1,2})\.(\d{3})$').firstMatch(value);
+  if (match == null) return null;
+  final hours = int.parse(match.group(1) ?? '0');
+  final minutes = int.parse(match.group(2)!);
+  final seconds = int.parse(match.group(3)!);
+  final millis = int.parse(match.group(4)!);
+  if (minutes > 59 || seconds > 59) return null;
+  return ((hours * 60 + minutes) * 60 + seconds) * 1000 + millis;
+}

--- a/lib/services/track_manager.dart
+++ b/lib/services/track_manager.dart
@@ -50,6 +50,11 @@ class TrackManager {
 
   MediaItem metadata;
   MediaSourceInfo? mediaInfo;
+
+  /// Whether the backend rendered the chosen subtitle into the video. There is
+  /// no native subtitle track to select in that case, so the selection wait
+  /// must not hold out for one (#1738).
+  bool subtitleIsBurnedIn;
   AudioTrack? preferredAudioTrack;
   SubtitlePreference? preferredSubtitleTrack;
   SubtitlePreference? preferredSecondarySubtitleTrack;
@@ -96,6 +101,7 @@ class TrackManager {
     required this.waitForProfileSettings,
     required this.metadata,
     this.mediaInfo,
+    this.subtitleIsBurnedIn = false,
     this.preferredAudioTrack,
     this.preferredSubtitleTrack,
     this.preferredSecondarySubtitleTrack,
@@ -241,8 +247,10 @@ class TrackManager {
       if (!selectionIsCurrent()) return;
 
       final tracks = player.state.tracks;
+      // A burned-in subtitle never becomes a native track, so waiting on one
+      // would always burn the full 30-second deadline for nothing (#1738).
       final waitingForAdvertisedSubtitles =
-          mediaInfo?.subtitleTracks.isNotEmpty == true && !_tracksReadyForSelection(tracks);
+          !subtitleIsBurnedIn && mediaInfo?.subtitleTracks.isNotEmpty == true && !_tracksReadyForSelection(tracks);
       if (!waitingForAdvertisedSubtitles) {
         _trackLoadingSubscription?.cancel();
         _trackLoadingSubscription = null;

--- a/lib/widgets/video_controls/models/track_controls_state.dart
+++ b/lib/widgets/video_controls/models/track_controls_state.dart
@@ -56,6 +56,10 @@ class TrackControlsState {
   final VoidCallback? onCancelAutoHide;
   final VoidCallback? onStartAutoHide;
   final void Function(String propertyName, int offset)? onSyncOffsetChanged;
+
+  /// Milliseconds the backend's subtitle timeline leads the video's, which the
+  /// player adds to the viewer's own offset when writing `sub-delay` (#1738).
+  final int subtitleTimelineOffsetMs;
   final String? serverId;
   final ShaderService? shaderService;
   final VoidCallback? onShaderChanged;
@@ -117,6 +121,7 @@ class TrackControlsState {
     this.onCancelAutoHide,
     this.onStartAutoHide,
     this.onSyncOffsetChanged,
+    this.subtitleTimelineOffsetMs = 0,
     this.serverId,
     this.shaderService,
     this.onShaderChanged,

--- a/lib/widgets/video_controls/parts/track_controls.dart
+++ b/lib/widgets/video_controls/parts/track_controls.dart
@@ -151,6 +151,7 @@ extension _PlexVideoControlsTrackMethods on _PlexVideoControlsState {
       videoZoomScale: widget.videoZoomScale,
       audioSyncOffset: _audioSyncOffset,
       subtitleSyncOffset: _subtitleSyncOffset,
+      subtitleTimelineOffsetMs: widget.subtitleTimelineOffsetMs,
       isRotationLocked: _isRotationLocked,
       isFullscreen: _isFullscreen,
       isAlwaysOnTop: _isAlwaysOnTop,

--- a/lib/widgets/video_controls/sheets/video_settings_sheet.dart
+++ b/lib/widgets/video_controls/sheets/video_settings_sheet.dart
@@ -370,6 +370,7 @@ class _VideoSettingsSheetState extends State<VideoSettingsSheet> {
             player: widget.player,
             propertyName: propertyName,
             initialOffset: initialOffset,
+            baselineOffsetMs: isSubtitle ? _state.subtitleTimelineOffsetMs : 0,
             sliderFocusNode: sliderFocusNode,
             onOffsetChanged: (offset) async {
               final settings = SettingsService.instance;
@@ -1181,6 +1182,7 @@ class _CompactSyncBar extends StatefulWidget {
   final Player player;
   final String propertyName;
   final int initialOffset;
+  final int baselineOffsetMs;
   final Future<void> Function(int offset) onOffsetChanged;
   final FocusNode sliderFocusNode;
 
@@ -1190,6 +1192,7 @@ class _CompactSyncBar extends StatefulWidget {
     required this.player,
     required this.propertyName,
     required this.initialOffset,
+    this.baselineOffsetMs = 0,
     required this.onOffsetChanged,
     required this.sliderFocusNode,
   });
@@ -1222,6 +1225,7 @@ class _CompactSyncBarState extends State<_CompactSyncBar> {
             player: widget.player,
             propertyName: widget.propertyName,
             initialOffset: widget.initialOffset,
+            baselineOffsetMs: widget.baselineOffsetMs,
             labelText: widget.title,
             onOffsetChanged: widget.onOffsetChanged,
             compact: true,

--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -507,6 +507,11 @@ class PlexVideoControls extends StatefulWidget {
   final TranscodeQualityPreset selectedQualityPreset;
   final bool serverSupportsTranscoding;
   final bool isTranscoding;
+
+  /// Milliseconds the source's subtitle timeline leads its video. The sync
+  /// slider adds this to the viewer's offset so a corrected stream still
+  /// reads 0 (#1738).
+  final int subtitleTimelineOffsetMs;
   final bool isOfflinePlayback;
   final List<MediaAudioTrack> sourceAudioTracks;
   final int? selectedAudioStreamId;
@@ -633,6 +638,7 @@ class PlexVideoControls extends StatefulWidget {
     this.selectedQualityPreset = TranscodeQualityPreset.original,
     this.serverSupportsTranscoding = false,
     this.isTranscoding = false,
+    this.subtitleTimelineOffsetMs = 0,
     this.isOfflinePlayback = false,
     this.sourceAudioTracks = const [],
     this.selectedAudioStreamId,

--- a/lib/widgets/video_controls/widgets/sync_offset_control.dart
+++ b/lib/widgets/video_controls/widgets/sync_offset_control.dart
@@ -18,6 +18,12 @@ import '../../../utils/latest_async_write.dart';
 class SyncOffsetControl extends StatefulWidget {
   final Player player;
   final String propertyName; // 'audio-delay' or 'sub-delay'
+
+  /// Milliseconds added to the viewer's offset before it reaches the player.
+  /// Non-zero when the backend's subtitle timeline leads the video's and the
+  /// player has to compensate, so the viewer's own slider still reads 0 when
+  /// subtitles are in sync (#1738).
+  final int baselineOffsetMs;
   final int initialOffset;
   final String labelText; // 'Audio' or 'Subtitles'
   final Future<void> Function(int offset) onOffsetChanged;
@@ -41,6 +47,7 @@ class SyncOffsetControl extends StatefulWidget {
     super.key,
     required this.player,
     required this.propertyName,
+    this.baselineOffsetMs = 0,
     required this.initialOffset,
     required this.labelText,
     required this.onOffsetChanged,
@@ -114,7 +121,7 @@ class _SyncOffsetControlState extends State<SyncOffsetControl> {
           // Convert milliseconds to seconds for mpv. Keep the native write and
           // persistence on the same per-player/property queue so an older
           // native write can never complete after a newer one.
-          final offsetSeconds = offsetMs / 1000.0;
+          final offsetSeconds = (offsetMs + widget.baselineOffsetMs) / 1000.0;
           await targetPlayer.setProperty(propertyName, offsetSeconds.toString());
           await persistOffset(offsetMs.round());
           if (mounted &&

--- a/test/screens/video_player/network_stream_tuning_test.dart
+++ b/test/screens/video_player/network_stream_tuning_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/screens/video_player_screen.dart';
+
+void main() {
+  test('transcode opens tune the demuxer and clear subtitle events on seek (#1738)', () {
+    final props = networkStreamTuningProperties(isNetworkVod: true, isTranscoding: true);
+
+    // Segment retries belong to ffmpeg's hls demuxer; the HTTP layer must not
+    // second-guess a finished segment (Plex sends WebVTT with no
+    // Content-Length, so a retry turns every clean EOF into a 416 loop).
+    expect(props['demuxer-lavf-o'], 'reconnect=0,reconnect_streamed=0,reconnect_on_network_error=0');
+    // Seeks re-deliver WebVTT cues with restarted ReadOrder; without this the
+    // same cue renders stacked on top of itself.
+    expect(props['sub-clear-on-seek'], 'yes');
+    // The #1520 playlist-level reconnect protection must survive unchanged.
+    expect(
+      props['stream-lavf-o'],
+      'reconnect=1,reconnect_on_network_error=1,reconnect_on_http_error=503,'
+      'reconnect_streamed=1,reconnect_delay_max=600',
+    );
+  });
+
+  test('non-transcode opens reset the transcode tuning so a reused player carries nothing over', () {
+    final networkDirectPlay = networkStreamTuningProperties(isNetworkVod: true, isTranscoding: false);
+    expect(networkDirectPlay['demuxer-lavf-o'], '');
+    expect(networkDirectPlay['sub-clear-on-seek'], 'no');
+    expect(networkDirectPlay['stream-lavf-o'], isNotEmpty);
+
+    final localFile = networkStreamTuningProperties(isNetworkVod: false, isTranscoding: false);
+    expect(localFile['stream-lavf-o'], '');
+    expect(localFile['demuxer-lavf-o'], '');
+    expect(localFile['sub-clear-on-seek'], 'no');
+  });
+
+  test('every mpv option-string entry is a complete key=value (no multi-code values needing quoting)', () {
+    for (final transcoding in [true, false]) {
+      final props = networkStreamTuningProperties(isNetworkVod: true, isTranscoding: transcoding);
+      for (final optionList in ['stream-lavf-o', 'demuxer-lavf-o']) {
+        final value = props[optionList]!;
+        if (value.isEmpty) continue;
+        // mpv splits key-value-list options on commas; a value containing a
+        // comma (e.g. reconnect_on_http_error=404,503) needs %len% quoting and
+        // must not appear here unquoted.
+        for (final entry in value.split(',')) {
+          expect(RegExp(r'^[a-z_]+=[0-9]+$').hasMatch(entry), isTrue, reason: '"$entry" in $optionList');
+        }
+      }
+    }
+  });
+}

--- a/test/screens/video_player/player_initialization_lifecycle_test.dart
+++ b/test/screens/video_player/player_initialization_lifecycle_test.dart
@@ -273,6 +273,30 @@ void main() {
     expect(selection.secondarySourceStreamId, isNull);
   });
 
+  test('a sidecar-stall fallback carries the unserved choice instead of a deliberate off (#1738)', () {
+    // The reopen drops the sidecars, so the selection goes off — but the
+    // viewer never asked for off. Leaving declinedPreference null makes
+    // subtitleOffIsDeliberate true, which persists -1 to the server and
+    // hardens a slow sidecar into a stored "subtitles off".
+    const picked = SubtitleTrack(id: 'source:7', title: 'English', language: 'eng', codec: 'pgs');
+
+    final selection = subtitleSelectionForSidecarFallback(
+      const PlaybackSubtitleSelection(primaryTrack: picked, primarySourceStreamId: 7),
+    );
+
+    expect(selection.isOff, isTrue);
+    expect(selection.declinedPreference, isNotNull);
+    expect(selection.declinedPreference, isA<SubtitleTrackPreference>());
+    expect((selection.declinedPreference! as SubtitleTrackPreference).track.id, 'source:7');
+  });
+
+  test('a sidecar-stall fallback leaves an already-deliberate off deliberate (#1738)', () {
+    final selection = subtitleSelectionForSidecarFallback(const PlaybackSubtitleSelection.off());
+
+    expect(selection.isOff, isTrue);
+    expect(selection.declinedPreference, isNull);
+  });
+
   test('a reload-path source subtitle pick becomes the session preference (#1785)', () {
     // Picks that cannot switch locally go through a full reload and never
     // reach the native remember chain; the authoritative source row still

--- a/test/services/plex_hls_timestamp_map_test.dart
+++ b/test/services/plex_hls_timestamp_map_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/services/plex_hls_timestamp_map.dart';
+
+void main() {
+  group('hlsSubtitleRenditionUri', () {
+    test('finds the SUBTITLES rendition among other media lines', () {
+      const master =
+          '#EXTM3U\n'
+          '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud",NAME="English",URI="audio/index.m3u8"\n'
+          '#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,URI="subtitles/index.m3u8"\n'
+          '#EXT-X-STREAM-INF:BANDWIDTH=3000000,SUBTITLES="subs"\n'
+          'video/index.m3u8\n';
+      expect(hlsSubtitleRenditionUri(master), 'subtitles/index.m3u8');
+    });
+
+    test('returns null without a subtitles rendition or for a non-playlist body', () {
+      expect(hlsSubtitleRenditionUri('#EXTM3U\n#EXT-X-STREAM-INF:BANDWIDTH=1\nvideo.m3u8\n'), isNull);
+      expect(hlsSubtitleRenditionUri('<html>503 Service Unavailable</html>'), isNull);
+    });
+  });
+
+  group('hlsSegmentUris', () {
+    test('returns the non-tag lines in order', () {
+      const playlist = '#EXTM3U\n#EXT-X-TARGETDURATION:6\n#EXTINF:6.0,\nseg-0.vtt\n#EXTINF:6.0,\nseg-1.vtt\n';
+      expect(hlsSegmentUris(playlist), ['seg-0.vtt', 'seg-1.vtt']);
+    });
+
+    test('returns an empty list for a playlist with no segments', () {
+      expect(hlsSegmentUris('#EXTM3U\n#EXT-X-TARGETDURATION:6\n'), isEmpty);
+    });
+  });
+
+  group('webVttTimestampMapOffsetMs', () {
+    test('parses the Plex-shaped header (LOCAL first, MM:SS.mmm)', () {
+      const segment = 'WEBVTT\nX-TIMESTAMP-MAP=LOCAL:00:00.000,MPEGTS:900000\n\n00:00.500 --> 00:02.000\nHello\n';
+      expect(webVttTimestampMapOffsetMs(segment), 10000);
+    });
+
+    test('parses the attribute order and HH:MM:SS.mmm form from the HLS spec', () {
+      const segment = 'WEBVTT\nX-TIMESTAMP-MAP=MPEGTS:900000,LOCAL:00:00:00.000\n';
+      expect(webVttTimestampMapOffsetMs(segment), 10000);
+    });
+
+    test('subtracts a non-zero LOCAL from the MPEG-TS clock', () {
+      // 1350000 / 90 = 15000ms, LOCAL 2.5s → 12500ms.
+      const segment = 'WEBVTT\nX-TIMESTAMP-MAP=LOCAL:00:00:02.500,MPEGTS:1350000\n';
+      expect(webVttTimestampMapOffsetMs(segment), 12500);
+    });
+
+    test('a mapless segment is no evidence — Plex serves bare WEBVTT stubs for cue-less spans', () {
+      expect(webVttTimestampMapOffsetMs('WEBVTT\n'), isNull);
+      expect(webVttTimestampMapOffsetMs('WEBVTT\n\n00:00.500 --> 00:02.000\nHello\n'), isNull);
+    });
+
+    test('rejects non-WebVTT bodies and malformed maps', () {
+      expect(webVttTimestampMapOffsetMs('<html>503 Service Unavailable</html>'), isNull);
+      expect(webVttTimestampMapOffsetMs('WEBVTT\nX-TIMESTAMP-MAP=MPEGTS:900000\n'), isNull);
+      expect(webVttTimestampMapOffsetMs('WEBVTT\nX-TIMESTAMP-MAP=LOCAL:bogus,MPEGTS:900000\n'), isNull);
+      expect(webVttTimestampMapOffsetMs('WEBVTT\nX-TIMESTAMP-MAP=LOCAL:99:99.999,MPEGTS:900000\n'), isNull);
+    });
+  });
+}

--- a/test/services/plex_playback_data_request_test.dart
+++ b/test/services/plex_playback_data_request_test.dart
@@ -130,10 +130,7 @@ void main() {
   }
 
   List<PlaybackSubtitleSidecar> buildTranscodeSubtitles(PlexClient client, List<MediaSubtitleTrack> subtitleTracks) {
-    return client.buildTranscodeSidecarSubtitlesForTesting(
-      mediaInfoWithSubtitles(subtitleTracks),
-      'https://plex.example.com/video.mkv?X-Plex-Token=token',
-    );
+    return client.buildTranscodeSidecarSubtitlesForTesting(mediaInfoWithSubtitles(subtitleTracks));
   }
 
   test('selectStreams sends audio stream selection with allParts', () async {
@@ -245,7 +242,7 @@ void main() {
     expect(data.mediaInfo?.subtitleTracks.single.selected, isTrue);
   });
 
-  test('transcode initialization wires a subtitle-free HLS request to the complete sidecar catalog', () async {
+  test('transcode initialization asks the server to carry the embedded subtitle (#1738)', () async {
     final requests = <http.Request>[];
     final client = makeClient((request) async {
       requests.add(request);
@@ -325,15 +322,199 @@ void main() {
     final decisionRequest = requests.singleWhere(
       (request) => request.url.path == '/video/:/transcode/universal/decision',
     );
-    expect(decisionRequest.url.queryParameters['subtitles'], 'none');
-    expect(decisionRequest.url.queryParameters.containsKey('subtitleStreamID'), isFalse);
-    expect(decisionRequest.url.queryParameters.containsKey('advancedSubtitles'), isFalse);
+    // Stream 401 is the server-selected embedded ASS track: the transcode has
+    // to carry it, because nothing the client could fetch it from is reachable
+    // while direct play is off (#1738). Stream 402 is a real keyed sidecar and
+    // stays a client-side fetch.
+    expect(decisionRequest.url.queryParameters['subtitles'], 'segmented');
+    expect(decisionRequest.url.queryParameters['subtitleStreamID'], '401');
+    expect(decisionRequest.url.queryParameters['advancedSubtitles'], 'text');
     expect(result.isTranscoding, isTrue);
     expect(result.videoUrl, contains('/video/:/transcode/universal/start.m3u8?'));
-    expect(result.subtitleSidecars.map((sidecar) => sidecar.sourceStreamId), [401, 402]);
-    expect(result.subtitleSidecars.every((sidecar) => sidecar.preload), isTrue);
-    expect(result.subtitleSidecars.first.track.isContainer, isTrue);
-    expect(result.subtitleSidecars.last.track.uri, contains('/library/streams/402.srt'));
+    expect(result.subtitleSidecars.map((sidecar) => sidecar.sourceStreamId), [402]);
+    expect(result.subtitleSidecars.single.track.isContainer, isFalse);
+    expect(result.subtitleSidecars.single.track.uri, contains('/library/streams/402.srt'));
+    // The mock serves no HLS playlists, so the offset probe falls back to the
+    // historical constant rather than failing the open.
+    expect(result.subtitleTimelineOffsetMs, plexHlsSubtitleTimelineOffsetMs);
+  });
+
+  test('segmented subtitle offset is read from the transcode\'s own X-TIMESTAMP-MAP (#1738)', () async {
+    final client = makeClient((request) async {
+      if (request.url.path == '/library/metadata/42') {
+        return http.Response(
+          jsonEncode({
+            'MediaContainer': {
+              'Metadata': [
+                {
+                  'ratingKey': '42',
+                  'type': 'movie',
+                  'title': 'Movie',
+                  'Media': [
+                    {
+                      'id': 7,
+                      'container': 'mkv',
+                      'Part': [
+                        {
+                          'id': 99,
+                          'key': '/library/parts/99/file.mkv',
+                          'Stream': [
+                            {'streamType': 1, 'id': 300, 'codec': 'h264'},
+                            {
+                              'streamType': 3,
+                              'id': 401,
+                              'index': 1,
+                              'codec': 'ass',
+                              'languageCode': 'eng',
+                              'selected': true,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      if (request.url.path == '/video/:/transcode/universal/decision') {
+        return http.Response(
+          jsonEncode({
+            'MediaContainer': {'generalDecisionCode': 1001, 'transcodeDecisionCode': 1001},
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      if (request.url.path == '/video/:/transcode/universal/start.m3u8') {
+        return http.Response(
+          '#EXTM3U\n'
+          '#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="subs",NAME="English",DEFAULT=YES,URI="subtitles/index.m3u8"\n'
+          '#EXT-X-STREAM-INF:BANDWIDTH=3000000,SUBTITLES="subs"\n'
+          'video/index.m3u8\n',
+          200,
+        );
+      }
+      if (request.url.path == '/video/:/transcode/universal/subtitles/index.m3u8') {
+        return http.Response(
+          '#EXTM3U\n#EXT-X-TARGETDURATION:3\n'
+          '#EXTINF:3,\nsegment-0.vtt\n#EXTINF:3,\nsegment-1.vtt\n#EXTINF:3,\nsegment-2.vtt\n',
+          200,
+        );
+      }
+      if (request.url.path == '/video/:/transcode/universal/subtitles/segment-0.vtt' ||
+          request.url.path == '/video/:/transcode/universal/subtitles/segment-1.vtt') {
+        // Cue-less spans come back as bare stubs with no timestamp map, the
+        // shape Plex serves for the (usually dialogue-free) opening seconds.
+        return http.Response('WEBVTT\n', 200);
+      }
+      if (request.url.path == '/video/:/transcode/universal/subtitles/segment-2.vtt') {
+        // A non-historical MPEGTS value (15s) proves the offset is derived
+        // from the stream, not assumed.
+        return http.Response(
+          'WEBVTT\nX-TIMESTAMP-MAP=LOCAL:00:00.000,MPEGTS:1350000\n\n00:06.500 --> 00:08.000\nHello\n',
+          200,
+        );
+      }
+      return http.Response('unexpected request', 500);
+    });
+    addTearDown(client.close);
+
+    final result = await client.getPlaybackInitialization(
+      PlaybackInitializationOptions(
+        metadata: testMediaItem(id: '42', backend: MediaBackend.plex, kind: MediaKind.movie, serverId: 'server-id'),
+        selectedMediaIndex: 0,
+        qualityPreset: TranscodeQualityPreset.p720_3mbps,
+        sessionIdentifier: 'session-id',
+        transcodeSessionId: 'transcode-id',
+      ),
+    );
+
+    expect(result.isTranscoding, isTrue);
+    expect(result.subtitleTimelineOffsetMs, 15000);
+  });
+
+  test('a stalled playlist fetch times out into the historical offset instead of blocking the open', () async {
+    // Real-timer test: the handler holds the master playlist past the probe's
+    // 4s per-fetch budget, so the open must proceed on the fallback constant
+    // after roughly one timeout — not hang for the server's sweet time.
+    final client = makeClient((request) async {
+      if (request.url.path == '/library/metadata/42') {
+        return http.Response(
+          jsonEncode({
+            'MediaContainer': {
+              'Metadata': [
+                {
+                  'ratingKey': '42',
+                  'type': 'movie',
+                  'title': 'Movie',
+                  'Media': [
+                    {
+                      'id': 7,
+                      'container': 'mkv',
+                      'Part': [
+                        {
+                          'id': 99,
+                          'key': '/library/parts/99/file.mkv',
+                          'Stream': [
+                            {'streamType': 1, 'id': 300, 'codec': 'h264'},
+                            {
+                              'streamType': 3,
+                              'id': 401,
+                              'index': 1,
+                              'codec': 'ass',
+                              'languageCode': 'eng',
+                              'selected': true,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      if (request.url.path == '/video/:/transcode/universal/decision') {
+        return http.Response(
+          jsonEncode({
+            'MediaContainer': {'generalDecisionCode': 1001, 'transcodeDecisionCode': 1001},
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      if (request.url.path == '/video/:/transcode/universal/start.m3u8') {
+        await Future<void>.delayed(const Duration(seconds: 6));
+        return http.Response('#EXTM3U\n', 200);
+      }
+      return http.Response('unexpected request', 500);
+    });
+    addTearDown(client.close);
+
+    final stopwatch = Stopwatch()..start();
+    final result = await client.getPlaybackInitialization(
+      PlaybackInitializationOptions(
+        metadata: testMediaItem(id: '42', backend: MediaBackend.plex, kind: MediaKind.movie, serverId: 'server-id'),
+        selectedMediaIndex: 0,
+        qualityPreset: TranscodeQualityPreset.p720_3mbps,
+        sessionIdentifier: 'session-id',
+        transcodeSessionId: 'transcode-id',
+      ),
+    );
+    stopwatch.stop();
+
+    expect(result.subtitleTimelineOffsetMs, plexHlsSubtitleTimelineOffsetMs);
+    // One 4s fetch timeout, bounded well under the 8s whole-probe ceiling.
+    expect(stopwatch.elapsed, lessThan(const Duration(seconds: 8)));
   });
 
   test('playback uses metadata availability flags without probing part URLs', () async {
@@ -538,7 +719,11 @@ void main() {
     expect(result.selectedMediaIndex, 1);
   });
 
-  test('transcode subtitle catalog includes embedded and keyed Plex streams', () {
+  test('transcode subtitle catalog carries only keyed Plex streams', () {
+    // An embedded stream has no fetchable URL during a transcode: Plex answers
+    // 501 for /library/streams on it, and the raw part file is refused (503)
+    // because direct play is off. It rides the HLS transcode instead, so it
+    // must not appear here as a sidecar (#1738).
     final client = makeClient((_) async => http.Response('not used', 500));
     addTearDown(client.close);
 
@@ -556,19 +741,16 @@ void main() {
       ),
     ]);
 
-    expect(subtitles, hasLength(2));
-    expect(subtitles.map((sidecar) => sidecar.sourceStreamId), [401, 402]);
-    expect(subtitles.every((sidecar) => sidecar.preload), isTrue);
-    expect(subtitles.first.track.isContainer, isTrue);
-    expect(subtitles.first.track.uri, 'https://plex.example.com/video.mkv?X-Plex-Token=token');
-    expect(subtitles.last.track.isContainer, isFalse);
+    expect(subtitles, hasLength(1));
+    expect(subtitles.single.sourceStreamId, 402);
+    expect(subtitles.single.track.isContainer, isFalse);
     expect(
-      subtitles.last.track.uri,
+      subtitles.single.track.uri,
       'https://plex.example.com/library/streams/402.srt?encoding=utf-8&X-Plex-Token=token',
     );
   });
 
-  test('tokenless transcode keeps embedded and keyed subtitle sources', () {
+  test('tokenless transcode yields no sidecars', () {
     final client = testPlexClient(
       serverId: ServerId('server-id'),
       token: null,
@@ -589,14 +771,86 @@ void main() {
           external: true,
         ),
       ]),
-      'https://plex.example.com/video.mkv',
     );
 
-    expect(subtitles, hasLength(2));
-    expect(subtitles.first.track.isContainer, isTrue);
-    expect(subtitles.first.track.uri, 'https://plex.example.com/video.mkv');
-    expect(subtitles.last.track.isContainer, isFalse);
-    expect(subtitles.last.track.uri, 'https://plex.example.com/library/streams/402.srt?encoding=utf-8');
+    expect(subtitles, isEmpty);
+  });
+
+  test('an embedded text subtitle is delivered as a segmented rendition (#1738)', () {
+    // Regression: main sent subtitles=none and expected the client to fetch the
+    // subtitle from the raw part file, which Plex refuses (503) whenever direct
+    // play is off — the very condition that forced the transcode. The server
+    // has to deliver it instead.
+    final client = makeClient((_) async => http.Response('not used', 500));
+    addTearDown(client.close);
+
+    final params = client.buildTranscodeParamsForTesting(
+      ratingKey: '42',
+      mediaIndex: 0,
+      preset: TranscodeQualityPreset.p720_3mbps,
+      sessionIdentifier: 'session-id',
+      transcodeSessionId: 'transcode-id',
+      selectedSubtitleTrack: MediaSubtitleTrack(
+        id: 401,
+        codec: 'srt',
+        languageCode: 'eng',
+        selected: true,
+        forced: false,
+      ),
+    );
+
+    expect(params['subtitles'], 'segmented');
+    expect(params['subtitleStreamID'], '401');
+    expect(params['advancedSubtitles'], 'text');
+  });
+
+  test('an embedded image subtitle is burned into the transcode (#1738)', () {
+    final client = makeClient((_) async => http.Response('not used', 500));
+    addTearDown(client.close);
+
+    final params = client.buildTranscodeParamsForTesting(
+      ratingKey: '42',
+      mediaIndex: 0,
+      preset: TranscodeQualityPreset.p720_3mbps,
+      sessionIdentifier: 'session-id',
+      transcodeSessionId: 'transcode-id',
+      selectedSubtitleTrack: MediaSubtitleTrack(
+        id: 401,
+        codec: 'pgs',
+        languageCode: 'eng',
+        selected: true,
+        forced: false,
+      ),
+    );
+
+    expect(params['subtitles'], 'burn');
+    expect(params['subtitleStreamID'], '401');
+    expect(params.containsKey('advancedSubtitles'), isFalse);
+  });
+
+  test('a keyed sidecar subtitle is left to the client, not the transcode', () {
+    final client = makeClient((_) async => http.Response('not used', 500));
+    addTearDown(client.close);
+
+    final params = client.buildTranscodeParamsForTesting(
+      ratingKey: '42',
+      mediaIndex: 0,
+      preset: TranscodeQualityPreset.p720_3mbps,
+      sessionIdentifier: 'session-id',
+      transcodeSessionId: 'transcode-id',
+      selectedSubtitleTrack: MediaSubtitleTrack(
+        id: 402,
+        codec: 'srt',
+        languageCode: 'swe',
+        selected: true,
+        forced: false,
+        key: '/library/streams/402',
+        external: true,
+      ),
+    );
+
+    expect(params['subtitles'], 'none');
+    expect(params.containsKey('subtitleStreamID'), isFalse);
   });
 
   test('video transcode stays subtitle-free while preserving the HLS profile', () {
@@ -682,7 +936,9 @@ void main() {
     expect(params['partIndex'], '2');
   });
 
-  test('image-based embedded subtitles use the shared container sidecar', () {
+  test('image-based embedded subtitles produce no sidecar (the server burns them)', () {
+    // HLS has no bitmap subtitle rendition, so PGS/VOBSUB can only reach the
+    // viewer burned into the video by the transcode (#1738).
     final client = makeClient((_) async => http.Response('not used', 500));
     addTearDown(client.close);
 
@@ -691,11 +947,7 @@ void main() {
       MediaSubtitleTrack(id: 402, codec: 'dvd_subtitle', languageCode: 'eng', selected: false, forced: false),
     ]);
 
-    expect(subtitles, hasLength(2));
-    expect(subtitles.every((sidecar) => sidecar.track.isContainer), isTrue);
-    expect(subtitles.map((sidecar) => sidecar.track.uri).toSet(), {
-      'https://plex.example.com/video.mkv?X-Plex-Token=token',
-    });
+    expect(subtitles, isEmpty);
   });
 
   group('playback metadata failure contract', () {

--- a/test/services/plex_playback_data_request_test.dart
+++ b/test/services/plex_playback_data_request_test.dart
@@ -936,6 +936,26 @@ void main() {
     expect(params['partIndex'], '2');
   });
 
+  test('quality-capped transcode caps video via the profile and direct-streams compatible audio', () {
+    final client = makeClient((_) async => http.Response('not used', 500));
+    addTearDown(client.close);
+
+    final params = client.buildTranscodeParamsForTesting(
+      ratingKey: '42',
+      mediaIndex: 0,
+      preset: TranscodeQualityPreset.p720_3mbps,
+      sessionIdentifier: 'session-id',
+      transcodeSessionId: 'transcode-id',
+    );
+
+    // maxVideoBitrate budgets the whole stream and forces profile-compatible
+    // audio down to low-rate AAC; the cap must ride the client-profile
+    // limitation alone so directStreamAudio can copy the source audio.
+    expect(params.containsKey('maxVideoBitrate'), isFalse, reason: 'the cap rides the profile add-limitation');
+    expect(params['X-Plex-Client-Profile-Extra'], contains('name=video.bitrate&value=3000'));
+    expect(params['directStreamAudio'], '1');
+  });
+
   test('image-based embedded subtitles produce no sidecar (the server burns them)', () {
     // HLS has no bitmap subtitle rendition, so PGS/VOBSUB can only reach the
     // viewer burned into the video by the transcode (#1738).


### PR DESCRIPTION
During a transcode with direct play disabled, an embedded subtitle has no fetchable URL — `/library/streams/{id}.{ext}` answers 501 for embedded streams, and the raw part file answers 503, the very thing the transcode exists to avoid. The client still tried to read the source container as a sidecar, ffmpeg's auto-reconnect retried the 503 forever, and the open guard tore down every subtitle with "Selected subtitles could not be loaded". This is the Plex half of #1738.

The fix asks the server to deliver the selected embedded stream: text tracks ride a segmented WebVTT rendition, image tracks are burned in (HLS has no bitmap rendition), keyed sidecar files stay client-fetched. ffmpeg's HLS demuxer never applies `X-TIMESTAMP-MAP` (`webvttdec.c` passes cue times straight through; `hls.c` has no option for it), so the declared offset is read from the transcode's own segments at open and compensated via `sub-delay` — the viewer's sync slider rides on top and still reads zero. `sub-clear-on-seek` on transcode opens stops re-delivered cues stacking after a seek. A second commit stops a quality-capped transcode re-encoding profile-compatible audio (EAC3 5.1 640k was becoming 360k AAC): the video cap rides the client-profile `add-limitation` and `directStreamAudio=1` copies the audio through.

Everything here was measured against a live PMS 1.43 rather than inferred — including the surprise that cue-less spans are served as bare `WEBVTT` stubs with no timestamp map, which the offset probe has to skip. Verified on-device across three rounds: no stall or error, subtitles in sync including after seeks, audio copied.

I'll be upfront that this isn't the ideal shape: it leans on the transcoder where direct play/direct stream just hand the player the subtitle stream to handle natively. That path isn't reachable here — the source container is the one URL a disabled direct play forbids — and this is the best mechanism I found that actually works. If anyone sees a better one, I'm happy for it to win. The Jellyfin half of #1738 is deliberately not in this PR; it's a separate defect (the sidecar loads but the track is never applied) and will follow as its own PR so the two backends end up consistent. Please review carefully.