### PR TITLE
fix(player): remember subtitle and audio sync offsets per media item

### DIFF
--- a/lib/screens/video_player/parts/episode_navigation.dart
+++ b/lib/screens/video_player/parts/episode_navigation.dart
@@ -818,6 +818,17 @@ extension _VideoPlayerEpisodeNavigationMethods on VideoPlayerScreenState {
               // loop guard.
               _spuriousEofRecoveryAttempts = 0;
               _spuriousEofRecoveryBaselineMs = null;
+              settingsService.activeMediaKey = metadata.globalKey;
+              final audioOffset = settingsService.getAudioSyncOffset(metadata.globalKey);
+              final subOffset = settingsService.getSubtitleSyncOffset(metadata.globalKey);
+              await settingsService.write(SettingsService.audioSyncOffset, audioOffset);
+              await settingsService.write(SettingsService.subtitleSyncOffset, subOffset);
+              try {
+                await currentPlayer.setProperty('audio-delay', (audioOffset / 1000.0).toString());
+                await currentPlayer.setProperty('sub-delay', (subOffset / 1000.0).toString());
+              } catch (e) {
+                appLogger.w('Failed to apply sync offsets on item change', error: e);
+              }
             }
 
             // Versions/mediaInfo come from the committed session; rebuild so

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -1581,13 +1581,16 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
         }
       }
 
-      final audioSyncOffset = settingsService.read(SettingsService.audioSyncOffset);
+      settingsService.activeMediaKey = _currentMetadata.globalKey;
+      final audioSyncOffset = settingsService.getAudioSyncOffset(_currentMetadata.globalKey);
+      await settingsService.write(SettingsService.audioSyncOffset, audioSyncOffset);
       if (audioSyncOffset != 0) {
         final offsetSeconds = audioSyncOffset / 1000.0;
         await currentPlayer.setProperty('audio-delay', offsetSeconds.toString());
       }
 
