### PR TITLE
Emby: Add Emby as option in issue and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,11 +77,12 @@ body:
     id: media-server
     attributes:
       label: Media Server
-      description: Are you using Jellyfin or Plex?
+      description: Are you using Jellyfin, Plex or Emby?
       multiple: true
       options:
         - Jellyfin
         - Plex
+        - Emby
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -71,6 +71,7 @@ body:
       options:
         - Jellyfin
         - Plex
+        - Emby
     validations:
       required: true
 


### PR DESCRIPTION
Since Emby is pretty new as a backend option, it didn't make it into the issue templates yet. This fixes this.