### PR TITLE
feat(jellyfin): honor "Enable rewatching in Next Up" for Continue Watching

### DIFF
--- a/lib/i18n/az.i18n.json
+++ b/lib/i18n/az.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Daha az animasiya və daha aşağı keyfiyyətli şəkillər",
     "hideSpoilers": "Baxılmamış seriyalar üçün spoylerləri gizlə",
     "hideSpoilersDescription": "Baxılmamış seriyalar üçün miniatürləri və təsvirləri bulanıqlaşdır",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Oynadıcı infrastrukturu",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/bg.i18n.json
+++ b/lib/i18n/bg.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "По-малко анимации и изображения с по-ниска резолюция",
     "hideSpoilers": "Скривай спойлери за негледани епизоди",
     "hideSpoilersDescription": "Замазвай миниатюри и описания за негледани епизоди",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Система за възпроизвеждане",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/da.i18n.json
+++ b/lib/i18n/da.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Færre animationer og illustrationer i lavere opløsning",
     "hideSpoilers": "Skjul spoilere for usete episoder",
     "hideSpoilersDescription": "Slør miniaturebilleder og beskrivelser for usete episoder",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Afspillermotor",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Weniger Animationen und Grafiken mit niedrigerer Auflösung",
     "hideSpoilers": "Spoiler für nicht gesehene Episoden verbergen",
     "hideSpoilersDescription": "Vorschaubilder und Beschreibungen ungesehener Episoden verwischen",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Wiedergabe-Engine",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Fewer animations and lower-resolution artwork",
     "hideSpoilers": "Hide Spoilers for Unwatched Episodes",
     "hideSpoilersDescription": "Blur thumbnails and descriptions for unwatched episodes",
+    "jellyfinRewatchingInNextUp": "Rewatching in Next Up",
+    "jellyfinRewatchingInNextUpDescription": "Keep showing the next episode of shows you have already finished (Jellyfin)",
     "playerBackend": "Player Backend",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Menos animaciones e ilustraciones de menor resolución",
     "hideSpoilers": "Ocultar spoilers de episodios no vistos",
     "hideSpoilersDescription": "Desenfocar miniaturas y descripciones de episodios no vistos",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Motor de reproducción",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/fr.i18n.json
+++ b/lib/i18n/fr.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Moins d’animations et d’illustrations de plus faible résolution",
     "hideSpoilers": "Masquer les spoilers des épisodes non vus",
     "hideSpoilersDescription": "Flouter les miniatures et descriptions des épisodes non vus",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Moteur de lecture",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/hu.i18n.json
+++ b/lib/i18n/hu.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Kevesebb animáció és alacsonyabb felbontású képek",
     "hideSpoilers": "Spoilerek elrejtése a nem látott epizódoknál",
     "hideSpoilersDescription": "Bélyegképek és leírások elhomályosítása a még meg nem nézett epizódoknál",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Lejátszómotor",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/it.i18n.json
+++ b/lib/i18n/it.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Meno animazioni e immagini a risoluzione inferiore",
     "hideSpoilers": "Nascondi spoiler per episodi non visti",
     "hideSpoilersDescription": "Sfoca miniature e descrizioni degli episodi non visti",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Motore di riproduzione",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/ja.i18n.json
+++ b/lib/i18n/ja.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "アニメーションを減らし、低解像度のアートワークを使用します",
     "hideSpoilers": "未視聴エピソードのネタバレを非表示",
     "hideSpoilersDescription": "未視聴エピソードのサムネイルと説明をぼかします",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "プレーヤーバックエンド",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/kk.i18n.json
+++ b/lib/i18n/kk.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Аз анимация және төмен сапалы суреттер",
     "hideSpoilers": "Көрілмеген бөлімдер үшін спойлерлерді жасыру",
     "hideSpoilersDescription": "Көрілмеген бөлімдердің суреттері мен сипаттамаларын бұлдырату",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Ойнатқыш инфрақұрылымы",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/ko.i18n.json
