### PR TITLE
fix(ui): let logo-less detail titles use full hero width

### DIFF
--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -3441,6 +3441,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                                 context,
                                 metadata,
                                 width: logoWidth,
+                                titleWidth: constraints.maxWidth,
                                 height: logoHeight,
                                 titleBuilder: (context, title) => _buildDetailTitle(
                                   context,
@@ -3585,11 +3586,16 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
     required double width,
     required double height,
     required Widget Function(BuildContext context, String title) titleBuilder,
+    double? titleWidth,
   }) {
     Widget titleFallback(BuildContext context) => titleBuilder(context, metadata.displayTitle);
 
     if (metadata.clearLogoPath == null) {
-      return SizedBox(width: width, height: height, child: titleFallback(context));
+      // A clear-logo image is capped at [width] so it doesn't stretch across a
+      // wide hero, but the text-title fallback for logo-less media wants the
+      // full available width — otherwise FittingTitleText shrinks and clips a
+      // long title inside the logo box even when the display could fit it (#1796).
+      return SizedBox(width: titleWidth ?? width, height: height, child: titleFallback(context));
     }
 
     return SizedBox(
@@ -4209,6 +4215,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                           context,
                           metadata,
                           width: logoWidth,
+                          titleWidth: constraints.maxWidth,
                           height: logoHeight,
                           titleBuilder: (context, title) => _buildDetailTitle(
                             context,

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -3412,6 +3412,12 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
             actionGap +
             actionHeight;
         final logoWidth = desiredLogoWidth < constraints.maxWidth ? desiredLogoWidth : constraints.maxWidth;
+        // Same rule as the non-TV hero: a logo-less title may use up to twice
+        // the logo box, never more than the column. This foreground is already a
+        // ~57% column (see the 0.43 right reservation in _buildTvDetailScreen),
+        // so in practice the column bounds it; the cap keeps both heroes on one rule.
+        final desiredTitleWidth = desiredLogoWidth * 2;
+        final titleWidth = desiredTitleWidth < constraints.maxWidth ? desiredTitleWidth : constraints.maxWidth;
 
         return ClipRect(
           child: SizedBox(
@@ -3441,7 +3447,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                                 context,
                                 metadata,
                                 width: logoWidth,
-                                titleWidth: constraints.maxWidth,
+                                titleWidth: titleWidth,
                                 height: logoHeight,
                                 titleBuilder: (context, title) => _buildDetailTitle(
                                   context,
@@ -3592,9 +3598,10 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
     if (metadata.clearLogoPath == null) {
       // A clear-logo image is capped at [width] so it doesn't stretch across a
-      // wide hero, but the text-title fallback for logo-less media wants the
-      // full available width — otherwise FittingTitleText shrinks and clips a
-      // long title inside the logo box even when the display could fit it (#1796).
+      // wide hero, but the text-title fallback for logo-less media gets its own
+      // wider (still bounded) [titleWidth] — otherwise FittingTitleText shrinks
+      // and clips a long title inside the logo box even when the display could
+      // fit it (#1796). Callers decide the bound; it defaults to the logo width.
       return SizedBox(width: titleWidth ?? width, height: height, child: titleFallback(context));
     }
 
@@ -4189,6 +4196,11 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
         final showLogo = logoHeight >= 24;
         final effectiveLogoGap = showLogo ? logoGap : 0.0;
         final logoWidth = desiredLogoWidth.clamp(0.0, constraints.maxWidth).toDouble();
+        // Logo-less fallback title: wider than the logo box so a long title isn't
+        // crushed at 400px on a wide display (#1796), but bounded — twice the logo
+        // box, never the whole hero — so it reads as a title column, not a banner.
+        // On phones the hero itself is narrower than this, so nothing changes there.
+        final titleWidth = (desiredLogoWidth * 2).clamp(0.0, constraints.maxWidth).toDouble();
         final titleFontSize = (logoHeight * 0.38).clamp(24.0, 40.0).toDouble();
         final contentHeight =
             (showLogo ? logoHeight + effectiveLogoGap : 0.0) +
@@ -4215,7 +4227,7 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
                           context,
                           metadata,
                           width: logoWidth,
-                          titleWidth: constraints.maxWidth,
+                          titleWidth: titleWidth,
                           height: logoHeight,
                           titleBuilder: (context, title) => _buildDetailTitle(
                             context,

--- a/test/screens/media_detail_screen_test.dart
+++ b/test/screens/media_detail_screen_test.dart
@@ -42,6 +42,7 @@ import 'package:plezy/utils/video_player_navigation.dart';
 import 'package:plezy/widgets/collapsible_text.dart';
 import 'package:plezy/widgets/cycling_media_backdrop.dart';
 import 'package:plezy/widgets/episode_card.dart';
+import 'package:plezy/widgets/fitting_title_text.dart';
 import 'package:plezy/widgets/tv_browse_rail.dart';
 import 'package:provider/provider.dart';
 
@@ -98,11 +99,12 @@ void main() {
     expect(titleText.style!.fontSize!, lessThan(baseFontSize));
   });
 
-  testWidgets('wide non-TV hero lets a logo-less title use the full width', (tester) async {
+  testWidgets('wide non-TV hero gives a logo-less title a capped width wider than the logo box', (tester) async {
     // Non-TV (iPad/desktop) hero: without a clear logo the fallback title used
     // to be boxed at the logo's 400px width cap, so a long title clipped early
     // on a wide display even with room to spare (#1796). It should now lay out
-    // wider than that cap.
+    // wider than that cap — but bounded (twice the logo box), not the whole
+    // hero, so it reads as a title column rather than a banner.
     TvDetectionService.debugSetAppleTVOverride(false);
     await SettingsService.getInstance();
     tester.view.physicalSize = const Size(1400, 900);
@@ -163,9 +165,130 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(find.text(title), findsWidgets);
-    // Old logo width cap was 400 (desiredLogoWidth in _buildHeroHeaderContent).
-    expect(tester.getSize(find.text(title).first).width, greaterThan(400));
+    // The hero title is the only FittingTitleText on this screen (the title
+    // string also appears further down the page), and its box is exactly the
+    // width the hero hands the fallback title — so measure the box itself.
+    final heroTitleBox = find.ancestor(of: find.text(title), matching: find.byType(FittingTitleText));
+    expect(heroTitleBox, findsOneWidget);
+    // The hero here is 1368px wide (1400 minus 16px side padding). The old logo
+    // cap was 400; the title now gets twice that — 800 — and no more: wider
+    // than the logo box, but clearly not the full hero.
+    expect(tester.getSize(heroTitleBox).width, closeTo(800, 0.5));
+  });
+
+  testWidgets('phone-width hero keeps a logo-less title inside the hero', (tester) async {
+    // On a phone the hero is narrower than the title cap, so the cap never
+    // binds: the title simply fills the hero, exactly as it did before #1796.
+    TvDetectionService.debugSetAppleTVOverride(false);
+    await SettingsService.getInstance();
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const title = 'The Surprisingly Long Movie Title That Needs Two Whole Lines';
+    final movie = testMediaItem(
+      id: 'phone_movie',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      title: title,
+      serverId: 'server_1',
+      serverName: 'Server',
+    );
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    PlexApiCache.initialize(db);
+    JellyfinApiCache.initialize(db);
+    final downloadManager = DownloadManagerService(
+      database: db,
+      storageService: DownloadStorageService.instance,
+      clientResolver: (serverId, {clientScopeId}) => null,
+    );
+    downloadManager.recoveryFuture = Future<void>.value();
+    final downloadProvider = DownloadProvider.forTesting(downloadManager: downloadManager, database: db);
+    await downloadProvider.ensureInitialized();
+
+    final client = _FakeMediaServerClient(show: movie, childrenByParent: const {});
+    final multiServerProvider = testMultiServer(clients: [client]).provider;
+    final watchStateOverlay = WatchStateStore();
+
+    addTearDown(() async {
+      watchStateOverlay.dispose();
+      downloadProvider.dispose();
+      downloadManager.dispose();
+      await db.close();
+    });
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
+            ChangeNotifierProvider<WatchStateStore>.value(value: watchStateOverlay),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(child: MediaDetailScreen(metadata: movie)),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final heroTitleBox = find.ancestor(of: find.text(title), matching: find.byType(FittingTitleText));
+    expect(heroTitleBox, findsOneWidget);
+    // The hero is the 390 viewport minus 16px side padding = 358. The title
+    // fills it: the 800 cap is far wider than the hero, so it never binds, and
+    // the title is not narrowed below the hero either. This is the "mobile is
+    // unchanged" half of #1796 — a smaller cap would break it.
+    expect(tester.getSize(heroTitleBox).width, closeTo(390 - 32, 0.5));
+  });
+
+  testWidgets('TV hero gives a logo-less title more than the logo box, within its column', (tester) async {
+    // TV side of #1796. The TV foreground is laid out as a ~57% column (the
+    // right 43% of the screen is reserved for artwork), so at 1080p the column
+    // is ≈1062px while the logo box is 790 * scale. The fallback title must be
+    // allowed past the logo box, but can never leave the column.
+    await SettingsService.getInstance();
+    tester.view.physicalSize = const Size(1920, 1080);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const title = 'The Surprisingly Long Movie Title That Needs Two Whole Lines';
+    final movie = testMediaItem(
+      id: 'tv_wide_movie',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      title: title,
+    );
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          theme: monoTheme(dark: true),
+          home: withProfileNavigationScope(child: MediaDetailScreen(metadata: movie)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    final heroTitleBox = find.ancestor(of: find.text(title), matching: find.byType(FittingTitleText));
+    expect(heroTitleBox, findsOneWidget);
+    final titleWidth = tester.getSize(heroTitleBox).width;
+    final scale = TvLayoutConstants.scaleForSize(const Size(1920, 1080));
+    final logoBoxWidth = 790 * scale;
+    // spotlightLeft = (24 * scale).clamp(18, 40); the column is what's left
+    // of the screen after the 0.43 right reservation.
+    final columnWidth = 1920 * 0.57 - (24 * scale).clamp(18.0, 40.0);
+    expect(titleWidth, greaterThan(logoBoxWidth));
+    expect(titleWidth, lessThanOrEqualTo(columnWidth + 0.5));
   });
 
   testWidgets('TV detail exposes hero information as one semantic node', (tester) async {

--- a/test/screens/media_detail_screen_test.dart
+++ b/test/screens/media_detail_screen_test.dart
@@ -98,6 +98,76 @@ void main() {
     expect(titleText.style!.fontSize!, lessThan(baseFontSize));
   });
 
+  testWidgets('wide non-TV hero lets a logo-less title use the full width', (tester) async {
+    // Non-TV (iPad/desktop) hero: without a clear logo the fallback title used
+    // to be boxed at the logo's 400px width cap, so a long title clipped early
+    // on a wide display even with room to spare (#1796). It should now lay out
+    // wider than that cap.
+    TvDetectionService.debugSetAppleTVOverride(false);
+    await SettingsService.getInstance();
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    const title = 'The Surprisingly Long Movie Title That Needs Two Whole Lines';
+    final movie = testMediaItem(
+      id: 'wide_movie',
+      backend: MediaBackend.jellyfin,
+      kind: MediaKind.movie,
+      title: title,
+      serverId: 'server_1',
+      serverName: 'Server',
+    );
+
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    PlexApiCache.initialize(db);
+    JellyfinApiCache.initialize(db);
+    final downloadManager = DownloadManagerService(
+      database: db,
+      storageService: DownloadStorageService.instance,
+      clientResolver: (serverId, {clientScopeId}) => null,
+    );
+    downloadManager.recoveryFuture = Future<void>.value();
+    final downloadProvider = DownloadProvider.forTesting(downloadManager: downloadManager, database: db);
+    await downloadProvider.ensureInitialized();
+
+    final client = _FakeMediaServerClient(show: movie, childrenByParent: const {});
+    final multiServerProvider = testMultiServer(clients: [client]).provider;
+    final watchStateOverlay = WatchStateStore();
+
+    addTearDown(() async {
+      watchStateOverlay.dispose();
+      downloadProvider.dispose();
+      downloadManager.dispose();
+      await db.close();
+    });
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MultiProvider(
+          providers: [
+            ChangeNotifierProvider<MultiServerProvider>.value(value: multiServerProvider),
+            ChangeNotifierProvider<DownloadProvider>.value(value: downloadProvider),
+            ChangeNotifierProvider<WatchStateStore>.value(value: watchStateOverlay),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: withProfileNavigationScope(child: MediaDetailScreen(metadata: movie)),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text(title), findsWidgets);
+    // Old logo width cap was 400 (desiredLogoWidth in _buildHeroHeaderContent).
+    expect(tester.getSize(find.text(title).first).width, greaterThan(400));
+  });
+
   testWidgets('TV detail exposes hero information as one semantic node', (tester) async {
     final semantics = tester.ensureSemantics();
     await SettingsService.getInstance();


### PR DESCRIPTION
## What

When a movie or show has no clear-logo image, the detail hero falls back to rendering its title as text. That fallback was boxed at the *logo's* width cap — 400px on the phone/desktop hero, 790px on the TV hero — so `FittingTitleText` shrank the font and ellipsized a long title inside the logo box even on a wide display that had plenty of room. This is #1796 (reported on iPad Pro 12.9" / MacBook Air, Plex). At 40px title font, the 400px box clips titles as short as ~33 characters.

## Fix

One rule, applied to both heroes: **a logo-less title may use up to twice the logo box width, never more than the hero.** `_buildDetailLogoOrTitle` takes an optional `titleWidth`; the text fallback uses it, while a clear-logo *image* keeps the narrower `width` cap. `titleWidth` defaults to `width`, so logo-present paths are unchanged.

Per layout:

| Layout | Effective title width |
|---|---|
| Phone | the hero (narrower than the cap) — unchanged |
| Tablet / desktop | 800px (2 × the 400 logo box) — wider than before, but a title column, not edge-to-edge |
| TV | the foreground column (the right 43% of the screen is already reserved for artwork, which bounds it below the scaled 2× cap) |

With the 800 cap, titles up to ~70 characters fit on two lines at full size (measured with the bundled font at 40px — "Dr. Strangelove or: How I Learned to Stop Worrying and Love the Bomb" fits). Longer outliers still ellipsize at the cap, because `FittingTitleText` only shrinks the font on height pressure, not width; if you'd like those to shrink-to-fit instead, I can follow up with an opt-in width-aware shrink.

## Testing

- `wide non-TV hero gives a logo-less title a capped width wider than the logo box`: 1400×900 non-TV viewport, asserts the title box is exactly 800 — wider than the old 400, not the 1368px hero. Fails with the cap removed (box becomes 1368).
- `phone-width hero keeps a logo-less title inside the hero`: 390×844, asserts the box is exactly the hero width (358) — the "mobile unchanged" claim; fails if the cap were ever narrower than the hero.
- `TV hero gives a logo-less title more than the logo box, within its column`: 1920×1080 TV, asserts the box exceeds the 790px logo box and stays inside the foreground column. Fails on the pre-fix behavior (box = 790).
- Existing `TV detail scales fallback title to fit logo bounds` still passes.
- `flutter analyze`, `dart format --line-length 120`, `dart_code_linter` unused-code/unused-files, full `flutter test` (5825): clean.

Screenshots from the Windows desktop build are in the comments.
