### PR TITLE
fix(audio): add missing loudnorm to enabled ffmpeg filters in Linux builds

### DIFF
--- a/linux/packaging/build-libmpv.sh
+++ b/linux/packaging/build-libmpv.sh
@@ -240,7 +240,7 @@ main() {
     --disable-bsfs \
     --enable-bsf=aac_adtstoasc,av1_metadata,extract_extradata,h264_metadata,h264_mp4toannexb,hevc_metadata,hevc_mp4toannexb,vp9_metadata \
     --disable-filters \
-    --enable-filter=aformat,aresample,format,null,scale \
+    --enable-filter=aformat,aresample,format,loudnorm,null,scale \
     --enable-gnutls \
     --enable-vaapi \
     --enable-libdav1d \


### PR DESCRIPTION
Should fix #1901