### PR TITLE
feat: add vscode config options

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	"recommendations": [
+		"Dart-Code.dart-code",
+		"Dart-Code.flutter",
+		"EditorConfig.EditorConfig"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Plezy (debug)",
+			"type": "dart",
+			"request": "launch",
+			"program": "lib/main.dart",
+			"flutterMode": "debug"
+		},
+		{
+			"name": "Plezy (profile)",
+			"type": "dart",
+			"request": "launch",
+			"program": "lib/main.dart",
+			"flutterMode": "profile"
+		},
+		{
+			"name": "Plezy (release)",
+			"type": "dart",
+			"request": "launch",
+			"program": "lib/main.dart",
+			"flutterMode": "release"
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"editor.formatOnSave": true,
+	"[dart]": {
+		"editor.defaultFormatter": "Dart-Code.dart-code"
+	}
+}

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,13 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:


### PR DESCRIPTION
Adds extension recommendations, default settings and launch configs for VSCode. The Flutter SDK seems to also add some extra directories to the analysis_options.yaml exclude config. Adding those here since Flutter makes this change on launch but let me know if you disagree with this.