### PR TITLE
fix(ios): pin the AVFoundation audio output so multichannel survives

### DIFF
--- a/ios/Runner/MpvPlayer/MpvPlayerCore.swift
+++ b/ios/Runner/MpvPlayer/MpvPlayerCore.swift
@@ -2,6 +2,7 @@ import AVFoundation
 #if os(tvOS)
   import AVKit
 #endif
+import Libmpv
 import QuartzCore
 import UIKit
 
@@ -68,6 +69,15 @@ class MpvPlayerCore: MpvPlayerCoreBase {
     print("[MpvPlayerCore] Initialized successfully with MPV")
     return true
   }
+
+  #if os(iOS)
+    override func configurePlatformMpvOptions(mpv: OpaquePointer) {
+      // Must not be left to mpv's probe order: audiounit wins it and folds
+      // multichannel to stereo before the output. iOS only, because tvOS
+      // routes already report more than two channels.
+      checkError(mpv_set_option_string(mpv, "ao", "avfoundation,audiounit"))
+    }
+  #endif
 
   var sampleBufferDisplayLayer: MpvVideoLayer? { videoLayer }
 


### PR DESCRIPTION
My last PR on this was overloaded and I didn't review it closely enough
before opening it. This is the same fix on its own.

Multichannel sources play in stereo on iPhone and iPad. mpv probes
`audiounit` ahead of `avfoundation`, and `ao_audiounit` clamps `ao->channels`
to stereo whenever the session reports two output channels — which it always
does, because nothing on that path calls
`AVAudioSession.setSupportsMultichannelContent:` (default `NO`).

Pinned `ao` to `avfoundation,audiounit`, following the macOS pattern. iOS
only: tvOS compiles the same file, but its HDMI routes already report more
than two channels, so `audiounit` never clamps there.

Reverting the line for a before reading, on a simulator: `current-ao`
`audiounit` → `avfoundation`, `audio-out-params/hr-channels` `stereo` →
`5.1`, `audio-params/hr-channels` `5.1` in both. The real per-route channel
grant needs a device.