+++ b/lib/i18n/ko.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "애니메이션을 줄이고 아트워크 해상도를 낮춥니다",
     "hideSpoilers": "미시청 에피소드 스포일러 숨기기",
     "hideSpoilersDescription": "시청하지 않은 에피소드의 썸네일과 설명을 흐리게 처리",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "플레이어 백엔드",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/nb.i18n.json
+++ b/lib/i18n/nb.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Færre animasjoner og grafikk med lavere oppløsning",
     "hideSpoilers": "Skjul spoilere for usette episoder",
     "hideSpoilersDescription": "Slør miniatyrbilder og beskrivelser for usette episoder",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Avspillingsmotor",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/nl.i18n.json
+++ b/lib/i18n/nl.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Minder animaties en illustraties met lagere resolutie",
     "hideSpoilers": "Spoilers voor ongekeken afleveringen verbergen",
     "hideSpoilersDescription": "Vervaag miniaturen en beschrijvingen van ongekeken afleveringen",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Afspeelbackend",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/pl.i18n.json
+++ b/lib/i18n/pl.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Mniej animacji i grafiki o niższej rozdzielczości",
     "hideSpoilers": "Ukryj spoilery nieobejrzanych odcinków",
     "hideSpoilersDescription": "Rozmywaj miniatury i opisy nieobejrzanych odcinków",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Mechanizm odtwarzania",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/pt.i18n.json
+++ b/lib/i18n/pt.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Menos animações e imagens em menor resolução",
     "hideSpoilers": "Ocultar spoilers de episódios não assistidos",
     "hideSpoilersDescription": "Desfocar miniaturas e descrições de episódios não assistidos",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Mecanismo de reprodução",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/ru.i18n.json
+++ b/lib/i18n/ru.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Меньше анимаций и графика с более низким разрешением",
     "hideSpoilers": "Скрыть спойлеры непросмотренных эпизодов",
     "hideSpoilersDescription": "Размывать миниатюры и описания непросмотренных серий",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Бэкенд плеера",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 22
-/// Strings: 40980 (1862 per locale)
+/// Strings: 40982 (1862 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -573,6 +573,12 @@ class Translations$settings$en {
 	/// en: 'Blur thumbnails and descriptions for unwatched episodes'
 	String get hideSpoilersDescription => 'Blur thumbnails and descriptions for unwatched episodes';
 
+	/// en: 'Rewatching in Next Up'
+	String get jellyfinRewatchingInNextUp => 'Rewatching in Next Up';
+
+	/// en: 'Keep showing the next episode of shows you have already finished (Jellyfin)'
+	String get jellyfinRewatchingInNextUpDescription => 'Keep showing the next episode of shows you have already finished (Jellyfin)';
+
 	/// en: 'Player Backend'
 	String get playerBackend => 'Player Backend';
 
