### PR TITLE
fix(linux): defer buffer_scale until first frame is presented

### DIFF
--- a/linux/runner/mpv/wayland_video_surface.cc
+++ b/linux/runner/mpv/wayland_video_surface.cc
@@ -1161,7 +1161,15 @@ void WaylandVideoSurface::SetRect(int32_t x, int32_t y, int32_t width, int32_t h
 
   if (surface_ == nullptr || subsurface_ == nullptr || egl_window_ == nullptr) return;
 
-  if (scale_changed) wl_surface_set_buffer_scale(surface_, scale_);
+  // A buffer_scale change must not reach the wire before the first frame:
+  // mesa commits the EGL surface's pre-allocated 1x1 back buffer on the
+  // first swap regardless of wl_egl_window_resize, and a 1x1 buffer at
+  // scale > 1 is a fatal protocol error (the compositor disconnects us).
+  // Present() flushes the deferred scale right after the first commit.
+  if (scale_changed && buffer_attached_ && scale_ != scale_sent_) {
+    wl_surface_set_buffer_scale(surface_, scale_);
+    scale_sent_ = scale_;
+  }
   if (size_changed || scale_changed) wl_egl_window_resize(egl_window_, width_, height_, 0, 0);
   // Both axes are floored into surface-local units and then offset by the
   // view's position inside the toplevel; PlaneSurfacePosition explains why.
@@ -1217,6 +1225,13 @@ bool WaylandVideoSurface::Present() {
   }
   if (!buffer_attached_) {
     buffer_attached_ = true;
+    // First frame published at scale 1; the real scale may now go out. It
+    // applies to the next commit, whose buffer mesa allocates at the resized
+    // window size (a multiple of the scale).
+    if (scale_ != scale_sent_) {
+      wl_surface_set_buffer_scale(surface_, scale_);
+      scale_sent_ = scale_;
+    }
     // The first buffer changes what the plane occludes; make sure the parent's
     // view of the subsurface is up to date.
     RequestParentCommit();

--- a/linux/runner/mpv/wayland_video_surface.cc
+++ b/linux/runner/mpv/wayland_video_surface.cc
@@ -1088,9 +1088,12 @@ void WaylandVideoSurface::Destroy() {
   width_ = 0;
   height_ = 0;
   scale_ = 1;
+  // A fresh wl_surface starts at buffer_scale 1; a stale scale_sent_ would
+  // suppress the first scale request after recreation.
+  scale_sent_ = 1;
   visible_ = false;
   rect_valid_ = false;
-  buffer_attached_ = false;
+  first_frame_presented_ = false;
 }
 
 void WaylandVideoSurface::RequestParentCommit() {
@@ -1161,12 +1164,15 @@ void WaylandVideoSurface::SetRect(int32_t x, int32_t y, int32_t width, int32_t h
 
   if (surface_ == nullptr || subsurface_ == nullptr || egl_window_ == nullptr) return;
 
-  // A buffer_scale change must not reach the wire before the first frame:
-  // mesa commits the EGL surface's pre-allocated 1x1 back buffer on the
-  // first swap regardless of wl_egl_window_resize, and a 1x1 buffer at
+  // A buffer_scale change must not reach the wire before the first frame is
+  // presented: mesa commits the EGL surface's pre-allocated 1x1 back buffer
+  // on the first swap regardless of wl_egl_window_resize, and a 1x1 buffer at
   // scale > 1 is a fatal protocol error (the compositor disconnects us).
-  // Present() flushes the deferred scale right after the first commit.
-  if (scale_changed && buffer_attached_ && scale_ != scale_sent_) {
+  // Present() flushes the deferred scale right after that first commit. The
+  // gate is the first-frame latch rather than buffer attachment: the committed
+  // scale survives a detach, so once a frame has been presented the scale must
+  // be updatable with no buffer attached.
+  if (scale_changed && first_frame_presented_ && scale_ != scale_sent_) {
     wl_surface_set_buffer_scale(surface_, scale_);
     scale_sent_ = scale_;
   }
@@ -1188,7 +1194,6 @@ void WaylandVideoSurface::DetachBuffer() {
   ClearFrameCallback();
   wl_surface_attach(surface_, nullptr, 0, 0);
   wl_surface_commit(surface_);
-  buffer_attached_ = false;
 }
 
 void WaylandVideoSurface::SetVisible(bool visible) {
@@ -1223,11 +1228,14 @@ bool WaylandVideoSurface::Present() {
     g_warning("MPV video plane: eglSwapBuffers failed: 0x%x", eglGetError());
     return false;
   }
-  if (!buffer_attached_) {
-    buffer_attached_ = true;
+  if (!first_frame_presented_) {
     // First frame published at scale 1; the real scale may now go out. It
     // applies to the next commit, whose buffer mesa allocates at the resized
-    // window size (a multiple of the scale).
+    // window size (a multiple of the scale). The latch is deliberately not
+    // buffer attachment: DetachBuffer() clears that while the committed scale
+    // stays on the wire, and once a frame has been presented SetRect() must be
+    // free to change the scale with no buffer attached.
+    first_frame_presented_ = true;
     if (scale_ != scale_sent_) {
       wl_surface_set_buffer_scale(surface_, scale_);
       scale_sent_ = scale_;

--- a/linux/runner/mpv/wayland_video_surface.h
+++ b/linux/runner/mpv/wayland_video_surface.h
@@ -335,6 +335,10 @@ class WaylandVideoSurface {
   int32_t width_ = 0;
   int32_t height_ = 0;
   int32_t scale_ = 1;
+  // The buffer_scale actually on the wire. A change is deferred until the
+  // first frame is presented: the compositor must never see a scale > 1
+  // while the EGL surface's pre-allocated 1x1 back buffer is still live.
+  int32_t scale_sent_ = 1;
   // The view's own offset inside the toplevel, which is the frame
   // wl_subsurface_set_position uses. Non-zero under client-side decorations.
   int32_t view_x_ = 0;

--- a/linux/runner/mpv/wayland_video_surface.h
+++ b/linux/runner/mpv/wayland_video_surface.h
@@ -338,6 +338,8 @@ class WaylandVideoSurface {
   // The buffer_scale actually on the wire. A change is deferred until the
   // first frame is presented: the compositor must never see a scale > 1
   // while the EGL surface's pre-allocated 1x1 back buffer is still live.
+  // Reset to 1 in Destroy(): a freshly created wl_surface starts at scale 1,
+  // and a stale value would suppress the first scale request after recreation.
   int32_t scale_sent_ = 1;
   // The view's own offset inside the toplevel, which is the frame
   // wl_subsurface_set_position uses. Non-zero under client-side decorations.
@@ -347,7 +349,14 @@ class WaylandVideoSurface {
   // Set from the size Dart asked for, before SetRect rounds it into a whole
   // number of scale-sized blocks. See has_size().
   bool rect_valid_ = false;
-  bool buffer_attached_ = false;
+  // Set once a frame has been presented at the current scale, cleared only
+  // when the wl_surface is torn down. While false, the EGL surface's
+  // pre-allocated 1x1 back buffer is still live, so scale changes must be
+  // deferred; once true the wire scale may change at any time, because the
+  // next buffer mesa allocates matches the current window size. Deliberately
+  // not "a buffer is attached": a detach keeps the committed scale on the
+  // wire, so the scale gate must not depend on attachment.
+  bool first_frame_presented_ = false;
   bool frame_pending_ = false;
   wl_callback* frame_callback_ = nullptr;
   std::function<void()> on_frame_;


### PR DESCRIPTION
Fixes #1872.

Learned about plezy today and wanted to try it out, but saw it didn't run on my CachyOS install. Had my LLM investigate and it came up with this. Full disclosure, never done any work with C++ outside of school. Tested it locally and it worked, HW decoding also worked, confirmed using amdgpu_top. 

Let me know if you agree or if I need to touch something up!

----

## Root cause
The video plane creates its wl_egl_window as a 1x1 placeholder. When playback
starts, SetRect() sends wl_surface.set_buffer_scale(2) and resizes the window,
but mesa commits the EGL surface's pre-allocated 1x1 back buffer on the first
eglSwapBuffers. A 1x1 buffer is not an integer multiple of buffer_scale 2, so
the compositor raises WL_SURFACE_ERROR_INVALID_SIZE and kills the whole Wayland
connection — app death. At 100% scale the same 1x1 buffer is legal, which is
why the "display scale 100%" workaround works.

## Fix
Defer set_buffer_scale until after the first frame is presented: the first
commit is 1x1 at scale 1 (always legal); the scale change then lands on the
wire and applies to the next commit, whose buffer mesa allocates at the
resized (scale-multiple) window size. The one-frame 1x1 flash is mpv's black
first frame — imperceptible.

## Verification
- Minimal Wayland repro client replicating plezy's exact sequence: crashes with
  the identical error before the fix, survives after.
- Rebuilt the AUR plezy-git package with the patch and played video on the
  Wayland plane at 200% scale (CachyOS/Arch + GNOME Wayland, AMD Vega): no
  protocol error, app alive, clean exit.