-      final subtitleSyncOffset = settingsService.read(SettingsService.subtitleSyncOffset);
+      final subtitleSyncOffset = settingsService.getSubtitleSyncOffset(_currentMetadata.globalKey);
+      await settingsService.write(SettingsService.subtitleSyncOffset, subtitleSyncOffset);
       if (subtitleSyncOffset != 0) {
         final offsetSeconds = subtitleSyncOffset / 1000.0;
         await currentPlayer.setProperty('sub-delay', offsetSeconds.toString());
@@ -1893,6 +1896,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
   @override
   void dispose() {
     unawaited(AndroidExitDiagnostics.markUiState(AndroidUiState.mainScreen));
+    SettingsService.instance.activeMediaKey = null;
     _playerInitializationGeneration++;
     _frameRate.dispose();
     WidgetsBinding.instance.removeObserver(this);

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -396,6 +396,75 @@ class SettingsService extends BaseSharedPreferencesService {
   static const sleepTimerDuration = IntPref('sleep_timer_duration', defaultValue: 30);
   static const audioSyncOffset = IntPref('audio_sync_offset');
   static const subtitleSyncOffset = IntPref('subtitle_sync_offset');
+
+  /// Per-media sync offsets (media globalKey → offset in ms).
+  static final subtitleSyncOffsets = JsonPref<Map<String, int>>(
+    'subtitle_sync_offsets_by_media',
+    defaultValue: const {},
+    encode: json.encode,
+    decode: (raw) => (raw as Map<String, dynamic>).map((k, v) => MapEntry(k, v as int)),
+  );
+  static final audioSyncOffsets = JsonPref<Map<String, int>>(
+    'audio_sync_offsets_by_media',
+    defaultValue: const {},
+    encode: json.encode,
+    decode: (raw) => (raw as Map<String, dynamic>).map((k, v) => MapEntry(k, v as int)),
+  );
+
+  /// Active media key for the currently playing item. When set, writes to
+  /// [subtitleSyncOffset] or [audioSyncOffset] automatically persist under
+  /// this key in [subtitleSyncOffsets] or [audioSyncOffsets].
+  String? activeMediaKey;
+
+  @override
+  Future<void> write<T>(Pref<T> pref, T value) async {
+    await super.write(pref, value);
+    final currentKey = activeMediaKey;
+    if (currentKey != null) {
+      if (identical(pref, subtitleSyncOffset) && value is int) {
+        final map = Map<String, int>.from(read(subtitleSyncOffsets));
+        if (value == 0) {
+          map.remove(currentKey);
+        } else {
+          map[currentKey] = value;
+        }
+        await super.write(subtitleSyncOffsets, map);
+      } else if (identical(pref, audioSyncOffset) && value is int) {
+        final map = Map<String, int>.from(read(audioSyncOffsets));
+        if (value == 0) {
+          map.remove(currentKey);
+        } else {
+          map[currentKey] = value;
+        }
+        await super.write(audioSyncOffsets, map);
+      }
+    }
+  }
+
+  int getSubtitleSyncOffset(String globalKey) => read(subtitleSyncOffsets)[globalKey] ?? 0;
+  int getAudioSyncOffset(String globalKey) => read(audioSyncOffsets)[globalKey] ?? 0;
+
+  Future<void> setSubtitleSyncOffset(String globalKey, int offset) async {
+    final map = Map<String, int>.from(read(subtitleSyncOffsets));
+    if (offset == 0) {
+      map.remove(globalKey);
+    } else {
+      map[globalKey] = offset;
+    }
+    await write(subtitleSyncOffsets, map);
+    await write(subtitleSyncOffset, offset);
+  }
+
+  Future<void> setAudioSyncOffset(String globalKey, int offset) async {
+    final map = Map<String, int>.from(read(audioSyncOffsets));
+    if (offset == 0) {
+      map.remove(globalKey);
+    } else {
+      map[globalKey] = offset;
+    }
+    await write(audioSyncOffsets, map);
+    await write(audioSyncOffset, offset);
+  }
   static const subtitleSearchLanguage = NullableStringPref('subtitle_search_language');
   static const volume = DoublePref('volume', defaultValue: 100.0);
   static const rotationLocked = BoolPref('rotation_locked', defaultValue: true);
@@ -953,6 +1022,8 @@ class SettingsService extends BaseSharedPreferencesService {
     sleepTimerDuration,
     audioSyncOffset,
     subtitleSyncOffset,
+    subtitleSyncOffsets,
+    audioSyncOffsets,
     subtitleSearchLanguage,
     volume,
     subtitleFontSize,

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -338,6 +338,41 @@ void main() {
       expect(settings.isLibraryAllowedForTracker(TrackerService.trakt, 'server:allowed'), isTrue);
     });
   });
+
+  group('SettingsService per-media sync offsets', () {
+    test('defaults to 0 for unrecorded media', () async {
+      final settings = await SettingsService.getInstance();
+      expect(settings.getSubtitleSyncOffset('movie_1'), 0);
+      expect(settings.getAudioSyncOffset('movie_1'), 0);
+    });
+
+    test('saves and retrieves per-media offsets independently', () async {
+      final settings = await SettingsService.getInstance();
+
+      await settings.setSubtitleSyncOffset('ep_1', 500);
+      await settings.setAudioSyncOffset('ep_1', -200);
+
+      await settings.setSubtitleSyncOffset('ep_2', -300);
+
+      expect(settings.getSubtitleSyncOffset('ep_1'), 500);
+      expect(settings.getAudioSyncOffset('ep_1'), -200);
+      expect(settings.getSubtitleSyncOffset('ep_2'), -300);
+      expect(settings.getAudioSyncOffset('ep_2'), 0);
+      expect(settings.getSubtitleSyncOffset('ep_3'), 0);
+    });
+
+    test('removes entry from map when offset is set to 0', () async {
+      final settings = await SettingsService.getInstance();
+
+      await settings.setSubtitleSyncOffset('ep_1', 500);
+      expect(settings.getSubtitleSyncOffset('ep_1'), 500);
+
+      await settings.setSubtitleSyncOffset('ep_1', 0);
+      expect(settings.getSubtitleSyncOffset('ep_1'), 0);
+      expect(settings.read(SettingsService.subtitleSyncOffsets), isEmpty);
+    });
+  });
+
   group('BaseSharedPreferencesService initialization generations', () {
     test('a reset-raced initialization resolves to the replacement backend', () async {
       resetSharedPreferencesForTest(initialAsync: const {'generation_marker': 'old'});


### PR DESCRIPTION
Previously, subtitle and audio sync offsets were saved in global settings, causing offsets from one video to leak into subsequent episodes or movies (#1616).

### Changes
- Store sync offsets in a per-media map in `SettingsService` keyed by the active `MediaItem.globalKey`.
- Default to `0ms` for unadjusted media and persist custom offsets for the same video across playback sessions.
- Automatically evict `0ms` offsets from storage to keep saved preferences minimal.
- Read and apply active media offsets during player initialization and in-player episode navigation (`_reloadMediaInPlace`).

### Testing
- Added unit tests in `test/services/settings_service_test.dart` for default `0ms`, per-media isolation, and eviction on `0ms`.
- Verified manually on Android (Pixel 10 Pro) and Windows desktop.

Closes #1616