### PR TITLE
Add a play from beginning button to the detail screen

### DIFF
--- a/lib/screens/media_detail/action_buttons.dart
+++ b/lib/screens/media_detail/action_buttons.dart
@@ -53,6 +53,32 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
       }
     }
 
+    // Restart target: the item whose in-progress playback a "play from
+    // beginning" would discard. For shows that is the on-deck episode (the
+    // show itself never carries a view offset), otherwise the item itself.
+    MediaItem? restartTarget;
+    if (metadata.isShow) {
+      final episode = _onDeckEpisode == null ? null : _fresh(_onDeckEpisode!);
+      if (episode != null && (episode.viewOffsetMs ?? 0) > 0) {
+        restartTarget = episode;
+      }
+    } else if (!metadata.isSeason && (_fresh(metadata).viewOffsetMs ?? 0) > 0) {
+      restartTarget = _fresh(metadata);
+    }
+
+    Future<void> onRestartPressed() async {
+      final target = restartTarget;
+      if (target == null) return;
+      appLogger.d('Playing from beginning: ${target.title}');
+      await navigateToVideoPlayerWithRefresh(
+        context,
+        metadata: target.copyWith(viewOffsetMs: 0),
+        isOffline: widget.isOffline,
+        onRefresh: _loadFullMetadata,
+        resolveWatchState: false,
+      );
+    }
+
     final primaryTrailer = _getPrimaryTrailer();
 
     final isKeyboardMode = InputModeTracker.isKeyboardMode(context);
@@ -157,6 +183,19 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
       builder: (context, state) => playButton(state),
     );
 
+    final restartAction = restartTarget == null
+        ? null
+        : FocusableAction(
+            debugLabel: 'detail_restart',
+            onPressed: () => unawaited(onRestartPressed()),
+            builder: (context, state) => iconActionButton(
+              state,
+              onPressed: () => unawaited(onRestartPressed()),
+              icon: const AppIcon(Symbols.replay_rounded, fill: 1),
+              tooltip: t.mediaMenu.playFromBeginning,
+            ),
+          );
+
     final trailerAction = primaryTrailer == null
         ? null
         : FocusableAction(
@@ -254,6 +293,7 @@ extension _MediaDetailActionButtons on _MediaDetailScreenState {
 
     final allActions = <FocusableAction>[
       playAction,
+      ?restartAction,
       ?trailerAction,
       ?shuffleAction,
       ?downloadAction,

--- a/lib/utils/video_player_navigation.dart
+++ b/lib/utils/video_player_navigation.dart
@@ -408,6 +408,7 @@ Future<bool?> navigateToVideoPlayerWithRefresh(
   int? selectedMediaIndex,
   String? selectedMediaSourceId,
   bool usePushReplacement = false,
+  bool resolveWatchState = true,
 }) async {
   final result = await navigateToVideoPlayer(
     context,
@@ -419,6 +420,7 @@ Future<bool?> navigateToVideoPlayerWithRefresh(
     selectedMediaIndex: selectedMediaIndex,
     selectedMediaSourceId: selectedMediaSourceId,
     usePushReplacement: usePushReplacement,
+    resolveWatchState: resolveWatchState,
   );
 
   appLogger.d('Returned from playback, refreshing metadata');


### PR DESCRIPTION
On the show detail screen the play button resumes the on-deck episode, but there is no way to restart that episode from the start. "Play from beginning" only exists in the ⋮ menu for movies - the show item itself never carries a view offset, so the menu entry never appears for shows.

My use case: I fall asleep to a show most nights, so the next evening I want to rewatch the current episode from the start instead of resuming at wherever I dozed off.

This adds a replay button next to play, shown only when there is something to restart: the on-deck episode with progress for shows, or the item's own view offset for movies and episodes. It plays through the existing play-from-start path (view offset cleared plus `resolveWatchState: false`, same as the context menu entry does). `navigateToVideoPlayerWithRefresh` now passes `resolveWatchState` through to make that possible.

Reuses the existing `mediaMenu.playFromBeginning` string, so no new translation keys.

On narrow phone layouts the button drops out of the compact tiers like the other secondary actions - the episode card context menu still covers restarting there.
