### PR TITLE
Downrank relay in the connection race and stop persisting it as preferred

### DIFF
--- a/lib/services/multi_server_manager.dart
+++ b/lib/services/multi_server_manager.dart
@@ -335,7 +335,7 @@ class MultiServerManager {
 
     // Get storage and load cached endpoint for this server
     final storage = await StorageService.getInstance();
-    final cachedEndpoint = storage.getServerEndpoint(ServerId(serverId));
+    final cachedEndpoint = _nonRelayCachedEndpoint(server, storage.getServerEndpoint(ServerId(serverId)));
 
     // The connection race already hits `/` on the winning endpoint — capture
     // `transcoderVideo` from that response so PlexClient.create can skip the
@@ -375,6 +375,13 @@ class MultiServerManager {
       serverName: server.name,
       prioritizedEndpoints: prioritizedEndpoints,
       onEndpointChanged: (newUrl) async {
+        // Classify against the live server object, not the connect-time
+        // capture: a profile refresh replaces _plexServers[serverId] with a
+        // refetched server (fresh, rotated relay URIs) while this client and
+        // closure live on, and a rotated relay URL would misclassify as
+        // remote against the stale connection list.
+        final liveServer = _plexServers[ServerId(serverId)] ?? server;
+        if (!_shouldPersistEndpoint(liveServer, newUrl)) return;
         await storage.saveServerEndpoint(ServerId(serverId), newUrl);
         appLogger.i('Updated endpoint for ${server.name} after failover: $newUrl');
       },
@@ -382,8 +389,13 @@ class MultiServerManager {
       seedTranscoderVideoSupport: observedTranscoderVideo,
     );
 
-    // Save the initial endpoint
-    await storage.saveServerEndpoint(ServerId(serverId), baseUrl);
+    // Save the initial endpoint. Relay endpoints are deliberately never
+    // persisted: a cached relay URL would win the next launch's head-start
+    // probe and pin every session to the relay's 2 Mbps cap even when a
+    // direct endpoint is reachable again.
+    if (_shouldPersistEndpoint(server, baseUrl)) {
+      await storage.saveServerEndpoint(ServerId(serverId), baseUrl);
+    }
 
     appLogger.i(
       'Connected ${server.name}',
@@ -401,6 +413,23 @@ class MultiServerManager {
     return client;
   }
 
+  /// Whether [url] may be persisted as the server's preferred endpoint.
+  /// Relay URLs are excluded — see the comment at the initial-save site.
+  bool _shouldPersistEndpoint(PlexServer server, String url) {
+    if (server.networkClassForUrl(url) != PlexNetworkClass.relay) return true;
+    appLogger.d('Not persisting relay endpoint as preferred for ${server.name}');
+    return false;
+  }
+
+  /// Drops a cached preferred endpoint that classifies as relay so it never
+  /// gets the head-start probe. Also migrates caches written before relay
+  /// endpoints were excluded from persistence.
+  String? _nonRelayCachedEndpoint(PlexServer server, String? cached) {
+    if (cached == null || server.networkClassForUrl(cached) != PlexNetworkClass.relay) return cached;
+    appLogger.i('Ignoring cached relay endpoint for ${server.name}, rediscovering connections');
+    return null;
+  }
+
   /// Persists a new endpoint, rebuilds the failover list, and switches the
   /// client only while it is still the registered client for this server.
   Future<bool> _promoteEndpoint({
@@ -416,8 +445,12 @@ class MultiServerManager {
     }
 
     if (!isCurrent()) return false;
-    await storage.saveServerEndpoint(serverId, newUrl);
-    if (!isCurrent()) return false;
+    // Still switch the live client to a relay endpoint when it is the only
+    // working one, but never persist it as the preferred endpoint.
+    if (_shouldPersistEndpoint(server, newUrl)) {
+      await storage.saveServerEndpoint(serverId, newUrl);
+      if (!isCurrent()) return false;
+    }
     final newEndpoints = server.prioritizedEndpointUrls(preferredFirst: newUrl);
     await client.updateEndpointPreferences(newEndpoints, switchToFirst: true);
     return isCurrent();
@@ -1042,7 +1075,7 @@ class MultiServerManager {
       // Non-Plex client registered for this serverId — no Plex-style optimizer to run.
       return;
     }
-    final cachedEndpoint = storage.getServerEndpoint(serverId);
+    final cachedEndpoint = _nonRelayCachedEndpoint(server, storage.getServerEndpoint(serverId));
 
     try {
       appLogger.d('Starting connection optimization for ${server.name}', error: {'reason': reason});
@@ -1065,6 +1098,7 @@ class MultiServerManager {
           appLogger.i('Switched ${server.name} to better endpoint: $newUrl', error: {'type': connection.displayType});
         } else {
           if (_plexServers[serverId] != server) return;
+          if (!_shouldPersistEndpoint(server, newUrl)) continue;
           await storage.saveServerEndpoint(serverId, newUrl);
           if (_plexServers[serverId] != server) return;
           appLogger.i('Updated optimal endpoint for ${server.name}: $newUrl', error: {'type': connection.displayType});

--- a/lib/services/plex_auth_service.dart
+++ b/lib/services/plex_auth_service.dart
@@ -504,6 +504,12 @@ class PlexServer {
       onFirstSuccess: (_, result) {
         if (result.transcoderVideo != null) onTranscoderCapability?.call(result.transcoderVideo!);
       },
+      // Relay endpoints answer fast (plex.tv edge) but cap the session at
+      // 2 Mbps, and a bare file request over relay is rejected server-side
+      // with an opaque HTTP 500 (#1343/#665). Let direct endpoints claim the
+      // race first; relay only wins when nothing else responds in time.
+      probeDelayOf: (candidate) =>
+          candidate.connection.relay ? MediaServerTimeouts.relayProbeHandicap : Duration.zero,
     )) {
       if (selection.phase == EndpointRacePhase.first) {
         final firstCandidate = selection.candidate;

--- a/lib/utils/endpoint_race.dart
+++ b/lib/utils/endpoint_race.dart
@@ -48,6 +48,7 @@ Stream<EndpointRaceSelection<C, R>> raceEndpointCandidates<C, R>({
   required bool Function(R result) isSuccess,
   required C? Function(Map<C, R> successfulResults) selectBestCandidate,
   void Function(C candidate, R result)? onFirstSuccess,
+  Duration Function(C candidate)? probeDelayOf,
   Duration preferredTimeout = MediaServerTimeouts.preferredEndpointProbe,
   Duration preferredHeadStart = MediaServerTimeouts.preferredEndpointHeadStart,
   Duration raceTimeout = MediaServerTimeouts.connectionRace,
@@ -113,6 +114,7 @@ Stream<EndpointRaceSelection<C, R>> raceEndpointCandidates<C, R>({
           mergedCached != null && identical(candidate, mergedCached) ? pendingCachedProbe! : probe(candidate, timeout),
       isSuccess: isSuccess,
       onFirstSuccess: onFirstSuccess,
+      probeDelayOf: probeDelayOf,
       timeout: raceTimeout,
     );
     if (first == null) {
@@ -197,6 +199,7 @@ Future<({C candidate, R result})?> _raceFirstSuccess<C, R>({
   String Function(C candidate)? displayTypeOf,
   Map<String, Object?> Function(C candidate, R result)? failureLogFields,
   void Function(C candidate, R result)? onFirstSuccess,
+  Duration Function(C candidate)? probeDelayOf,
 }) async {
   final completer = Completer<({C candidate, R result})?>();
   var completedTests = 0;
@@ -206,10 +209,33 @@ Future<({C candidate, R result})?> _raceFirstSuccess<C, R>({
     error: {'candidateCount': candidates.length},
   );
 
+  // Handicapped candidates (e.g. relay endpoints) start their probe late so
+  // preferred endpoint families get first claim on the race. If the race is
+  // already decided when the handicap elapses, the probe is skipped entirely.
+  // The probe result is wrapped in a record so a skip (null) stays
+  // distinguishable from a probe legitimately resolving to null should R ever
+  // be instantiated as a nullable type.
+  Future<({R result})?> delayedProbe(C candidate) async {
+    final delay = probeDelayOf?.call(candidate) ?? Duration.zero;
+    if (delay > Duration.zero) {
+      await Future<void>.delayed(delay);
+      if (completer.isCompleted) return null;
+    }
+    return (result: await probe(candidate, timeout));
+  }
+
   for (final candidate in candidates) {
     unawaited(
-      probe(candidate, timeout)
-          .then((result) {
+      delayedProbe(candidate)
+          .then((wrapped) {
+            if (wrapped == null) {
+              // Skipped probe: the race was already decided during the
+              // handicap, so this test can never be the one that completes
+              // the race — only the counter needs updating.
+              completedTests++;
+              return;
+            }
+            final result = wrapped.result;
             completedTests++;
 
             if (!isSuccess(result)) {

--- a/lib/utils/media_server_timeouts.dart
+++ b/lib/utils/media_server_timeouts.dart
@@ -41,6 +41,14 @@ class MediaServerTimeouts {
   /// parallel (used in [PlexServer.findBestWorkingConnection]).
   static const connectionRace = Duration(seconds: 2);
 
+  /// Head start granted to non-relay candidates before relay endpoints are
+  /// probed in the phase-1 race. Plex's relay edge often answers faster than a
+  /// direct/reverse-proxied endpoint's TLS handshake, but winning the race puts
+  /// the whole session behind the relay's 2 Mbps cap — any direct endpoint that
+  /// answers inside this window should beat it. Relay remains a full fallback:
+  /// if nothing else responds, its (delayed) probe still wins the race.
+  static const relayProbeHandicap = Duration(milliseconds: 800);
+
   /// Per-server connection watchdog ceiling. The discovery path is no longer
   /// strictly serial (cached probe overlaps the race; the HTTPS upgrade runs
   /// off the critical path), so this is a generous upper bound rather than a

--- a/test/services/multi_server_manager_test.dart
+++ b/test/services/multi_server_manager_test.dart
@@ -769,6 +769,94 @@ void main() {
       expect(storage.getServerEndpoint(ServerId('fresh-server')), promoted.uri);
     });
 
+    test('relay discovery winner connects but is never persisted as preferred', () async {
+      final storage = await _prepareFreshPlexManagerTest();
+      final relayEndpoint = _plexEndpoint('relay-winner', relay: true);
+      final server = _ControlledPlexServer(
+        serverId: 'relay-server',
+        endpoints: [relayEndpoint],
+        discoveryStreams: [() => Stream.value(relayEndpoint)],
+      );
+      final factory = _RecordingPlexFactory();
+      final manager = MultiServerManager(
+        plexClientFactory: factory.create,
+        connectivityChanges: () => const Stream.empty(),
+      );
+      addTearDown(manager.dispose);
+
+      final bound = await manager.refreshTokensForProfile(
+        _plexAccount('relay-account', [server]),
+        profileId: 'profile-a',
+      );
+      await pumpEventQueue();
+
+      expect(bound, {'relay-server'});
+      expect(factory.clients['relay-server']!.config.baseUrl, relayEndpoint.uri);
+      expect(storage.getServerEndpoint(ServerId('relay-server')), isNull);
+    });
+
+    test('promotion to a relay endpoint switches the client but leaves storage unchanged', () async {
+      final storage = await _prepareFreshPlexManagerTest();
+      final direct = _plexEndpoint('direct-first');
+      final relayEndpoint = _plexEndpoint('relay-late', relay: true);
+      final discoveries = StreamController<PlexConnection>(sync: true);
+      final server = _ControlledPlexServer(
+        serverId: 'mixed-server',
+        endpoints: [direct, relayEndpoint],
+        discoveryStreams: [() => discoveries.stream],
+      );
+      final factory = _RecordingPlexFactory();
+      final manager = MultiServerManager(
+        plexClientFactory: factory.create,
+        connectivityChanges: () => const Stream.empty(),
+      );
+      addTearDown(manager.dispose);
+      addTearDown(discoveries.close);
+
+      final refresh = manager.refreshTokensForProfile(_plexAccount('mixed-account', [server]), profileId: 'profile-a');
+      await pumpEventQueue();
+      discoveries.add(direct);
+      expect(await refresh, {'mixed-server'});
+      expect(storage.getServerEndpoint(ServerId('mixed-server')), direct.uri);
+
+      discoveries.add(relayEndpoint);
+      await discoveries.close();
+      await pumpEventQueue(times: 20);
+
+      final client = factory.clients['mixed-server']!;
+      expect(client.config.baseUrl, relayEndpoint.uri);
+      expect(storage.getServerEndpoint(ServerId('mixed-server')), direct.uri);
+    });
+
+    test('a cached relay endpoint is ignored at bind and replaced by the direct winner', () async {
+      final storage = await _prepareFreshPlexManagerTest();
+      final direct = _plexEndpoint('direct-home');
+      final relayEndpoint = _plexEndpoint('relay-cached', relay: true);
+      await storage.saveServerEndpoint(ServerId('cached-server'), relayEndpoint.uri);
+      final server = _ControlledPlexServer(
+        serverId: 'cached-server',
+        endpoints: [direct, relayEndpoint],
+        discoveryStreams: [() => Stream.value(direct)],
+      );
+      final factory = _RecordingPlexFactory();
+      final manager = MultiServerManager(
+        plexClientFactory: factory.create,
+        connectivityChanges: () => const Stream.empty(),
+      );
+      addTearDown(manager.dispose);
+
+      final bound = await manager.refreshTokensForProfile(
+        _plexAccount('cached-account', [server]),
+        profileId: 'profile-a',
+      );
+      await pumpEventQueue();
+
+      expect(bound, {'cached-server'});
+      // The relay URL must never reach discovery as the preferred endpoint.
+      expect(server.capturedPreferredUris, [null]);
+      expect(storage.getServerEndpoint(ServerId('cached-server')), direct.uri);
+    });
+
     test('fresh bind isolates a sibling factory failure and publishes both outcomes', () async {
       await _prepareFreshPlexManagerTest();
       final goodEndpoint = _plexEndpoint('good');
@@ -1638,13 +1726,13 @@ void main() {
   });
 }
 
-PlexConnection _plexEndpoint(String label) => PlexConnection(
+PlexConnection _plexEndpoint(String label, {bool relay = false}) => PlexConnection(
   protocol: 'https',
   address: '$label.invalid',
   port: 32400,
   uri: 'https://$label.invalid:32400',
-  local: true,
-  relay: false,
+  local: !relay,
+  relay: relay,
   ipv6: false,
 );
 
@@ -1657,6 +1745,7 @@ class _ControlledPlexServer extends PlexServer {
 
   final List<Stream<PlexConnection> Function()> discoveryStreams;
   int discoveryCalls = 0;
+  final List<String?> capturedPreferredUris = [];
 
   @override
   Stream<PlexConnection> findBestWorkingConnection({
@@ -1664,6 +1753,7 @@ class _ControlledPlexServer extends PlexServer {
     String? clientIdentifier,
     void Function(bool)? onTranscoderCapability,
   }) {
+    capturedPreferredUris.add(preferredUri);
     onTranscoderCapability?.call(true);
     final index = discoveryCalls++;
     if (discoveryStreams.isEmpty) return const Stream.empty();

--- a/test/utils/endpoint_race_test.dart
+++ b/test/utils/endpoint_race_test.dart
@@ -27,6 +27,7 @@ void main() {
     Future<_Result> Function(String url)? measure,
     String? Function(Map<String, _Result> results)? selectBest,
     Map<String, Object?> Function(String candidate, _Result result)? failureLogFields,
+    Duration Function(String url)? probeDelayOf,
   }) {
     return raceEndpointCandidates<String, _Result>(
       label: 'test',
@@ -34,6 +35,7 @@ void main() {
       urlOf: (c) => c,
       preferredUrl: preferred,
       failureLogFields: failureLogFields,
+      probeDelayOf: probeDelayOf,
       probe: (c, _) => probe(c),
       measure: measure ?? (c) async => (url: c, ok: false),
       isSuccess: (r) => r.ok,
@@ -274,6 +276,61 @@ void main() {
     ).toList();
 
     expect(selections, isEmpty);
+  });
+
+  test('handicapped candidate loses to a slower direct candidate inside the window', () {
+    fakeAsync((async) {
+      const handicap = Duration(milliseconds: 100);
+      final probeCounts = <String, int>{};
+      final selections = <EndpointRaceSelection<String, _Result>>[];
+
+      race(
+        candidates: ['direct', 'relay'],
+        probeDelayOf: (url) => url == 'relay' ? handicap : Duration.zero,
+        probe: (url) {
+          probeCounts[url] = (probeCounts[url] ?? 0) + 1;
+          // Relay would answer instantly; direct takes 50ms — still inside
+          // the handicap window, so direct must win phase 1.
+          final delay = url == 'direct' ? const Duration(milliseconds: 50) : Duration.zero;
+          return Future<_Result>.delayed(delay, () => (url: url, ok: true));
+        },
+      ).listen(selections.add);
+      async.flushMicrotasks();
+
+      // Relay's probe has not started yet.
+      expect(probeCounts, {'direct': 1});
+
+      async.elapse(const Duration(milliseconds: 50));
+      expect(selections.first.phase, EndpointRacePhase.first);
+      expect(selections.first.candidate, 'direct');
+
+      // Once the race is decided, the handicapped probe is skipped entirely.
+      async.elapse(handicap);
+      expect(probeCounts.containsKey('relay'), isFalse);
+    });
+  });
+
+  test('handicapped candidate still wins when nothing else responds', () {
+    fakeAsync((async) {
+      const handicap = Duration(milliseconds: 100);
+      final selections = <EndpointRaceSelection<String, _Result>>[];
+
+      race(
+        candidates: ['direct', 'relay'],
+        probeDelayOf: (url) => url == 'relay' ? handicap : Duration.zero,
+        probe: (url) async => (url: url, ok: url == 'relay'),
+      ).listen(selections.add);
+      async.flushMicrotasks();
+
+      // Direct failed immediately; relay has not been probed yet, so the race
+      // must still be undecided rather than completed empty.
+      expect(selections, isEmpty);
+
+      async.elapse(handicap);
+      async.flushMicrotasks();
+      expect(selections.first.phase, EndpointRacePhase.first);
+      expect(selections.first.candidate, 'relay');
+    });
   });
 
   test('phase 2 still promotes the selector-best endpoint', () {


### PR DESCRIPTION
A relay connection can win the phase-1 race (plex.tv edge answers fast) and then gets saved as the preferred endpoint. The cached endpoint gets the head-start probe on the next launch, so one relay win pins every future session to relay's 2 Mbps cap even after direct connectivity is back. On Original quality that surfaces as the HTTP 500s from #1343 / #665. Hit this live: two remote users stuck on relay for an evening while the server's direct URL was reachable the whole time. Restarting the app didn't clear it because the relay URL was cached.

Changes:

- Non-relay candidates get an 800ms head start in the phase-1 race (new optional probeDelayOf hook on raceEndpointCandidates). If the race is decided before the handicap elapses, the relay probe is skipped entirely. Relay still wins when nothing else answers, just 800ms later.
- Relay URLs are never persisted as the preferred endpoint. Classification runs against the live registered server, not the connect-time capture, so relay URIs rotated by a profile refresh can't slip through classified as remote.
- A relay URL cached by an older version is ignored at bind, so existing installs self-heal on upgrade.

Relay stays a full fallback for people who genuinely need it (double NAT etc.); it just never becomes sticky and never beats a working direct endpoint. Doesn't touch the Original-quality playback path, so this sidesteps the transcode-API debate from #1495 entirely.

Tests cover the handicap (loses to a slower direct endpoint inside the window, still wins when alone) and all three persistence behaviors. Full suite green on 3.47.0 stable. Jellyfin discovery is untouched; it doesn't pass the hook.