### PR TITLE
feat(rpm): add rpm signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ env:
     libva-dev libvdpau-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxi-dev
     libxss-dev libxpresent-dev libxkbcommon-dev libpulse-dev libdbus-1-dev libdrm-dev
     libgbm-dev libwayland-dev wayland-protocols liblcms2-dev libmujs-dev liblua5.2-dev
-    ruby ruby-dev rubygems build-essential rpm libarchive-tools imagemagick libcurl4-openssl-dev
+    ruby ruby-dev rubygems build-essential rpm gnupg libarchive-tools imagemagick libcurl4-openssl-dev
 
 jobs:
   validate-trusted-ref:
@@ -772,6 +772,12 @@ jobs:
           ARCH_SUFFIX=${{ matrix.arch }} \
           OUTPUT_DIR="$GITHUB_WORKSPACE" \
           python3 linux/packaging/build-packages.py
+
+      - name: Sign Linux RPM
+        shell: bash
+        env:
+          RPM_SIGNING_PRIVATE_KEY: ${{ secrets.RPM_SIGNING_PRIVATE_KEY }}
+        run: bash linux/packaging/sign-rpm.sh "plezy-linux-${{ matrix.arch }}.rpm"
 
       - name: Copy libmpv into bundle
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
       - name: Verify translation hygiene
         run: python3 scripts/clean_translations.py --check --strict
 
+      - name: Install RPM test dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends gnupg rpm ruby
+          sudo gem install fpm --version 1.17.0 --no-document
+
       - name: Verify workflow and script guards
         run: bash scripts/ci_guard_checks.sh
 

