### PR TITLE
fix: hide window on close

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1280,7 +1280,7 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
     await TrackerCoordinator.instance.stopPlayback().timeout(const Duration(seconds: 3), onTimeout: () {});
     TrackerCoordinator.instance.cancelInFlight();
 
-    await _serverManager.disconnectAllGracefully();
+    await _serverManager.disconnectAllGracefully(emitStatus: false);
     await Future.wait([
       httpClient.closeGracefully(drainTimeout: const Duration(seconds: 5)),
       closeArtworkHttpClientGracefully(),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -943,6 +943,7 @@ class _MainScreenState extends State<MainScreen>
   /// trackers owning their own watched semantics depend on.
   Future<void> _exitOnWindowClose() async {
     try {
+      await windowManager.hide();
       await AppExitService.requestGracefulExit().timeout(const Duration(seconds: 5));
     } catch (e, st) {
       appLogger.w('Graceful window close failed; exiting immediately', error: e, stackTrace: st);

--- a/lib/services/multi_server_manager.dart
+++ b/lib/services/multi_server_manager.dart
@@ -1294,16 +1294,23 @@ class MultiServerManager {
     unawaited(disconnectAllGracefully(drainTimeout: const Duration(seconds: 2)));
   }
 
-  Future<void> disconnectAllGracefully({Duration drainTimeout = const Duration(seconds: 5)}) async {
+  /// Disconnects every server and waits for their connections to drain.
+  ///
+  /// Terminal app shutdown can set [emitStatus] to false because no UI needs
+  /// the final disconnected snapshot.
+  Future<void> disconnectAllGracefully({
+    Duration drainTimeout = const Duration(seconds: 5),
+    bool emitStatus = true,
+  }) async {
     appLogger.i('Gracefully disconnecting all servers');
-    final clients = _detachAllClients();
+    final clients = _detachAllClients(emitStatus: emitStatus);
     await Future.wait(
       clients.map((client) => _closeClientGracefully(client, drainTimeout: drainTimeout)),
       eagerError: false,
     );
   }
 
-  Set<MediaServerClient> _detachAllClients() {
+  Set<MediaServerClient> _detachAllClients({bool emitStatus = true}) {
     ++_profileRefreshEpoch;
     _profileRefreshGenerations.clear();
     _stopNetworkMonitoring();
@@ -1324,7 +1331,7 @@ class MultiServerManager {
     _clientIdByServer.clear();
     _plexScopeByServer.clear();
     _activeOptimizations.clear();
-    if (!_statusController.isClosed) {
+    if (emitStatus && !_statusController.isClosed) {
       _statusController.add({});
     }
     return clients;

--- a/test/services/multi_server_manager_test.dart
+++ b/test/services/multi_server_manager_test.dart
@@ -1602,6 +1602,26 @@ void main() {
       expect(emitted.last, isEmpty);
     });
 
+    test('terminal shutdown clears all status without emitting a snapshot', () async {
+      final m = MultiServerManager();
+      addTearDown(m.dispose);
+
+      m.updateServerStatus(ServerId('a'), true);
+      m.updateServerStatus(ServerId('b'), false);
+
+      final emitted = <Map<String, bool>>[];
+      final sub = m.statusStream.listen(emitted.add);
+      addTearDown(sub.cancel);
+
+      await m.disconnectAllGracefully(emitStatus: false);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(m.serverIds, isEmpty);
+      expect(m.onlineServerIds, isEmpty);
+      expect(m.offlineServerIds, isEmpty);
+      expect(emitted, isEmpty);
+    });
+
     test('clears inactive Jellyfin scoped clients', () {
       final m = MultiServerManager();
       addTearDown(m.dispose);


### PR DESCRIPTION
After [this change](https://github.com/edde746/plezy/commit/5a25c1f9cc3cc30e18f220370f45a6497210719b) where a graceful exit is requested instead of immediately exiting, Plezy has a strange looking behavior on exit where screens disappear as they shut down and it's visible to the user. For example I click X and I see this:

<img width="1763" height="1098" alt="Screenshot_20260818_052250" src="https://github.com/user-attachments/assets/42815d76-caf2-4c3f-be8d-c0df60f2d2b3" />

then the window itself does not close until I either press X again, or I wait a while for the window to finish closing.

To the user this looks like the app broke instead of closing like they expected. This hides the window before requesting the shutdown event so that the user experience matches their expectation of the Window just going away.

I also noticed on shutdown the app was throwing `AppLifecycleListener was used after being disposed.` so just don't emit the UI status transition since the app is closing anyway and already hidden from the user.