### PR TITLE
Dismiss the skip prompt on Back instead of exiting the player

### DIFF
--- a/lib/screens/video_player/parts/build.dart
+++ b/lib/screens/video_player/parts/build.dart
@@ -321,6 +321,7 @@ extension _VideoPlayerBuildMethods on VideoPlayerScreenState {
                         canNavigateMediaItems: authority.canNavigateMediaItems,
                         hasFirstFrame: _firstFrame.uiReady,
                         playNextFocusNode: _episode.showPlayNextDialog ? _playNextConfirmFocusNode : null,
+                        playbackPromptOpen: _showStillWatchingPrompt,
                         chromeController: _chromeController,
                         shaderService: _shaderService,
                         // ignore: no-empty-block - state update triggers rebuild to reflect shader change

--- a/lib/widgets/video_controls/parts/key_events.dart
+++ b/lib/widgets/video_controls/parts/key_events.dart
@@ -90,7 +90,11 @@ extension _PlexVideoControlsKeyEventMethods on _PlexVideoControlsState {
     unawaited(_playOrPause());
   }
 
-  KeyEventResult _handleLocalPlayerNavigationKeyEvent(KeyEvent event, PlayerNavigationKey navigationKey) {
+  KeyEventResult _handleLocalPlayerNavigationKeyEvent(
+    KeyEvent event,
+    PlayerNavigationKey navigationKey,
+    bool isMobile,
+  ) {
     if (navigationKey == PlayerNavigationKey.none || navigationKey == PlayerNavigationKey.home) {
       return KeyEventResult.ignored;
     }
@@ -109,6 +113,38 @@ extension _PlexVideoControlsKeyEventMethods on _PlexVideoControlsState {
         widget.chromeController.setContentStripVisible(false);
         _restartHideTimerForCurrentPlaybackState();
       });
+    }
+
+    // A skip prompt is a local layer like the sheet and the content strip
+    // above it: Select takes the skip, Back declines it. Without this stage the
+    // only key that reads as "no thanks" on a remote is also the one that walks
+    // the screen's exit chain, so declining an intro costs the viewer the rest
+    // of the episode.
+    //
+    // The claim is latched for the whole press rather than re-derived per
+    // event. handleBackKeyAction consumes the key-down and acts on the key-up,
+    // and the button's own 7s dismiss timer — armed for every prompt while
+    // auto-skip is off, which is the default — can fire in between. Asking the
+    // full question again on the key-up would hand that press back to the
+    // screen and exit the player, which is the bug this stage exists to
+    // prevent.
+    //
+    // The button vanishing is the only race the latch covers. The chrome
+    // coming up, or a prompt opening, genuinely moves the key back to the
+    // screen's stages, so those release the claim mid-press.
+    final skipMarkerOwnsPress = event is KeyDownEvent
+        ? shouldDismissSkipMarkerOnBack(
+            navigationKey: navigationKey,
+            controlsVisible: _showControls,
+            skipMarkerButtonVisible: _isSkipMarkerButtonVisible,
+            canControl: widget.canControl,
+            isMobile: isMobile,
+            playbackPromptOpen: widget.playbackPromptOpen,
+          )
+        : _skipMarkerOwnsBackPress && !_showControls && !widget.playbackPromptOpen;
+    _skipMarkerOwnsBackPress = event is KeyUpEvent ? false : skipMarkerOwnsPress;
+    if (skipMarkerOwnsPress) {
+      return handlePlayerNavigationKeyAction(event, navigationKey, _dismissSkipMarker);
     }
 
     // The enclosing player screen is the sole owner of fullscreen, chrome,
@@ -202,7 +238,7 @@ extension _PlexVideoControlsKeyEventMethods on _PlexVideoControlsState {
 
   KeyEventResult _handleControlsKeyEvent(KeyEvent event, bool isMobile) {
     final navigationKey = classifyPlayerNavigationKey(event, isAppleTV: PlatformDetector.isAppleTV());
-    final navigationResult = _handleLocalPlayerNavigationKeyEvent(event, navigationKey);
+    final navigationResult = _handleLocalPlayerNavigationKeyEvent(event, navigationKey, isMobile);
     if (navigationResult != KeyEventResult.ignored) {
       return navigationResult;
     }

--- a/lib/widgets/video_controls/parts/markers.dart
+++ b/lib/widgets/video_controls/parts/markers.dart
@@ -234,6 +234,28 @@ extension _PlexVideoControlsMarkerMethods on _PlexVideoControlsState {
     _performAutoSkip();
   }
 
+  /// The viewer's "no thanks" to a skip prompt: stops any running auto-skip
+  /// countdown and hides the button for the rest of this marker.
+  ///
+  /// The mirror of [_activateSkipMarker]. The focus hand-back carries its own
+  /// chrome guard rather than relying on the caller's: with the chrome up the
+  /// button stays visible and keeps focus, so releasing it there would pull the
+  /// remote off a control the viewer can still see.
+  void _dismissSkipMarker() {
+    if (!_isSkipMarkerButtonVisible) return;
+    // Cancelled here rather than left to the global key handler's
+    // _cancelAutoSkipFromUserInteraction: gamepad and companion-remote presses
+    // are synthesized straight onto the focus chain and never reach
+    // HardwareKeyboard, so for those this is the only thing that stops the
+    // countdown.
+    _cancelAutoSkipTimer();
+    _cancelSkipButtonDismissTimer();
+    _setControlsState(() {
+      _skipButtonDismissed = true;
+    });
+    if (!_showControls) _releaseSkipMarkerFocusToSurface();
+  }
+
   Widget _buildSkipMarkerButton() {
     final isAutoSkipActive = _autoSkipTimer?.isActive ?? false;
     return SkipMarkerButton(

--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -389,6 +389,44 @@ class PlayerNavigationCoordinator {
   }
 }
 
+/// Whether a Back press should answer a visible skip prompt instead of walking
+/// the screen's staged Back chain.
+///
+/// Mirrors the "sole affordance on screen" rule Select already uses in
+/// `_activatePlayerSurfaceSelect`: the prompt owns the key only while the
+/// chrome is down, the button is up, and the viewer can actually drive
+/// playback. With the chrome up the button is an ordinary focusable control
+/// and `skipButtonDismissed` would not hide it anyway, so Back stays the
+/// chrome's own key there; without [canControl] the button is inert, and
+/// eating a guest's exit press for a control they cannot operate is worse than
+/// leaving the prompt up.
+///
+/// Both Back flavours count. A local layer takes the dismiss key ahead of the
+/// screen's fullscreen and exit stages, the same way an open sheet already
+/// swallows a physical Escape — and Escape is only a fullscreen key when
+/// [shouldPhysicalEscapeExitFullscreen] holds, so excluding it would leave it
+/// exiting the player outright on macOS, on a windowed player, or with player
+/// navigation turned on.
+///
+/// Phones are excluded: there Back is unconditionally "leave the player"
+/// (#1938), and a stage sitting above the coordinator would quietly revoke
+/// that. So is an open playback prompt, whose own Back stage lives on the
+/// screen and would otherwise never be reached.
+bool shouldDismissSkipMarkerOnBack({
+  required PlayerNavigationKey navigationKey,
+  required bool controlsVisible,
+  required bool skipMarkerButtonVisible,
+  required bool canControl,
+  required bool isMobile,
+  required bool playbackPromptOpen,
+}) {
+  if (isMobile || playbackPromptOpen) return false;
+  if (navigationKey != PlayerNavigationKey.back && navigationKey != PlayerNavigationKey.physicalEscape) {
+    return false;
+  }
+  return canControl && !controlsVisible && skipMarkerButtonVisible;
+}
+
 // ignore: unused-code
 PlayerBackDisposition resolvePlayerBackDisposition({
   required PlayerNavigationKey navigationKey,
@@ -577,6 +615,12 @@ class PlexVideoControls extends StatefulWidget {
   /// Optional focus node for Play Next dialog button (for TV navigation from timeline)
   final FocusNode? playNextFocusNode;
 
+  /// Whether a screen-level playback prompt (e.g. "Still watching?") owns the
+  /// remote. The Play Next dialog announces itself through
+  /// [playNextFocusNode]; the others have no node here, and a local layer must
+  /// not answer a Back the prompt is waiting for.
+  final bool playbackPromptOpen;
+
   /// Shared controller for player chrome visibility, auto-hide, and layout state.
   final PlayerChromeController chromeController;
 
@@ -685,6 +729,7 @@ class PlexVideoControls extends StatefulWidget {
     required this.canNavigateMediaItems,
     this.hasFirstFrame,
     this.playNextFocusNode,
+    this.playbackPromptOpen = false,
     required this.chromeController,
     this.shaderService,
     this.onShaderChanged,
@@ -794,6 +839,9 @@ class _PlexVideoControlsState extends State<PlexVideoControls>
   int _hiddenSeekRepeatCount = 0;
   // Current marker state
   MediaMarker? _currentMarker;
+
+  /// Latched for the whole Back press; see [_handleLocalPlayerNavigationKeyEvent].
+  bool _skipMarkerOwnsBackPress = false;
   late List<MediaMarker> _markers = widget.initialMarkers ?? [];
   late bool _markersLoaded = widget.initialMarkers != null;
   // Playback state subscription for auto-hide timer

--- a/test/widgets/video_controls_select_key_test.dart
+++ b/test/widgets/video_controls_select_key_test.dart
@@ -21,6 +21,8 @@ import 'package:plezy/widgets/video_controls/desktop_video_controls.dart';
 import 'package:plezy/widgets/video_controls/player_chrome_controller.dart';
 import 'package:plezy/widgets/video_controls/video_controls.dart';
 import 'package:plezy/widgets/video_controls/widgets/player_toast_indicator.dart';
+import 'package:plezy/widgets/video_controls/widgets/skip_marker_button.dart';
+import 'package:plezy/focus/dpad_navigator.dart';
 
 import '../test_helpers/media_items.dart';
 import '../test_helpers/prefs.dart';
@@ -48,6 +50,17 @@ void main() {
   late FocusNode screenFocusNode;
   var toggles = 0;
 
+  /// What the player screen would have done with each Back that escaped the
+  /// controls. The harness cannot run the real staged chain, so it records the
+  /// disposition the screen would have resolved: an empty list means the
+  /// controls answered the press themselves.
+  final screenBackDispositions = <PlayerBackDisposition>[];
+
+  /// Back key-downs that reached the screen node. A stage that claims the press
+  /// consumes the down as well as the up, so this separates "the controls
+  /// declined the press" from "a later guard handed it back".
+  var screenBackKeyDowns = 0;
+
   Future<void> setNavigationEnabled(bool value) => settings.write(SettingsService.videoPlayerNavigationEnabled, value);
 
   setUp(() async {
@@ -71,10 +84,13 @@ void main() {
     hasFirstFrame = ValueNotifier<bool>(true);
     screenFocusNode = FocusNode(debugLabel: 'VideoPlayerScreen');
     toggles = 0;
+    screenBackDispositions.clear();
+    screenBackKeyDowns = 0;
   });
 
   tearDown(() async {
     TvDetectionService.debugSetAppleTVOverride(null);
+    TvDetectionService.setForceTVSync(false);
     PlatformDetector.debugSetIsDesktopOSOverride(null);
     hasFirstFrame.dispose();
     screenFocusNode.dispose();
@@ -92,7 +108,7 @@ void main() {
   /// so the controls' own `autofocus` cannot win it back. Without that, the
   /// surface would take focus by default and the startup claim would look
   /// correct even when it is not.
-  Widget shell(Widget child) => InputModeTracker(
+  Widget shell(Widget child, {TargetPlatform platform = TargetPlatform.windows}) => InputModeTracker(
     child: MultiProvider(
       providers: [
         Provider<AppDatabase>.value(value: database),
@@ -100,25 +116,50 @@ void main() {
         ChangeNotifierProvider<WatchTogetherProvider>.value(value: watchTogether),
       ],
       child: MaterialApp(
-        theme: ThemeData(platform: TargetPlatform.windows, extensions: const [testMonoTokens]),
+        theme: ThemeData(platform: platform, extensions: const [testMonoTokens]),
         home: Scaffold(
           body: SizedBox(
             width: 1280,
             height: 720,
-            child: Focus(focusNode: screenFocusNode, autofocus: true, child: child),
+            child: Focus(
+              focusNode: screenFocusNode,
+              autofocus: true,
+              onKeyEvent: (node, event) {
+                if (event is KeyDownEvent && event.logicalKey.isBackKey) screenBackKeyDowns++;
+                if (event is KeyUpEvent && event.logicalKey.isBackKey) {
+                  screenBackDispositions.add(
+                    resolvePlayerBackDisposition(
+                      navigationKey: classifyPlayerNavigationKey(event, isAppleTV: PlatformDetector.isAppleTV()),
+                      contentStripVisible: chrome.contentStripVisible,
+                      controlsVisible: chrome.controlsVisible,
+                      physicalEscapeExitsFullscreen: false,
+                    ),
+                  );
+                }
+                return KeyEventResult.ignored;
+              },
+              child: child,
+            ),
           ),
         ),
       ),
     ),
   );
 
-  Future<void> pumpPlayer(WidgetTester tester, {List<MediaMarker>? markers}) async {
-    await tester.pumpWidget(shell(const SizedBox.expand()));
+  Future<void> pumpPlayer(
+    WidgetTester tester, {
+    List<MediaMarker>? markers,
+    TargetPlatform platform = TargetPlatform.windows,
+    bool canControl = true,
+    bool playbackPromptOpen = false,
+  }) async {
+    await tester.pumpWidget(shell(const SizedBox.expand(), platform: platform));
     await tester.pump();
     expect(screenFocusNode.hasPrimaryFocus, isTrue, reason: 'precondition: the screen node owns the remote');
 
     await tester.pumpWidget(
       shell(
+        platform: platform,
         PlexVideoControls(
           player: player,
           volumeController: volume,
@@ -128,6 +169,8 @@ void main() {
           chromeController: chrome,
           hasFirstFrame: hasFirstFrame,
           canNavigateMediaItems: false,
+          canControl: canControl,
+          playbackPromptOpen: playbackPromptOpen,
           onPlayPauseRequested: (_) async => toggles++,
         ),
       ),
@@ -149,9 +192,22 @@ void main() {
 
   /// Mounts the player, runs [body], then unmounts and disarms the auto-hide
   /// timer so the harness's pending-timer check stays honest.
-  void playerTest(String description, Future<void> Function(WidgetTester tester) body, {List<MediaMarker>? markers}) {
+  void playerTest(
+    String description,
+    Future<void> Function(WidgetTester tester) body, {
+    List<MediaMarker>? markers,
+    TargetPlatform platform = TargetPlatform.windows,
+    bool canControl = true,
+    bool playbackPromptOpen = false,
+  }) {
     testWidgets(description, (tester) async {
-      await pumpPlayer(tester, markers: markers);
+      await pumpPlayer(
+        tester,
+        markers: markers,
+        platform: platform,
+        canControl: canControl,
+        playbackPromptOpen: playbackPromptOpen,
+      );
       await body(tester);
       chrome.cancelAutoHide();
       await tester.pumpWidget(const SizedBox.shrink());
@@ -315,6 +371,179 @@ void main() {
       expect(chrome.controlsVisible, isFalse);
       expect(focusLabel(), 'PlayerSurface');
     });
+  });
+
+  // Declining a skip prompt is the mirror of taking it. Back used to fall
+  // through to the screen's staged chain and exit the player outright, so the
+  // only key on a remote that means "no thanks" also ended the episode.
+  // Desktop, not TV, because Apple TV runs Back on key-down: the normal
+  // down-consume/up-act path is where the claim has to hold.
+  group('declining a skip prompt', () {
+    final introMarker = MediaMarker(id: 1, type: 'intro', startTimeOffset: 10000, endTimeOffset: 45000);
+
+    Future<void> showPrompt(WidgetTester tester) async {
+      player.emitPosition(const Duration(seconds: 15));
+      await tester.pumpAndSettle();
+      expect(find.byType(SkipMarkerButton), findsOneWidget, reason: 'precondition: the prompt is up');
+    }
+
+    playerTest('Back hides the prompt without skipping or exiting', markers: [introMarker], (tester) async {
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+
+      expect(find.byType(SkipMarkerButton), findsNothing, reason: 'the prompt is declined');
+      expect(player.state.position, const Duration(seconds: 15), reason: 'declining must not skip');
+      expect(focusLabel(), 'PlayerSurface', reason: 'the vanished button must hand the remote back');
+      expect(screenBackDispositions, isEmpty, reason: 'the press must not reach the exit chain');
+    });
+
+    playerTest('the next Back belongs to the screen again', markers: [introMarker], (tester) async {
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+
+      expect(screenBackDispositions, [PlayerBackDisposition.exitPlayer], reason: 'one press declines, the next leaves');
+    });
+
+    // The button's own 7s auto-dismiss is armed for every prompt while
+    // auto-skip is off, which is the default. handleBackKeyAction acts on the
+    // key-up, so a timer landing mid-press used to flip the gate and hand the
+    // press to the screen -- exiting the player on the very press meant to
+    // keep it open.
+    playerTest('a mid-press auto-dismiss cannot turn the press into an exit', markers: [introMarker], (tester) async {
+      await showPrompt(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.gameButtonB);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 8));
+      expect(find.byType(SkipMarkerButton), findsNothing, reason: 'precondition: the timer fired mid-press');
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.gameButtonB);
+      await tester.pumpAndSettle();
+
+      expect(screenBackDispositions, isEmpty, reason: 'the claim is latched for the whole press');
+    });
+
+    playerTest('physical Escape declines it too, having no fullscreen role here', markers: [introMarker], (
+      tester,
+    ) async {
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.escape);
+
+      expect(find.byType(SkipMarkerButton), findsNothing);
+      expect(screenBackDispositions, isEmpty, reason: 'Escape must not exit the player either');
+    });
+
+    playerTest('a screen-level prompt keeps its own Back', markers: [introMarker], playbackPromptOpen: true, (
+      tester,
+    ) async {
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+
+      expect(find.byType(SkipMarkerButton), findsOneWidget, reason: 'the prompt is not ours to answer');
+      expect(screenBackKeyDowns, 1, reason: 'the press is never claimed, not merely handed back');
+      expect(screenBackDispositions, isNotEmpty, reason: 'the prompt stage lives on the screen');
+    });
+
+    playerTest('a viewer who cannot skip keeps their exit press', markers: [introMarker], canControl: false, (
+      tester,
+    ) async {
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+
+      expect(find.byType(SkipMarkerButton), findsOneWidget, reason: 'the button is inert, not dismissable');
+      expect(screenBackDispositions, [PlayerBackDisposition.exitPlayer]);
+    });
+
+    playerTest('the chrome owns a press that starts under it', markers: [introMarker], (tester) async {
+      await showPrompt(tester);
+      chrome.show();
+      await tester.pumpAndSettle();
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+
+      expect(screenBackKeyDowns, 1, reason: 'the press is never claimed, not merely handed back');
+      expect(screenBackDispositions, [PlayerBackDisposition.hideControls]);
+    });
+
+    // The gesture the feature exists for: "no thanks" while the countdown runs.
+    playerTest('declining stops a running auto-skip countdown', markers: [introMarker], (tester) async {
+      await settings.write(SettingsService.autoSkipIntro, true);
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+      await tester.pump(const Duration(seconds: 10));
+
+      expect(player.state.position, const Duration(seconds: 15), reason: 'a declined countdown must not fire');
+      expect(screenBackDispositions, isEmpty);
+    });
+
+    // The latch covers the button vanishing mid-press, not the chrome rising.
+    // With the OSD up Back belongs to the chrome, so a press that starts under
+    // a bare prompt and ends under the OSD has to be handed back.
+    playerTest('the claim is released when the chrome comes up mid-press', markers: [introMarker], (tester) async {
+      await showPrompt(tester);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.gameButtonB);
+      await tester.pump();
+      chrome.show();
+      await tester.pumpAndSettle();
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.gameButtonB);
+      await tester.pumpAndSettle();
+
+      expect(screenBackDispositions, [
+        PlayerBackDisposition.hideControls,
+      ], reason: 'with the chrome up the press is the chrome to stage');
+    });
+
+    playerTest('a phone Back stays unconditional', markers: [introMarker], platform: TargetPlatform.android, (
+      tester,
+    ) async {
+      await showPrompt(tester);
+
+      await press(tester, LogicalKeyboardKey.gameButtonB);
+
+      expect(find.byType(SkipMarkerButton), findsOneWidget, reason: 'the prompt does not own a phone Back');
+      expect(screenBackDispositions, [PlayerBackDisposition.exitPlayer], reason: '#1938: mobile Back exits, always');
+    });
+  });
+
+  // Android TV is the platform the report came from, and it is materially
+  // different: the marker autofocuses the button, so the key is dispatched
+  // from the button's node upward rather than from the surface. The forced-TV
+  // override is the only way to get a non-Apple TV, since the Apple override
+  // sets both isTV and isAppleTV.
+  group('declining a skip prompt on Android TV', () {
+    setUp(() async {
+      TvDetectionService.debugSetAppleTVOverride(null);
+      await TvDetectionService.getInstance(forceTv: true);
+      TvDetectionService.setForceTVSync(true);
+      PlatformDetector.debugSetIsDesktopOSOverride(false);
+      await setNavigationEnabled(true);
+    });
+
+    playerTest(
+      'Back declines the focused prompt and hands the remote back',
+      markers: [MediaMarker(id: 1, type: 'intro', startTimeOffset: 10000, endTimeOffset: 45000)],
+      (tester) async {
+        InputModeTracker.reportNonPointerInput();
+        player.emitPosition(const Duration(seconds: 15));
+        await tester.pumpAndSettle();
+        expect(focusLabel(), 'SkipMarkerButton', reason: 'precondition: TV autofocuses the sole affordance');
+
+        await press(tester, LogicalKeyboardKey.gameButtonB);
+
+        expect(find.byType(SkipMarkerButton), findsNothing);
+        expect(player.state.position, const Duration(seconds: 15), reason: 'declining must not skip');
+        expect(focusLabel(), 'PlayerSurface', reason: 'the vanished button must hand the remote back');
+        expect(screenBackKeyDowns, 0, reason: 'the prompt answered the press');
+        expect(screenBackDispositions, isEmpty);
+      },
+    );
   });
 
   group('skip intro on a television', () {

--- a/test/widgets/video_controls_test.dart
+++ b/test/widgets/video_controls_test.dart
@@ -924,6 +924,59 @@ void main() {
     });
   });
 
+  group('shouldDismissSkipMarkerOnBack', () {
+    bool call({
+      PlayerNavigationKey navigationKey = PlayerNavigationKey.back,
+      bool controlsVisible = false,
+      bool skipMarkerButtonVisible = true,
+      bool canControl = true,
+      bool isMobile = false,
+      bool playbackPromptOpen = false,
+    }) {
+      return shouldDismissSkipMarkerOnBack(
+        navigationKey: navigationKey,
+        controlsVisible: controlsVisible,
+        skipMarkerButtonVisible: skipMarkerButtonVisible,
+        canControl: canControl,
+        isMobile: isMobile,
+        playbackPromptOpen: playbackPromptOpen,
+      );
+    }
+
+    test('declines a skip prompt while the button is the sole affordance', () {
+      expect(call(), isTrue);
+    });
+
+    test('claims physical Escape too, which has no fullscreen role here', () {
+      expect(call(navigationKey: PlayerNavigationKey.physicalEscape), isTrue);
+    });
+
+    test('leaves Back to the screen when no skip button is up', () {
+      expect(call(skipMarkerButtonVisible: false), isFalse);
+    });
+
+    test('keeps Back on the chrome while the controls are visible', () {
+      expect(call(controlsVisible: true), isFalse);
+    });
+
+    test('leaves a phone Back unconditional, as #1938 requires', () {
+      expect(call(isMobile: true), isFalse);
+    });
+
+    test('does not eat the exit press for a viewer who cannot skip', () {
+      expect(call(canControl: false), isFalse);
+    });
+
+    test('leaves Back to a screen-level prompt that is waiting for it', () {
+      expect(call(playbackPromptOpen: true), isFalse);
+    });
+
+    test('ignores keys the screen owns outright', () {
+      expect(call(navigationKey: PlayerNavigationKey.home), isFalse);
+      expect(call(navigationKey: PlayerNavigationKey.none), isFalse);
+    });
+  });
+
   group('shouldPhysicalEscapeExitFullscreen', () {
     test('uses fullscreen-first behavior for normal Windows and Linux navigation', () {
       expect(


### PR DESCRIPTION
Closes #2048.

While a Skip Intro / Skip Credits button is up and the chrome is down, Back walks the screen's staged Back chain and exits playback. On a remote nothing else means "no thanks": left/right seek, OK takes the skip, up/down raises the OSD.

This adds a stage for it, alongside the sheet and content-strip stages that already run locally in the player controls:

- `shouldDismissSkipMarkerOnBack` in `video_controls.dart`, a pure predicate next to `resolvePlayerBackDisposition`.
- The stage in `_handleLocalPlayerNavigationKeyEvent`, above the "screen owns the rest" return.
- `_dismissSkipMarker()` in `markers.dart`, the mirror of `_activateSkipMarker()`.

Gated on the same condition as Select's skip path: chrome down, button visible, `canControl`. Off on phones, since Back there is unconditionally "leave the player" (#1938). Off while a screen-level playback prompt owns the key, which needed `playbackPromptOpen` plumbed through, because only the Play Next dialog announced itself via `playNextFocusNode`.

The claim is latched for the whole press rather than re-derived per event. `handleBackKeyAction` consumes the key-down and acts on the key-up, and the button's 7s auto-dismiss is armed for every prompt while auto-skip is off, which is the default. Re-asking on the key-up handed the press back to the screen and exited the player, which is the bug the stage exists to prevent. A chrome raise or a prompt opening does release the claim mid-press.

`physicalEscape` is included, not just `back`. Escape only owns fullscreen when `shouldPhysicalEscapeExitFullscreen` holds, so excluding it left Escape exiting the player outright on macOS, on a windowed player, or with player navigation on. Sheets and content strips already swallow Escape the same way. The tradeoff: on Windows/Linux with player navigation off and the player fullscreen, Escape now dismisses the prompt before exiting fullscreen. Happy to drop it back to `back`-only if you would rather keep that untouched.

Second Back exits the player as before.

Tests: 8 cases on the predicate, 11 widget-level cases on the wiring in `video_controls_select_key_test.dart`, covering Android TV, desktop, phone, Escape, the mid-press timer, the chrome-raise release, and declining a running countdown. The screen shell in that harness now records the `PlayerBackDisposition` the screen would have resolved rather than a bare key count, so a test can tell "hid the chrome" from "exited the player". Full suite passes, analyzer and `dart format` clean.