--- a/linux/packaging/build-packages.py
+++ b/linux/packaging/build-packages.py
@@ -52,6 +52,13 @@ DISTROS = {
         "category": "Multimedia",
         "ext": "rpm",
         "compression": ["--rpm-compression", "xzmt"],
+        "extra_files": [
+            {
+                "source": "plezy.repo",
+                "destination": "/etc/yum.repos.d/plezy.repo",
+                "config": True,
+            }
+        ],
         "depends": [
             "gtk3",
             "mpv-libs",
@@ -108,13 +115,18 @@ def generate_icons():
             shutil.copy(source, dest)
 
 
-def get_file_mappings() -> list[str]:
+def get_file_mappings(distro: str) -> list[str]:
     """Get file mappings for fpm."""
     mappings = [
         f"{BUILD_DIR}/=/opt/plezy/",
         f"{SCRIPT_DIR}/com.edde746.plezy.desktop=/usr/share/applications/com.edde746.plezy.desktop",
         f"{SCRIPT_DIR}/plezy.sh=/usr/bin/plezy",
     ]
+
+    for extra_file in DISTROS[distro].get("extra_files", []):
+        mappings.append(
+            f"{SCRIPT_DIR / extra_file['source']}={extra_file['destination']}"
+        )
 
     for size in ICON_SIZES:
         mappings.append(
@@ -153,6 +165,10 @@ def build_package(distro: str, version: str):
     for dep in config["depends"]:
         cmd.extend(["--depends", dep])
 
+    for extra_file in config.get("extra_files", []):
+        if extra_file.get("config"):
+            cmd.extend(["--config-files", extra_file["destination"]])
+
     cmd.extend(config["compression"])
 
     cmd.extend([
@@ -161,7 +177,7 @@ def build_package(distro: str, version: str):
         "--package", str(output_file),
     ])
 
-    cmd.extend(get_file_mappings())
+    cmd.extend(get_file_mappings(distro))
 
     subprocess.run(cmd, check=True)
     print(f"Created: {output_file}")

--- a/linux/packaging/plezy.repo
+++ b/linux/packaging/plezy.repo
@@ -1,0 +1,8 @@
+[plezy]
+name=Plezy
+baseurl=https://plezy.app/rpm/$basearch/
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://plezy.app/rpm/RPM-GPG-KEY-plezy
+metadata_expire=6h

--- a/linux/packaging/sign-rpm.sh
+++ b/linux/packaging/sign-rpm.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <rpm-path>" >&2
+  exit 2
+fi
+
+if [[ -z "${RPM_SIGNING_PRIVATE_KEY:-}" ]]; then
+  echo "RPM_SIGNING_PRIVATE_KEY is required to sign release RPMs." >&2
+  exit 1
+fi
+
+rpm_path=$1
+if [[ ! -f "$rpm_path" ]]; then
+  echo "RPM file not found: $rpm_path" >&2
+  exit 1
+fi
+
+signing_root=$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/plezy-rpm-signing.XXXXXX")
+cleanup() {
+  rm -rf -- "$signing_root"
+}
+
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+export GNUPGHOME="$signing_root/gnupg"
+mkdir -m 700 "$GNUPGHOME"
+
+private_key_path="$signing_root/private-key.asc"
+(umask 077 && printf '%s' "$RPM_SIGNING_PRIVATE_KEY" > "$private_key_path")
+unset RPM_SIGNING_PRIVATE_KEY
+
+if ! gpg --batch --quiet --import "$private_key_path" >/dev/null 2>&1; then
+  echo "Could not import RPM signing key." >&2
+  exit 1
+fi
+
+rm -f -- "$private_key_path"
+
+secret_key_listing=$(gpg --batch --with-colons --list-secret-keys --fingerprint)
+mapfile -t primary_fingerprints < <(
+  awk -F: '
+    $1 == "sec" { need_fingerprint = 1; next }
+    need_fingerprint && $1 == "fpr" { print $10; need_fingerprint = 0 }
+  ' <<< "$secret_key_listing"
+)
+
+if [[ ${#primary_fingerprints[@]} -ne 1 ]]; then
+  echo "RPM signing key must contain exactly one primary private key." >&2
+  exit 1
+fi
+
+fingerprint=${primary_fingerprints[0]}
+primary_record=$(awk -F: '$1 == "sec" { print; exit }' <<< "$secret_key_listing")
+IFS=: read -r -a primary_fields <<< "$primary_record"
+validity=${primary_fields[1]}
+capabilities=${primary_fields[11]}
+if [[ "$validity" =~ [erdi] || "${capabilities,,}" != *s* ]]; then
+  echo "RPM signing key was invalid." >&2
+  exit 1
+fi
+
+public_key_path="$signing_root/public-key.asc"
+gpg --batch --armor --export "$fingerprint" > "$public_key_path"
+if [[ ! -s "$public_key_path" ]]; then
+  echo "Could not export RPM signing public key." >&2
+  exit 1
+fi
+
+gpg_binary=$(command -v gpg)
+rpmsign \
+  --addsign \
+  --define "__gpg $gpg_binary" \
+  --define "_gpg_path $GNUPGHOME" \
+  --define "_gpg_name $fingerprint" \
+  --define "_openpgp_sign_id $fingerprint" \
+  "$rpm_path"
+
+rpm_db="$signing_root/rpmdb"
+mkdir -m 700 "$rpm_db"
+rpm --dbpath "$rpm_db" --initdb
+rpm --dbpath "$rpm_db" --import "$public_key_path"
+
+if ! verification_output=$(rpm --dbpath "$rpm_db" --checksig "$rpm_path"); then
+  echo "RPM signature verification failed." >&2
+  exit 1
+fi
+
+if [[ "$verification_output" != *"signatures OK"* || "$verification_output" == *"NOKEY"* || "$verification_output" == *"NOT OK"* ]]; then
+  echo "RPM signature verification failed." >&2
+  exit 1
+fi
+
+printf '%s\n' "$verification_output"

--- a/scripts/test_build_packages.py
+++ b/scripts/test_build_packages.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import configparser
+import importlib.util
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+from urllib.parse import urlparse
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_PACKAGES = ROOT / "linux/packaging/build-packages.py"
+REPOSITORY_PATH = "/etc/yum.repos.d/plezy.repo"
+REQUIRED_TOOLS = (
+    "fpm",
+    "rpm",
+)
+
+def load_build_packages():
+    spec = importlib.util.spec_from_file_location("build_packages", BUILD_PACKAGES)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {BUILD_PACKAGES}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+def assert_repository_behavior(test: unittest.TestCase, contents: str) -> None:
+    config = configparser.ConfigParser(interpolation=None)
+    config.read_string(contents)
+    repository = config["plezy"]
+    test.assertTrue(repository.getboolean("enabled"))
+    test.assertTrue(repository.getboolean("gpgcheck"))
+    test.assertTrue(repository.getboolean("repo_gpgcheck"))
+    base_url = urlparse(repository["baseurl"])
+    key_url = urlparse(repository["gpgkey"])
+    test.assertEqual((base_url.scheme, base_url.netloc, base_url.path), ("https", "plezy.app", "/rpm/$basearch/"))
+    test.assertEqual(
+        (key_url.scheme, key_url.netloc, key_url.path),
+        ("https", "plezy.app", "/rpm/RPM-GPG-KEY-plezy"),
+    )
+
+class BuildPackagesTest(unittest.TestCase):
+    @unittest.skipIf(
+        any(shutil.which(tool) is None for tool in REQUIRED_TOOLS),
+        "RPM packaging toolchain is unavailable",
+    )
+    def test_installing_the_unsigned_rpm_registers_authenticated_updates(self) -> None:
+        module = load_build_packages()
+        source = ROOT / "linux/packaging"
+
+        with tempfile.TemporaryDirectory(prefix="plezy-package-test-") as directory:
+            fixture = Path(directory)
+            packaging = fixture / "packaging"
+            bundle = fixture / "bundle"
+            output = fixture / "output"
+            shutil.copytree(source, packaging)
+            bundle.mkdir()
+            output.mkdir()
+            for size in module.ICON_SIZES:
+                icon = packaging / f"icons/{size}x{size}/plezy.png"
+                icon.parent.mkdir(parents=True, exist_ok=True)
+                icon.write_bytes(b"package fixture")
+            executable = bundle / "plezy"
+            executable.write_text("#!/bin/sh\n", encoding="utf-8")
+            executable.chmod(0o755)
+
+            module.SCRIPT_DIR = packaging
+            module.BUILD_DIR = bundle
+            module.OUTPUT_DIR = output
+            module.ARCH_SUFFIX = "x64"
+            module.build_package("rpm", "1.2.3")
+
+            rpm_path = output / "plezy-linux-x64.rpm"
+            unsigned = subprocess.run(
+                ["rpm", "--checksig", str(rpm_path)],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertNotIn("signatures OK", unsigned)
+
+            install_root = fixture / "installed"
+            (install_root / "var/lib/rpm").mkdir(parents=True)
+            subprocess.run(
+                ["rpm", "--root", str(install_root), "--dbpath", "/var/lib/rpm", "--initdb"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [
+                    "rpm",
+                    "--root",
+                    str(install_root),
+                    "--dbpath",
+                    "/var/lib/rpm",
+                    "--nodeps",
+                    "--noscripts",
+                    "--install",
+                    str(rpm_path),
+                ],
+                check=True,
+                capture_output=True,
+            )
+            assert_repository_behavior(
+                self,
+                (install_root / REPOSITORY_PATH.lstrip("/")).read_text(encoding="utf-8"),
+            )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_sign_rpm.py
+++ b/scripts/test_sign_rpm.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SIGN_RPM = ROOT / "linux/packaging/sign-rpm.sh"
+REAL_SIGNING_TOOLS = ("fpm", "gpg", "rpm", "rpmsign")
+
+def generate_private_key_export(
+    primary_keys: int,
+    capabilities: str = "sign",
+    add_signing_subkey: bool = False,
+) -> str:
+    with tempfile.TemporaryDirectory(prefix="plezy-test-gnupg-", dir="/tmp") as directory:
+        home = Path(directory)
+        home.chmod(0o700)
+        env = os.environ.copy()
+        env["GNUPGHOME"] = str(home)
+        for index in range(primary_keys):
+            subprocess.run(
+                [
+                    "gpg",
+                    "--batch",
+                    "--pinentry-mode",
+                    "loopback",
+                    "--passphrase",
+                    "",
+                    "--quick-gen-key",
+                    f"Plezy RPM Test {index} <rpm-test-{index}@plezy.invalid>",
+                    "rsa2048",
+                    capabilities,
+                    "1d",
+                ],
+                env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if add_signing_subkey:
+                listing = subprocess.run(
+                    ["gpg", "--batch", "--with-colons", "--list-secret-keys", "--fingerprint"],
+                    env=env,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout
+                fingerprint = next(
+                    line.split(":")[9]
+                    for line in listing.splitlines()
+                    if line.startswith("fpr:")
+                )
+                subprocess.run(
+                    [
+                        "gpg",
+                        "--batch",
+                        "--pinentry-mode",
+                        "loopback",
+                        "--passphrase",
+                        "",
+                        "--quick-add-key",
+                        fingerprint,
+                        "rsa2048",
+                        "sign",
+                        "1d",
+                    ],
+                    env=env,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+        return subprocess.run(
+            ["gpg", "--batch", "--armor", "--export-secret-keys"],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+def run_signer(private_key: str | None) -> tuple[subprocess.CompletedProcess[str], bytes, list[Path]]:
+    with tempfile.TemporaryDirectory(prefix="plezy-sign-rpm-test-", dir="/tmp") as directory:
+        temp_dir = Path(directory)
+        rpm_path = temp_dir / "plezy.rpm"
+        rpm_path.write_bytes(b"unsigned rpm fixture")
+        env = os.environ.copy()
+        env["RUNNER_TEMP"] = str(temp_dir)
+        if private_key is None:
+            env.pop("RPM_SIGNING_PRIVATE_KEY", None)
+        else:
+            env["RPM_SIGNING_PRIVATE_KEY"] = private_key
+        result = subprocess.run(
+            ["bash", str(SIGN_RPM), str(rpm_path)],
+            cwd=ROOT,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result, rpm_path.read_bytes(), list(temp_dir.glob("plezy-rpm-signing.*"))
+
+class SignRpmTest(unittest.TestCase):
+    def test_missing_or_invalid_key_fails_before_modifying_the_rpm(self) -> None:
+        invalid_keys = (
+            None,
+            "not an OpenPGP private key",
+            generate_private_key_export(2),
+            generate_private_key_export(1, capabilities="encr"),
+        )
+
+        for private_key in invalid_keys:
+            with self.subTest(key_supplied=private_key is not None):
+                result, package, temporary_paths = run_signer(private_key)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(package, b"unsigned rpm fixture")
+                self.assertEqual(temporary_paths, [])
+                if private_key:
+                    self.assertNotIn(private_key, result.stdout + result.stderr)
+
+    @unittest.skipIf(
+        any(shutil.which(tool) is None for tool in REAL_SIGNING_TOOLS),
+        "complete RPM signing toolchain is unavailable",
+    )
+    def test_real_rpm_is_signed_and_verified_with_a_signing_subkey(self) -> None:
+        private_key = generate_private_key_export(
+            1,
+            capabilities="cert",
+            add_signing_subkey=True,
+        )
+        with tempfile.TemporaryDirectory(prefix="plezy-real-signing-test-", dir="/tmp") as directory:
+            temp_dir = Path(directory)
+            payload = temp_dir / "payload"
+            payload.mkdir()
+            (payload / "plezy").write_text("package fixture\n", encoding="utf-8")
+            rpm_path = temp_dir / "plezy.rpm"
+            subprocess.run(
+                [
+                    "fpm",
+                    "-s",
+                    "dir",
+                    "-t",
+                    "rpm",
+                    "-n",
+                    "plezy",
+                    "-v",
+                    "1.2.3",
+                    "--iteration",
+                    "1",
+                    "--package",
+                    str(rpm_path),
+                    f"{payload}/=/opt/plezy/",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            env = os.environ.copy()
+            env["RPM_SIGNING_PRIVATE_KEY"] = private_key
+            env["RUNNER_TEMP"] = str(temp_dir)
+            signing = subprocess.run(
+                ["bash", str(SIGN_RPM), str(rpm_path)],
+                cwd=ROOT,
+                env=env,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(signing.returncode, 0, signing.stderr)
+            self.assertNotIn(private_key, signing.stdout + signing.stderr)
+            self.assertEqual(list(temp_dir.glob("plezy-rpm-signing.*")), [])
+
+            verification_home = temp_dir / "verification-gnupg"
+            verification_home.mkdir(mode=0o700)
+            verification_env = os.environ.copy()
+            verification_env["GNUPGHOME"] = str(verification_home)
+            subprocess.run(
+                ["gpg", "--batch", "--import"],
+                input=private_key,
+                env=verification_env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            public_key = temp_dir / "public-key.asc"
+            public_key.write_text(
+                subprocess.run(
+                    ["gpg", "--batch", "--armor", "--export"],
+                    env=verification_env,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout,
+                encoding="utf-8",
+            )
+            rpm_database = temp_dir / "verification-rpmdb"
+            subprocess.run(
+                ["rpm", "--dbpath", str(rpm_database), "--initdb"],
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["rpm", "--dbpath", str(rpm_database), "--import", str(public_key)],
+                check=True,
+                capture_output=True,
+            )
+            verification = subprocess.run(
+                ["rpm", "--dbpath", str(rpm_database), "--checksig", str(rpm_path)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(verification.returncode, 0, verification.stdout + verification.stderr)
+            self.assertNotIn("NOKEY", verification.stdout)
+            self.assertNotIn("NOT OK", verification.stdout)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@edde746 I'm creating this as a draft because my motivation for this is to see if you'd be willing to setup an RPM repository which would allow RPM package managers to auto update Plezy.

This PR sets up some of what you would need for that, signing the RPMs. The other part would be hosting the repository metadata and setting up the signing keys etc. The metadata is relatively small, it would mostly just be the list of versions and links to the signed RPM assets, fingerprints, public key etc.