### PR TITLE
fix(player): accept clock-sync pongs only from the host

### DIFF
--- a/lib/watch_together/services/watch_together_controller.dart
+++ b/lib/watch_together/services/watch_together_controller.dart
@@ -354,7 +354,7 @@ class WatchTogetherController {
         break;
 
       case SyncMessageType.pong:
-        if (message.pingId != null && !_session.isHost) {
+        if (!_session.isHost && senderId == _session.hostPeerId && message.pingId != null) {
           _clockSync?.onPong(message.pingId!, message.timestamp);
         }
         break;


### PR DESCRIPTION
The media state is authenticated correctly; the clock used to interpret it is not.

A guest cannot forge `STATE` — `_handleMessage` checks the relay-stamped `senderId`
against `_session.hostPeerId` before room state or `hostExitedPlayer` is acted on.
The `pong` case only asked "am I a guest, and is this a `pingId` I'm waiting for?",
never "did this come from my pinned host?", so any peer could answer another guest's
clock-sync ping.

That estimate is how a guest reads authentic host instructions. It converts every
`anchorHostTimeMs` into its own timeline through the offset, so a pong stamped 50 s
off doesn't command a seek — it moves the coordinate system underneath the host's
legitimate state, and the reconciler hard-seeks past the 2000 ms threshold and keeps
mistranslating the corrections that follow. Scheduled synchronized starts convert
through the same offset. The host and other guests see nothing wrong.

Not "anyone can take over playback" — the forged pong still needs an outstanding
`pingId` inside its RTT window. But the sender is already stamped, so enforcing the
invariant costs one conjunct.

No test: asserting a single conjunct would need a third-peer seam `FakeRelayHub`
doesn't have, and `clock_sync_test.dart` already covers the `ClockSync` side.

Verified: full suite green (5788 tests, 5 skipped), 186 under `test/watch_together`,
plus format, analyzer, and codegen freshness.