@@ -6639,6 +6645,8 @@ extension on Translations {
 			'settings.visualEffectsReducedDescription' => 'Fewer animations and lower-resolution artwork',
 			'settings.hideSpoilers' => 'Hide Spoilers for Unwatched Episodes',
 			'settings.hideSpoilersDescription' => 'Blur thumbnails and descriptions for unwatched episodes',
+			'settings.jellyfinRewatchingInNextUp' => 'Rewatching in Next Up',
+			'settings.jellyfinRewatchingInNextUpDescription' => 'Keep showing the next episode of shows you have already finished (Jellyfin)',
 			'settings.playerBackend' => 'Player Backend',
 			'settings.exoPlayer' => 'ExoPlayer',
 			'settings.mpv' => 'mpv',
@@ -6996,10 +7004,10 @@ extension on Translations {
 			'mediaMenu.fileInfo' => 'File Info',
 			'mediaMenu.deleteEpisodeFromServer' => 'Delete episode from server',
 			'mediaMenu.deleteSeasonFromServer' => 'Delete season from server',
-			'mediaMenu.deleteShowFromServer' => 'Delete show from server',
-			'mediaMenu.deleteMovieFromServer' => 'Delete movie from server',
 			_ => null,
 		} ?? switch (path) {
+			'mediaMenu.deleteShowFromServer' => 'Delete show from server',
+			'mediaMenu.deleteMovieFromServer' => 'Delete movie from server',
 			'mediaMenu.deleteEpisodeTitle' => 'Delete this episode?',
 			'mediaMenu.deleteSeasonTitle' => 'Delete this season?',
 			'mediaMenu.deleteShowTitle' => 'Delete this show?',
@@ -7510,10 +7518,10 @@ extension on Translations {
 			'explore.rows.upcomingMovies' => 'Upcoming Movies',
 			'explore.rows.upcomingShows' => 'Upcoming Shows',
 			'explore.status.airing' => 'Airing',
-			'explore.status.ended' => 'Ended',
-			'explore.status.canceled' => 'Canceled',
 			_ => null,
 		} ?? switch (path) {
+			'explore.status.ended' => 'Ended',
+			'explore.status.canceled' => 'Canceled',
 			'explore.status.upcoming' => 'Upcoming',
 			'explore.episodeCount' => ({required num n}) => (_root.$meta.cardinalResolver ?? PluralResolvers.cardinal('en'))(n, one: '${n} episode', other: '${n} episodes', ), 
 			'explore.cast' => 'Cast',
@@ -8024,10 +8032,10 @@ extension on Translations {
 			'companionRemote.remote.menu' => 'Menu',
 			'companionRemote.remote.tabNavigation' => 'Tab Navigation',
 			'companionRemote.remote.tabDiscover' => 'Discover',
-			'companionRemote.remote.tabLibraries' => 'Libraries',
-			'companionRemote.remote.tabSearch' => 'Search',
 			_ => null,
 		} ?? switch (path) {
+			'companionRemote.remote.tabLibraries' => 'Libraries',
+			'companionRemote.remote.tabSearch' => 'Search',
 			'companionRemote.remote.tabDownloads' => 'Downloads',
 			'companionRemote.remote.tabSettings' => 'Settings',
 			'companionRemote.remote.previous' => 'Previous',

--- a/lib/i18n/sv.i18n.json
+++ b/lib/i18n/sv.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Färre animationer och grafik med lägre upplösning",
     "hideSpoilers": "Dölj spoilers för osedda avsnitt",
     "hideSpoilersDescription": "Gör miniatyrbilder och beskrivningar oskarpa för osedda avsnitt",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Uppspelningsmotor",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/tr.i18n.json
+++ b/lib/i18n/tr.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Daha az animasyon ve daha düşük çözünürlüklü görseller",
     "hideSpoilers": "İzlenmeyen Bölümler İçin Sürpriz Bozanları Gizle",
     "hideSpoilersDescription": "İzlenmeyen bölümler için küçük resimleri ve açıklamaları bulanıklaştır",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Oynatıcı Altyapısı",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/uz.i18n.json
+++ b/lib/i18n/uz.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "Kamroq animatsiya va pastroq sifatli rasmlar",
     "hideSpoilers": "Koʻrilmagan qismlar uchun spoylerlarni yashirish",
     "hideSpoilersDescription": "Koʻrilmagan qismlar rasmlari va tavsiflarini xiralashtirish",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "Pleyer infratuzilmasi",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/zh-Hant.i18n.json
+++ b/lib/i18n/zh-Hant.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "減少動畫並使用較低解析度的封面圖片",
     "hideSpoilers": "隱藏未觀看單集的劇透內容",
     "hideSpoilersDescription": "模糊未觀看單集的縮圖與描述",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "播放器引擎",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/i18n/zh.i18n.json
+++ b/lib/i18n/zh.i18n.json
@@ -165,6 +165,8 @@
     "visualEffectsReducedDescription": "减少动画并使用较低分辨率的封面图片",
     "hideSpoilers": "隐藏未看剧集的剧透内容",
     "hideSpoilersDescription": "模糊未观看剧集的缩略图和描述",
+    "jellyfinRewatchingInNextUp": "",
+    "jellyfinRewatchingInNextUpDescription": "",
     "playerBackend": "播放器引擎",
     "exoPlayer": "ExoPlayer",
     "mpv": "mpv",

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -198,6 +198,12 @@ class AppearanceSettingsScreen extends StatelessWidget {
               title: t.settings.hideSpoilers,
               subtitle: t.settings.hideSpoilersDescription,
             ),
+            SettingSwitchTile(
+              pref: SettingsService.jellyfinRewatchingInNextUp,
+              icon: Symbols.replay_rounded,
+              title: t.settings.jellyfinRewatchingInNextUp,
+              subtitle: t.settings.jellyfinRewatchingInNextUpDescription,
+            ),
             _episodeActionSelector(),
             if (hasMultipleProfiles)
               SettingSwitchTile(

--- a/lib/services/jellyfin_client.dart
+++ b/lib/services/jellyfin_client.dart
@@ -72,7 +72,7 @@ import 'jellyfin_trickplay_service.dart';
 import 'media_browser_paths.dart';
 import 'playback_initialization_types.dart';
 import 'scrub_preview_source.dart';
-import 'settings_service.dart' show SpecialsOrdering;
+import 'settings_service.dart' show SettingsService, SpecialsOrdering;
 import 'subtitle_preference.dart';
 import 'track_selection_service.dart';
 import '../mpv/mpv.dart';

--- a/lib/services/jellyfin_client/parts/browse.dart
+++ b/lib/services/jellyfin_client/parts/browse.dart
@@ -249,6 +249,17 @@ const _detailFields =
     'ProviderIds';
 
 mixin _JellyfinBrowseMethods on _JellyfinClientInternals {
+  /// `EnableRewatching` for `/Shows/NextUp`, honoring the user's
+  /// [SettingsService.jellyfinRewatchingInNextUp] preference (#1910). Sent only
+  /// when the user turned it on and the server is Jellyfin: Jellyfin defaults
+  /// it to false, and Emby's Next Up doesn't know the parameter, so every other
+  /// request stays byte-for-byte what it was.
+  String? get _nextUpRewatchingFlag {
+    if (dialect != MediaBrowserDialect.jellyfin) return null;
+    final enabled = SettingsService.instanceOrNull?.read(SettingsService.jellyfinRewatchingInNextUp) ?? false;
+    return enabled ? 'true' : null;
+  }
+
   // Shared endpoints and query shapes follow the official Jellyfin SDK so
   // Jellyfin requests remain unchanged. [MediaBrowserPaths] owns the measured
   // route differences: Emby 4.9.5 requires the older user-scoped spellings,
@@ -723,6 +734,7 @@ mixin _JellyfinBrowseMethods on _JellyfinClientInternals {
       'userId': connection.userId,
       'Limit': '1',
       'Fields': _episodeRowFields,
+      'EnableRewatching': ?_nextUpRewatchingFlag,
       ...jellyfinImageQueryParameters,
     });
     final onDeckEpisode = nextUp.isEmpty ? null : _mapItem(nextUp.first);
@@ -1651,6 +1663,7 @@ mixin _JellyfinBrowseMethods on _JellyfinClientInternals {
         'Limit': ?count?.toString(),
         'Fields': _hubRowFields,
         'EnableResumable': 'false',
+        'EnableRewatching': ?_nextUpRewatchingFlag,
         'NextUpDateCutoff': _nextUpDateCutoff(),
         'EnableTotalRecordCount': 'false',
         ...jellyfinImageQueryParameters,
@@ -1811,6 +1824,7 @@ mixin _JellyfinBrowseMethods on _JellyfinClientInternals {
                 'Limit': limit.toString(),
                 'Fields': _hubRowFields,
                 'EnableResumable': 'false',
+                'EnableRewatching': ?_nextUpRewatchingFlag,
                 'NextUpDateCutoff': _nextUpDateCutoff(),
                 'EnableTotalRecordCount': 'false',
                 ...jellyfinImageQueryParameters,

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -557,6 +557,13 @@ class SettingsService extends BaseSharedPreferencesService {
   static const showEpisodeNumberOnCards = BoolPref('show_episode_number_on_cards', defaultValue: true);
   static const showSeasonPostersOnTabs = BoolPref('show_season_posters_on_tabs');
   static const hideSpoilers = BoolPref('hide_spoilers');
+
+  /// Jellyfin's client-side "Enable rewatching in Next Up" display setting
+  /// (#1910). When on, `/Shows/NextUp` is asked for `EnableRewatching`, so a
+  /// series the user has already finished keeps surfacing its next episode in
+  /// Continue Watching / Next Up while they rewatch it. Jellyfin only: Plex
+  /// OnDeck has no equivalent switch, and Emby's Next Up route ignores it.
+  static const jellyfinRewatchingInNextUp = BoolPref('jellyfin_rewatching_in_next_up');
   static const showNavBarLabels = BoolPref('show_nav_bar_labels', defaultValue: true);
   static const globalShaderPreset = StringPref('global_shader_preset', defaultValue: 'none');
   static const requireProfileSelectionOnOpen = BoolPref('require_profile_selection_on_open');
@@ -1083,6 +1090,7 @@ class SettingsService extends BaseSharedPreferencesService {
     showEpisodeNumberOnCards,
     showSeasonPostersOnTabs,
     hideSpoilers,
+    jellyfinRewatchingInNextUp,
     showNavBarLabels,
     globalShaderPreset,
     requireProfileSelectionOnOpen,

--- a/test/screens/settings/appearance_settings_screen_test.dart
+++ b/test/screens/settings/appearance_settings_screen_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/i18n/strings.g.dart';
+import 'package:plezy/profiles/active_profile_provider.dart';
+import 'package:plezy/providers/theme_provider.dart';
+import 'package:plezy/screens/settings/appearance_settings_screen.dart';
+import 'package:plezy/services/settings_service.dart';
+import 'package:plezy/theme/mono_theme.dart';
+import 'package:provider/provider.dart';
+
+import '../../test_helpers/prefs.dart';
+import '../../test_helpers/profile_stack.dart';
+
+void main() {
+  setUp(() async {
+    resetSharedPreferencesForTest();
+    SettingsService.resetForTesting();
+    await SettingsService.getInstance();
+    LocaleSettings.setLocaleSync(AppLocale.en);
+  });
+
+  testWidgets('toggles the Jellyfin rewatching-in-Next-Up preference', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 1400);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final stack = await ProfileStack.create(withStorage: false);
+    final theme = ThemeProvider();
+    addTearDown(() async {
+      theme.dispose();
+      await stack.dispose();
+    });
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ActiveProfileProvider>.value(value: stack.active),
+          ChangeNotifierProvider<ThemeProvider>.value(value: theme),
+        ],
+        child: MaterialApp(theme: monoTheme(dark: true), home: const AppearanceSettingsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final title = find.text('Rewatching in Next Up');
+    await tester.scrollUntilVisible(title, 500, scrollable: find.byType(Scrollable).first);
+
+    final tile = find.ancestor(of: title, matching: find.byType(ListTile)).first;
+    expect(find.descendant(of: tile, matching: find.textContaining('shows you have already finished')), findsOneWidget);
+    final toggle = find.descendant(of: tile, matching: find.byType(Switch));
+    // Off by default: Jellyfin's own default, and the request stays as it was.
+    expect(tester.widget<Switch>(toggle).value, isFalse);
+    expect(SettingsService.instance.read(SettingsService.jellyfinRewatchingInNextUp), isFalse);
+
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    final settings = SettingsService.instance;
+    expect(tester.widget<Switch>(toggle).value, isTrue);
+    expect(settings.read(SettingsService.jellyfinRewatchingInNextUp), isTrue);
+    expect(settings.prefs.getBool(SettingsService.jellyfinRewatchingInNextUp.key), isTrue);
+  });
+}

--- a/test/services/jellyfin_client_urls_test.dart
+++ b/test/services/jellyfin_client_urls_test.dart
@@ -10,6 +10,7 @@ import 'package:plezy/connection/connection.dart';
 import 'package:plezy/media/artist_discography.dart';
 import 'package:plezy/media/library_query.dart';
 import 'package:plezy/media/media_backend.dart';
+import 'package:plezy/media/media_browser_dialect.dart';
 import 'package:plezy/media/media_item.dart';
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/media/media_playlist.dart';
@@ -3358,6 +3359,91 @@ void main() {
       await SettingsService.instance.write(SettingsService.specialsOrdering, SpecialsOrdering.specialsLast);
       final specialsApart = await orderedClient.fetchClientSideEpisodeQueue('show-1');
       expect(specialsApart!.map((e) => e.id), ['ep-1', 'ep-2', 'special']);
+    });
+
+    group('NextUp rewatching preference (#1910)', () {
+      // Every /Shows/NextUp request the client makes: the Continue Watching
+      // shelf, the home hub set, and the per-show on-deck chain.
+      Future<List<Uri>> nextUpRequests() async {
+        final nextUp = <Uri>[];
+        final scoped = JellyfinClient.forTesting(
+          connection: _conn(),
+          httpClient: MockClient((req) async {
+            if (req.url.path == '/Shows/NextUp') {
+              nextUp.add(req.url);
+              return jsonResponse({'Items': []});
+            }
+            if (req.url.path == '/UserItems/Resume' || req.url.path == '/Users/user-1/Items/Latest') {
+              return jsonResponse({'Items': []});
+            }
+            if (req.url.path == '/Users/user-1/Items/show-1') {
+              return jsonResponse({'Id': 'show-1', 'Type': 'Series', 'Name': 'Show 1'});
+            }
+            return http.Response('not found', 404);
+          }),
+        );
+        addTearDown(scoped.close);
+
+        await scoped.fetchContinueWatching();
+        await scoped.fetchGlobalHubs();
+        await scoped.fetchItemWithOnDeck('show-1');
+        expect(nextUp, hasLength(3), reason: 'shelf, hub set, and on-deck chain each query NextUp');
+        return nextUp;
+      }
+
+      setUp(() async {
+        resetSharedPreferencesForTest();
+        SettingsService.resetForTesting();
+        await SettingsService.getInstance();
+      });
+
+      test('NextUp requests omit EnableRewatching while the preference is off', () async {
+        // Jellyfin already defaults it to false; leaving it out keeps every
+        // request identical to before the preference existed.
+        for (final uri in await nextUpRequests()) {
+          expect(uri.queryParameters.containsKey('EnableRewatching'), isFalse, reason: '$uri');
+        }
+      });
+
+      test('NextUp requests send EnableRewatching=true once the preference is on', () async {
+        await SettingsService.instance.write(SettingsService.jellyfinRewatchingInNextUp, true);
+
+        for (final uri in await nextUpRequests()) {
+          expect(uri.queryParameters['EnableRewatching'], 'true', reason: '$uri');
+        }
+      });
+
+      test('Emby never receives EnableRewatching, even with the preference on', () async {
+        // Emby's Next Up doesn't know the parameter, and its shelf rides a
+        // different route anyway; the shared on-deck chain is the one place
+        // the flag could leak through, so pin it there.
+        await SettingsService.instance.write(SettingsService.jellyfinRewatchingInNextUp, true);
+        Uri? capturedNextUp;
+        final emby = JellyfinClient.forTesting(
+          connection: testJellyfinConnection(
+            dialect: MediaBrowserDialect.emby,
+            accessToken: 'tok-abc',
+            deviceId: 'dev-xyz',
+            createdAt: DateTime.fromMillisecondsSinceEpoch(0),
+          ),
+          httpClient: MockClient((req) async {
+            if (req.url.path == '/Shows/NextUp') {
+              capturedNextUp = req.url;
+              return jsonResponse({'Items': []});
+            }
+            if (req.url.path == '/Users/user-1/Items/show-1') {
+              return jsonResponse({'Id': 'show-1', 'Type': 'Series', 'Name': 'Show 1'});
+            }
+            return http.Response('not found', 404);
+          }),
+        );
+        addTearDown(emby.close);
+
+        await emby.fetchItemWithOnDeck('show-1');
+
+        expect(capturedNextUp, isNotNull);
+        expect(capturedNextUp!.queryParameters.containsKey('EnableRewatching'), isFalse);
+      });
     });
 
     test('fetchPersonMedia queries items by person id', () async {

--- a/test/services/settings_export_service_test.dart
+++ b/test/services/settings_export_service_test.dart
@@ -72,6 +72,18 @@ void main() {
       expect(jsonEncode(out), isNot(contains('private-order')));
     });
 
+    test('exports the Jellyfin rewatching-in-Next-Up preference', () async {
+      // Registered in the reset-and-portable set, so it rides along with a
+      // settings export like the other content toggles (#1910).
+      final prefs = await BaseSharedPreferencesService.sharedCache();
+      await prefs.setBool('jellyfin_rewatching_in_next_up', true);
+
+      final out = SettingsExportService.buildExportMap(prefs, currentUserUuid: 'alice', appVersion: '1.2.3');
+      final exported = out['prefs'] as Map<String, dynamic>;
+
+      expect(exported['jellyfin_rewatching_in_next_up'], {'type': 'bool', 'value': true});
+    });
+
     test('excludes device-local download roots while preserving portable download controls', () async {
       const sourcePath = '/source-device/downloads';
       final prefs = await BaseSharedPreferencesService.sharedCache();


### PR DESCRIPTION
## What

Jellyfin web has a client-side display setting, **"Enable rewatching in next up"**, which asks `/Shows/NextUp` for `EnableRewatching` so a series the user has already finished keeps surfacing its next episode while they rewatch it. Plezy never passed the flag, so rewatched shows dropped out of Continue Watching / Next Up (#1910). Because it's a per-client setting on Jellyfin's side, nothing from the web client carries over — it needs its own toggle here.

## Change

- New appearance toggle **Rewatching in Next Up** (subtitle notes it's Jellyfin), backed by a `jellyfinRewatchingInNextUp` pref registered with the reset-and-portable set so it rides along with settings export.
- When on, `EnableRewatching=true` is sent on every `/Shows/NextUp` request the client makes: the Continue Watching shelf, the home and library hub sets, and the per-show on-deck chain (so the detail page's resume episode follows the rewatch too).
- It is only sent when the toggle is on **and** the server is Jellyfin. Jellyfin already defaults it to false, so every other request stays byte-for-byte what it was; Emby's Next Up doesn't know the parameter and never receives it (the shared on-deck chain is gated on dialect). Plex OnDeck has no equivalent switch.

API: `GET /Shows/NextUp` → `enableRewatching` (boolean, default false), "Whether to include watched episodes in next up results" (Jellyfin OpenAPI).

Strings added to every locale per the usual convention (English text, empty elsewhere).

## Tests

- `NextUp requests omit EnableRewatching while the preference is off` / `…send EnableRewatching=true once the preference is on` — capture all three NextUp request sites (shelf, hub set, on-deck) and assert the parameter's absence/presence. The "on" test fails if the flag is dropped.
- `Emby never receives EnableRewatching, even with the preference on` — Emby-dialect client, preference on, on-deck chain: no parameter. Fails without the dialect gate.
- `toggles the Jellyfin rewatching-in-Next-Up preference` (new `appearance_settings_screen_test.dart`) — the tile renders with its description, defaults off, and tapping the switch persists `jellyfin_rewatching_in_next_up`.
- `exports the Jellyfin rewatching-in-Next-Up preference` — the pref rides along with a settings export.
- `flutter analyze`, `dart format --line-length 120`, `dart_code_linter` unused-code/unused-files, `clean_translations.py --check --strict`, `check_icon_consistency`, `codegen.sh --check`, full `flutter test`: clean.
