### PR TITLE
Add Emby remote subtitle search and download flow

### DIFF
--- a/lib/media/media_server_client.dart
+++ b/lib/media/media_server_client.dart
@@ -7,6 +7,7 @@ import '../utils/app_logger.dart';
 import '../utils/media_server_http_client.dart' show AbortController, MediaServerResponse, throwIfHttpError;
 import '../utils/external_ids.dart';
 import '../utils/watch_state_notifier.dart';
+import '../models/subtitles/subtitle_search_result.dart';
 import 'artist_discography.dart';
 import 'download_resolution.dart';
 import 'ids.dart';
@@ -774,6 +775,56 @@ abstract class MediaServerClient {
   /// cancellation, and malformed-payload failures throw rather than returning
   /// a partial resolution.
   Future<DownloadResolution> resolveDownload(MediaItem item, {int mediaIndex = 0, String? mediaSourceId});
+
+  /// Search server-side remote subtitle providers for [ratingKey].
+  ///
+  /// Backends that do not implement server-proxied subtitle search throw
+  /// [UnsupportedError].
+  Future<List<SubtitleSearchResult>> searchSubtitles(
+    String ratingKey, {
+    required String language,
+    String? title,
+    int mediaIndex = 0,
+    String? mediaSourceId,
+    bool? perfectMatch,
+    bool? forced,
+    bool? hearingImpaired,
+  });
+
+  /// Ask the server to download one remote subtitle and attach it to
+  /// [ratingKey].
+  ///
+  /// [key] is backend-defined (Plex subtitle key, Emby subtitle id).
+  Future<bool> downloadSubtitle(
+    String ratingKey, {
+    required String key,
+    String? codec,
+    String? language,
+    bool hearingImpaired = false,
+    bool forced = false,
+    String? providerTitle,
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  });
+
+  /// Consume a backend-reported source subtitle stream id for a subtitle that
+  /// was just downloaded for [ratingKey].
+  ///
+  /// Returns `null` when the backend does not expose this signal or there is
+  /// no pending downloaded-stream id to consume.
+  Future<int?> consumeDownloadedSubtitleStreamId(
+    String ratingKey, {
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  }) async => null;
+
+  /// Return current source subtitle tracks for [ratingKey] so callers can
+  /// detect newly-attached external subtitle streams.
+  Future<List<MediaSubtitleTrack>> fetchSourceSubtitleTracks(
+    String ratingKey, {
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  });
 
   /// The artwork files the download pipeline should persist for [item] so
   /// the offline UI can render its poster, clear logo, and background art.

--- a/lib/media/media_server_client.dart
+++ b/lib/media/media_server_client.dart
@@ -812,11 +812,8 @@ abstract class MediaServerClient {
   ///
   /// Returns `null` when the backend does not expose this signal or there is
   /// no pending downloaded-stream id to consume.
-  Future<int?> consumeDownloadedSubtitleStreamId(
-    String ratingKey, {
-    int mediaIndex = 0,
-    String? mediaSourceId,
-  }) async => null;
+  Future<int?> consumeDownloadedSubtitleStreamId(String ratingKey, {int mediaIndex = 0, String? mediaSourceId}) async =>
+      null;
 
   /// Return current source subtitle tracks for [ratingKey] so callers can
   /// detect newly-attached external subtitle streams.

--- a/lib/media/server_capabilities.dart
+++ b/lib/media/server_capabilities.dart
@@ -38,7 +38,8 @@ class ServerCapabilities {
   /// playback progress. Plex exposes this directly; Jellyfin does not.
   final bool continueWatchingRemoval;
 
-  /// External subtitle search/marketplace (Plex `/library/metadata/{id}/subtitles`).
+  /// External subtitle search/marketplace (Plex `/library/metadata/{id}/subtitles`,
+  /// Emby `/Items/{id}/RemoteSearch/Subtitles/{language}`).
   /// Hides the "Search subtitles" affordance when false.
   final bool externalSubtitleSearch;
 
@@ -137,7 +138,7 @@ class ServerCapabilities {
     numericUserRating: false,
     userFavorites: true,
     continueWatchingRemoval: true,
-    externalSubtitleSearch: false,
+    externalSubtitleSearch: true,
     richMetadataEdit: true,
     scrubThumbnails: true,
     folderGrouping: true,
@@ -145,10 +146,9 @@ class ServerCapabilities {
   );
 
   /// Every flag here is fixed per backend *kind* except [videoTranscoding],
-  /// which Plex probes per server (`PlexClient.capabilities`) — so that is the
-  /// only override this type needs. Widen the parameter list if another flag
-  /// ever becomes a runtime probe.
-  ServerCapabilities copyWith({bool? videoTranscoding}) {
+  /// which Plex probes per server (`PlexClient.capabilities`). Emby subtitle
+  /// search/download is also runtime-gated by Premiere status.
+  ServerCapabilities copyWith({bool? videoTranscoding, bool? externalSubtitleSearch}) {
     return ServerCapabilities(
       liveTv: liveTv,
       liveTvDvr: liveTvDvr,
@@ -157,7 +157,7 @@ class ServerCapabilities {
       numericUserRating: numericUserRating,
       userFavorites: userFavorites,
       continueWatchingRemoval: continueWatchingRemoval,
-      externalSubtitleSearch: externalSubtitleSearch,
+      externalSubtitleSearch: externalSubtitleSearch ?? this.externalSubtitleSearch,
       richMetadataEdit: richMetadataEdit,
       scrubThumbnails: scrubThumbnails,
       folderGrouping: folderGrouping,

--- a/lib/models/subtitles/subtitle_search_result.dart
+++ b/lib/models/subtitles/subtitle_search_result.dart
@@ -2,10 +2,10 @@ import 'package:json_annotation/json_annotation.dart';
 
 import '../../utils/json_utils.dart';
 
-part 'plex_subtitle_search_result.g.dart';
+part 'subtitle_search_result.g.dart';
 
 @JsonSerializable()
-class PlexSubtitleSearchResult {
+class SubtitleSearchResult {
   @JsonKey(fromJson: flexibleIntOrZero)
   final int id;
   @JsonKey(readValue: readStringField, defaultValue: '')
@@ -33,7 +33,7 @@ class PlexSubtitleSearchResult {
   @JsonKey(fromJson: flexibleBool)
   final bool forced;
 
-  PlexSubtitleSearchResult({
+  SubtitleSearchResult({
     required this.id,
     required this.key,
     this.codec,
@@ -49,7 +49,7 @@ class PlexSubtitleSearchResult {
     this.forced = false,
   });
 
-  factory PlexSubtitleSearchResult.fromJson(Map<String, dynamic> json) => _$PlexSubtitleSearchResultFromJson(json);
+  factory SubtitleSearchResult.fromJson(Map<String, dynamic> json) => _$SubtitleSearchResultFromJson(json);
 
-  Map<String, dynamic> toJson() => _$PlexSubtitleSearchResultToJson(this);
+  Map<String, dynamic> toJson() => _$SubtitleSearchResultToJson(this);
 }

--- a/lib/models/subtitles/subtitle_search_result.g.dart
+++ b/lib/models/subtitles/subtitle_search_result.g.dart
@@ -1,14 +1,12 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-part of 'plex_subtitle_search_result.dart';
+part of 'subtitle_search_result.dart';
 
 // **************************************************************************
 // JsonSerializableGenerator
 // **************************************************************************
 
-PlexSubtitleSearchResult _$PlexSubtitleSearchResultFromJson(
-  Map<String, dynamic> json,
-) => PlexSubtitleSearchResult(
+SubtitleSearchResult _$SubtitleSearchResultFromJson(Map<String, dynamic> json) => SubtitleSearchResult(
   id: flexibleIntOrZero(json['id']),
   key: readStringField(json, 'key') as String? ?? '',
   codec: readStringField(json, 'codec') as String?,
@@ -18,21 +16,13 @@ PlexSubtitleSearchResult _$PlexSubtitleSearchResultFromJson(
   providerTitle: readStringField(json, 'providerTitle') as String?,
   title: readStringField(json, 'title') as String?,
   displayTitle: readStringField(json, 'displayTitle') as String?,
-  hearingImpaired: json['hearingImpaired'] == null
-      ? false
-      : flexibleBool(json['hearingImpaired']),
-  perfectMatch: json['perfectMatch'] == null
-      ? false
-      : flexibleBool(json['perfectMatch']),
-  downloaded: json['downloaded'] == null
-      ? false
-      : flexibleBool(json['downloaded']),
-  forced: json['forced'] == null ? false : flexibleBool(json['forced']),
+  hearingImpaired: flexibleBool(json['hearingImpaired']),
+  perfectMatch: flexibleBool(json['perfectMatch']),
+  downloaded: flexibleBool(json['downloaded']),
+  forced: flexibleBool(json['forced']),
 );
 
-Map<String, dynamic> _$PlexSubtitleSearchResultToJson(
-  PlexSubtitleSearchResult instance,
-) => <String, dynamic>{
+Map<String, dynamic> _$SubtitleSearchResultToJson(SubtitleSearchResult instance) => <String, dynamic>{
   'id': instance.id,
   'key': instance.key,
   'codec': instance.codec,

--- a/lib/models/subtitles/subtitle_search_result.g.dart
+++ b/lib/models/subtitles/subtitle_search_result.g.dart
@@ -6,7 +6,9 @@ part of 'subtitle_search_result.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-SubtitleSearchResult _$SubtitleSearchResultFromJson(Map<String, dynamic> json) => SubtitleSearchResult(
+SubtitleSearchResult _$SubtitleSearchResultFromJson(
+  Map<String, dynamic> json,
+) => SubtitleSearchResult(
   id: flexibleIntOrZero(json['id']),
   key: readStringField(json, 'key') as String? ?? '',
   codec: readStringField(json, 'codec') as String?,
@@ -16,13 +18,21 @@ SubtitleSearchResult _$SubtitleSearchResultFromJson(Map<String, dynamic> json) =
   providerTitle: readStringField(json, 'providerTitle') as String?,
   title: readStringField(json, 'title') as String?,
   displayTitle: readStringField(json, 'displayTitle') as String?,
-  hearingImpaired: flexibleBool(json['hearingImpaired']),
-  perfectMatch: flexibleBool(json['perfectMatch']),
-  downloaded: flexibleBool(json['downloaded']),
-  forced: flexibleBool(json['forced']),
+  hearingImpaired: json['hearingImpaired'] == null
+      ? false
+      : flexibleBool(json['hearingImpaired']),
+  perfectMatch: json['perfectMatch'] == null
+      ? false
+      : flexibleBool(json['perfectMatch']),
+  downloaded: json['downloaded'] == null
+      ? false
+      : flexibleBool(json['downloaded']),
+  forced: json['forced'] == null ? false : flexibleBool(json['forced']),
 );
 
-Map<String, dynamic> _$SubtitleSearchResultToJson(SubtitleSearchResult instance) => <String, dynamic>{
+Map<String, dynamic> _$SubtitleSearchResultToJson(
+  SubtitleSearchResult instance,
+) => <String, dynamic>{
   'id': instance.id,
   'key': instance.key,
   'codec': instance.codec,

--- a/lib/services/jellyfin_client.dart
+++ b/lib/services/jellyfin_client.dart
@@ -42,6 +42,7 @@ import '../models/media_subscription.dart';
 import '../media/media_source_info.dart';
 import '../media/media_sort.dart';
 import '../media/media_version.dart';
+import '../models/subtitles/subtitle_search_result.dart';
 import '../utils/app_logger.dart';
 import '../utils/device_identity.dart';
 import '../utils/failover_http_client.dart';
@@ -57,6 +58,7 @@ import '../exceptions/media_server_exceptions.dart';
 import '../i18n/strings.g.dart';
 import '../utils/json_utils.dart';
 import '../utils/jellyfin_time.dart';
+import '../utils/language_codes.dart';
 import 'jellyfin_auth_header.dart';
 import 'jellyfin_endpoint_discovery.dart';
 import '../media/download_resolution.dart';
@@ -88,6 +90,7 @@ part 'jellyfin_client/parts/file_info.dart';
 part 'jellyfin_client/parts/live_tv.dart';
 part 'jellyfin_client/parts/live_tv_dvr.dart';
 part 'jellyfin_client/parts/images_downloads.dart';
+part 'jellyfin_client/parts/subtitle_search.dart';
 part 'jellyfin_client/parts/metadata_edit.dart';
 
 /// Canonical declarations of the [JellyfinClient] internals that the `part`
@@ -137,6 +140,9 @@ mixin _JellyfinClientInternals on MediaServerCacheMixin {
     bool burnSubtitles,
   });
   String _withApiKey(String urlOrPath);
+
+  void rememberDownloadedSubtitleStreamId(String itemId, String mediaSourceId, int streamId);
+  int? consumeDownloadedSubtitleStreamIdByKey(String itemId, String mediaSourceId);
 
   /// Positional core of the tolerant `/Items` array fetch. The browse part's
   /// implementation widens it with optional retry/abort/diagnostics knobs that
@@ -222,6 +228,7 @@ class JellyfinClient
         _JellyfinFileInfoMethods,
         _JellyfinLiveTvMethods,
         _JellyfinImageDownloadMethods,
+        _JellyfinSubtitleSearchMethods,
         _JellyfinMetadataEditMethods
     implements
         MediaServerClient,
@@ -231,7 +238,13 @@ class JellyfinClient
         GracefullyCloseable {
   JellyfinClient._({required this._connection, required this._http, FavoriteChannelsRepository? favoritesRepository})
     : _favoritesRepository = favoritesRepository ?? const SharedPreferencesFavoriteChannelsRepository(),
-      _paths = MediaBrowserPaths(dialect: _connection.dialect, userId: _connection.userId);
+      _paths = MediaBrowserPaths(dialect: _connection.dialect, userId: _connection.userId) {
+    if (_connection.dialect == MediaBrowserDialect.emby) {
+      // Prime policy-gated capabilities early so UI gates converge quickly
+      // even before the first periodic health sweep.
+      unawaited(_refreshEmbySubtitlePolicy(force: true));
+    }
+  }
 
   /// Build a fully-initialised [JellyfinClient]. Endpoint reachability is
   /// raced before construction by onboarding/profile binding; this factory
@@ -361,6 +374,13 @@ class JellyfinClient
   final FailoverHttpClient _http;
   final FavoriteChannelsRepository _favoritesRepository;
   bool _offlineMode = false;
+  final Map<String, int> _downloadedSubtitleStreamIds = <String, int>{};
+
+  // Runtime gate for Emby subtitle download/search availability.
+  // Emby exposes this as a per-user policy flag on /Users/{id}.
+  bool _embyCanDownloadSubtitles = false;
+  DateTime? _embySubtitlePolicyCheckedAt;
+  Future<void>? _embySubtitlePolicyProbe;
 
   /// Fired when the live `connection` snapshot diverges from the cached one
   /// (currently only on admin-status change). [MultiServerManager] uses this
@@ -372,6 +392,25 @@ class JellyfinClient
     for (final baseUrl in connection.baseUrls) {
       LogRedactionManager.registerServerUrl(baseUrl);
     }
+  }
+
+  static String _subtitleDownloadStreamKey(String itemId, String mediaSourceId) =>
+      '${itemId.trim()}|${mediaSourceId.trim()}';
+
+  @override
+  void rememberDownloadedSubtitleStreamId(String itemId, String mediaSourceId, int streamId) {
+    final item = itemId.trim();
+    final source = mediaSourceId.trim();
+    if (item.isEmpty || source.isEmpty) return;
+    _downloadedSubtitleStreamIds[_subtitleDownloadStreamKey(item, source)] = streamId;
+  }
+
+  @override
+  int? consumeDownloadedSubtitleStreamIdByKey(String itemId, String mediaSourceId) {
+    final item = itemId.trim();
+    final source = mediaSourceId.trim();
+    if (item.isEmpty || source.isEmpty) return null;
+    return _downloadedSubtitleStreamIds.remove(_subtitleDownloadStreamKey(item, source));
   }
 
   Future<void> _handleEndpointSwitch(String newBaseUrl, {required bool persist}) async {
@@ -386,6 +425,66 @@ class JellyfinClient
     if (persist) {
       await onConnectionUpdated?.call(_connection);
     }
+  }
+
+  Future<void> _refreshEmbySubtitlePolicy({bool force = false}) async {
+    if (dialect != MediaBrowserDialect.emby) return;
+
+    final now = DateTime.now();
+    final lastChecked = _embySubtitlePolicyCheckedAt;
+    if (!force && lastChecked != null && now.difference(lastChecked) < const Duration(minutes: 10)) {
+      return;
+    }
+
+    final inFlight = _embySubtitlePolicyProbe;
+    if (inFlight != null) {
+      await inFlight;
+      return;
+    }
+
+    final probe = () async {
+      bool canDownloadSubtitles = false;
+      try {
+        // Emby user policy surfaces subtitle permissions directly.
+        final response = await _http.get(
+          '/Users/${_segment(connection.userId)}',
+          timeout: MediaServerTimeouts.jellyfinProbe,
+        );
+
+        final data = response.data;
+        if (response.statusCode >= 200 && response.statusCode < 300 && data is Map<String, dynamic>) {
+          final policy = data['Policy'];
+          if (policy is Map<String, dynamic>) {
+            canDownloadSubtitles = _embyPolicyAllowsSubtitleDownloading(policy);
+          }
+        }
+      } catch (_) {
+        canDownloadSubtitles = false;
+      }
+
+      _embySubtitlePolicyCheckedAt = now;
+      if (canDownloadSubtitles == _embyCanDownloadSubtitles) return;
+
+      _embyCanDownloadSubtitles = canDownloadSubtitles;
+      appLogger.i('Emby subtitle capability changed: externalSubtitleSearch=$_embyCanDownloadSubtitles');
+      final listener = onConnectionUpdated;
+      if (listener != null) {
+        await Future.sync(() => listener(_connection));
+      }
+    }();
+
+    _embySubtitlePolicyProbe = probe;
+    try {
+      await probe;
+    } finally {
+      if (identical(_embySubtitlePolicyProbe, probe)) {
+        _embySubtitlePolicyProbe = null;
+      }
+    }
+  }
+
+  static bool _embyPolicyAllowsSubtitleDownloading(Map<String, dynamic> policy) {
+    return policy['EnableSubtitleDownloading'] == true || policy['EnableSubtitleManagement'] == true;
   }
 
   /// Read-only view of the headers attached to every outgoing request.
@@ -433,7 +532,8 @@ class JellyfinClient
   @override
   ServerCapabilities get capabilities => switch (dialect) {
     MediaBrowserDialect.jellyfin => ServerCapabilities.jellyfin,
-    MediaBrowserDialect.emby => ServerCapabilities.emby,
+    MediaBrowserDialect.emby =>
+      ServerCapabilities.emby.copyWith(externalSubtitleSearch: _embyCanDownloadSubtitles),
   };
 
   /// Neither dialect exposes a per-server played-threshold pref, so we mirror
@@ -498,6 +598,13 @@ class JellyfinClient
                 appLogger.w('Failed to handle Jellyfin connection update', error: e, stackTrace: st);
               }
             }
+          }
+        }
+        if (dialect == MediaBrowserDialect.emby) {
+          try {
+            await _refreshEmbySubtitlePolicy(force: true);
+          } catch (e, st) {
+            appLogger.w('Failed to refresh Emby subtitle policy', error: e, stackTrace: st);
           }
         }
         return HealthStatus.online;

--- a/lib/services/jellyfin_client.dart
+++ b/lib/services/jellyfin_client.dart
@@ -532,8 +532,7 @@ class JellyfinClient
   @override
   ServerCapabilities get capabilities => switch (dialect) {
     MediaBrowserDialect.jellyfin => ServerCapabilities.jellyfin,
-    MediaBrowserDialect.emby =>
-      ServerCapabilities.emby.copyWith(externalSubtitleSearch: _embyCanDownloadSubtitles),
+    MediaBrowserDialect.emby => ServerCapabilities.emby.copyWith(externalSubtitleSearch: _embyCanDownloadSubtitles),
   };
 
   /// Neither dialect exposes a per-server played-threshold pref, so we mirror

--- a/lib/services/jellyfin_client/parts/subtitle_search.dart
+++ b/lib/services/jellyfin_client/parts/subtitle_search.dart
@@ -113,6 +113,7 @@ mixin _JellyfinSubtitleSearchMethods on _JellyfinClientInternals {
     throwIfHttpError(response);
 
     final data = response.data;
+    await cache.deleteForItem(ServerId(cacheServerId), ratingKey);
     if (data is Map<String, dynamic> && data.containsKey('NewIndex')) {
       final newIndex = flexibleInt(data['NewIndex']);
       if (newIndex != null) {
@@ -142,6 +143,12 @@ mixin _JellyfinSubtitleSearchMethods on _JellyfinClientInternals {
     int mediaIndex = 0,
     String? mediaSourceId,
   }) async {
+    if (dialect == MediaBrowserDialect.emby) {
+      // Emby subtitle downloads mutate stream state asynchronously. The
+      // playback-bundle helper prefers fresh cache for up to 5 minutes, so
+      // evict before each probe to avoid polling a stale stream list.
+      await cache.deleteForItem(ServerId(cacheServerId), ratingKey);
+    }
     final bundle = await fetchPlaybackBundle(ratingKey, sourceIndex: mediaIndex, sourceId: mediaSourceId);
     if (bundle == null) return const <MediaSubtitleTrack>[];
     final info = jellyfinMediaSourceToMediaSourceInfo(

--- a/lib/services/jellyfin_client/parts/subtitle_search.dart
+++ b/lib/services/jellyfin_client/parts/subtitle_search.dart
@@ -126,11 +126,7 @@ mixin _JellyfinSubtitleSearchMethods on _JellyfinClientInternals {
   }
 
   @override
-  Future<int?> consumeDownloadedSubtitleStreamId(
-    String ratingKey, {
-    int mediaIndex = 0,
-    String? mediaSourceId,
-  }) async {
+  Future<int?> consumeDownloadedSubtitleStreamId(String ratingKey, {int mediaIndex = 0, String? mediaSourceId}) async {
     if (dialect != MediaBrowserDialect.emby) return null;
     final sourceId = await _resolveSubtitleMediaSourceId(
       ratingKey,
@@ -146,11 +142,7 @@ mixin _JellyfinSubtitleSearchMethods on _JellyfinClientInternals {
     int mediaIndex = 0,
     String? mediaSourceId,
   }) async {
-    final bundle = await fetchPlaybackBundle(
-      ratingKey,
-      sourceIndex: mediaIndex,
-      sourceId: mediaSourceId,
-    );
+    final bundle = await fetchPlaybackBundle(ratingKey, sourceIndex: mediaIndex, sourceId: mediaSourceId);
     if (bundle == null) return const <MediaSubtitleTrack>[];
     final info = jellyfinMediaSourceToMediaSourceInfo(
       bundle.selectedSource,
@@ -160,11 +152,7 @@ mixin _JellyfinSubtitleSearchMethods on _JellyfinClientInternals {
     return info.subtitleTracks;
   }
 
-  Future<String> _resolveSubtitleMediaSourceId(
-    String itemId, {
-    required int mediaIndex,
-    String? mediaSourceId,
-  }) async {
+  Future<String> _resolveSubtitleMediaSourceId(String itemId, {required int mediaIndex, String? mediaSourceId}) async {
     final requested = mediaSourceId?.trim();
     if (requested != null && requested.isNotEmpty) return requested;
 

--- a/lib/services/jellyfin_client/parts/subtitle_search.dart
+++ b/lib/services/jellyfin_client/parts/subtitle_search.dart
@@ -1,0 +1,187 @@
+part of '../../jellyfin_client.dart';
+
+mixin _JellyfinSubtitleSearchMethods on _JellyfinClientInternals {
+  @override
+  Future<List<SubtitleSearchResult>> searchSubtitles(
+    String ratingKey, {
+    required String language,
+    String? title,
+    int mediaIndex = 0,
+    String? mediaSourceId,
+    bool? perfectMatch,
+    bool? forced,
+    bool? hearingImpaired,
+  }) async {
+    if (dialect != MediaBrowserDialect.emby) {
+      throw UnsupportedError('Remote subtitle search is not supported for ${dialect.productName}');
+    }
+
+    final sourceId = await _resolveSubtitleMediaSourceId(
+      ratingKey,
+      mediaIndex: mediaIndex,
+      mediaSourceId: mediaSourceId,
+    );
+
+    final response = await _http.get(
+      '/Items/${_segment(ratingKey)}/RemoteSearch/Subtitles/${_segment(language)}',
+      queryParameters: {
+        'MediaSourceId': sourceId,
+        'IsPerfectMatch': ?perfectMatch,
+        'IsForced': ?forced,
+        'IsHearingImpaired': ?hearingImpaired,
+      },
+    );
+    throwIfHttpError(response);
+
+    final data = response.data;
+    if (data is! List) return const <SubtitleSearchResult>[];
+
+    final normalizedTitle = title?.trim().toLowerCase();
+    final results = <SubtitleSearchResult>[];
+    for (int i = 0; i < data.length; i++) {
+      final raw = data[i];
+      if (raw is! Map<String, dynamic>) continue;
+      final name = _readString(raw['Name']);
+      if (normalizedTitle != null && normalizedTitle.isNotEmpty) {
+        if (!name.toLowerCase().contains(normalizedTitle)) continue;
+      }
+      final providerTitle = _readStringOrNull(raw['ProviderName']);
+      final languageName = _readStringOrNull(raw['Language']);
+      final format = _readStringOrNull(raw['Format']);
+      final comment = _readStringOrNull(raw['Comment']);
+      final author = _readStringOrNull(raw['Author']);
+      final threeLetter = _readStringOrNull(raw['ThreeLetterISOLanguageName']);
+      final languageCode =
+          LanguageCodes.getIso6391Code(languageName ?? '') ??
+          LanguageCodes.getIso6391Code(threeLetter ?? '') ??
+          LanguageCodes.getIso6391Code(language);
+      final displayTitleParts = <String>[
+        ?providerTitle,
+        if (format != null && format.isNotEmpty) format.toUpperCase(),
+        ?author,
+        if (comment != null && comment.isNotEmpty) comment,
+      ];
+
+      results.add(
+        SubtitleSearchResult(
+          id: i,
+          key: _readString(raw['Id']),
+          codec: format,
+          language: languageName,
+          languageCode: languageCode,
+          score: flexibleDouble(raw['CommunityRating']),
+          providerTitle: providerTitle,
+          title: name,
+          displayTitle: displayTitleParts.isEmpty ? null : displayTitleParts.join(' - '),
+          hearingImpaired: flexibleBool(raw['IsHearingImpaired']),
+          perfectMatch: flexibleBool(raw['IsHashMatch']),
+          downloaded: false,
+          forced: flexibleBool(raw['IsForced']),
+        ),
+      );
+    }
+
+    return results;
+  }
+
+  @override
+  Future<bool> downloadSubtitle(
+    String ratingKey, {
+    required String key,
+    String? codec,
+    String? language,
+    bool hearingImpaired = false,
+    bool forced = false,
+    String? providerTitle,
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  }) async {
+    if (dialect != MediaBrowserDialect.emby) {
+      throw UnsupportedError('Remote subtitle download is not supported for ${dialect.productName}');
+    }
+
+    final sourceId = await _resolveSubtitleMediaSourceId(
+      ratingKey,
+      mediaIndex: mediaIndex,
+      mediaSourceId: mediaSourceId,
+    );
+
+    final response = await _http.post(
+      '/Items/${_segment(ratingKey)}/RemoteSearch/Subtitles/${_segment(key)}',
+      queryParameters: {'MediaSourceId': sourceId},
+    );
+    throwIfHttpError(response);
+
+    final data = response.data;
+    if (data is Map<String, dynamic> && data.containsKey('NewIndex')) {
+      final newIndex = flexibleInt(data['NewIndex']);
+      if (newIndex != null) {
+        rememberDownloadedSubtitleStreamId(ratingKey, sourceId, newIndex);
+        return true;
+      }
+      return false;
+    }
+
+    return response.statusCode >= 200 && response.statusCode < 300;
+  }
+
+  @override
+  Future<int?> consumeDownloadedSubtitleStreamId(
+    String ratingKey, {
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  }) async {
+    if (dialect != MediaBrowserDialect.emby) return null;
+    final sourceId = await _resolveSubtitleMediaSourceId(
+      ratingKey,
+      mediaIndex: mediaIndex,
+      mediaSourceId: mediaSourceId,
+    );
+    return consumeDownloadedSubtitleStreamIdByKey(ratingKey, sourceId);
+  }
+
+  @override
+  Future<List<MediaSubtitleTrack>> fetchSourceSubtitleTracks(
+    String ratingKey, {
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  }) async {
+    final bundle = await fetchPlaybackBundle(
+      ratingKey,
+      sourceIndex: mediaIndex,
+      sourceId: mediaSourceId,
+    );
+    if (bundle == null) return const <MediaSubtitleTrack>[];
+    final info = jellyfinMediaSourceToMediaSourceInfo(
+      bundle.selectedSource,
+      chapters: bundle.chapters,
+      trickplay: bundle.trickplay,
+    );
+    return info.subtitleTracks;
+  }
+
+  Future<String> _resolveSubtitleMediaSourceId(
+    String itemId, {
+    required int mediaIndex,
+    String? mediaSourceId,
+  }) async {
+    final requested = mediaSourceId?.trim();
+    if (requested != null && requested.isNotEmpty) return requested;
+
+    final bundle = await fetchPlaybackBundle(itemId, sourceIndex: mediaIndex, sourceId: requested);
+    final resolved = bundle?.selectedSourceId?.trim();
+    if (resolved != null && resolved.isNotEmpty) return resolved;
+
+    throw StateError('No media source id available for subtitle operation');
+  }
+
+  static String _readString(Object? value) {
+    final text = value is String ? value : value?.toString();
+    return text?.trim() ?? '';
+  }
+
+  static String? _readStringOrNull(Object? value) {
+    final text = _readString(value);
+    return text.isEmpty ? null : text;
+  }
+}

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -47,7 +47,7 @@ import '../models/plex/play_queue_response.dart';
 import '../media/media_file_info.dart';
 import '../media/media_filter.dart';
 import '../media/media_source_info.dart';
-import '../models/plex/plex_subtitle_search_result.dart';
+import '../models/subtitles/subtitle_search_result.dart';
 import '../models/plex/plex_match_result.dart';
 import '../utils/codec_utils.dart';
 import '../utils/content_utils.dart';
@@ -1457,27 +1457,32 @@ class PlexClient
 
   /// Search for subtitles from external providers (e.g. OpenSubtitles) via the Plex server.
   /// [language] is an ISO 639-1 two-letter code (e.g. "en", "es").
-  Future<List<PlexSubtitleSearchResult>> searchSubtitles(
+  @override
+  Future<List<SubtitleSearchResult>> searchSubtitles(
     String ratingKey, {
     required String language,
     String? title,
-    int hearingImpaired = 0,
-    int forced = 0,
+    int mediaIndex = 0,
+    String? mediaSourceId,
+    bool? perfectMatch,
+    bool? forced,
+    bool? hearingImpaired,
   }) async {
-    return _wrapListApiCall<PlexSubtitleSearchResult>(
+    return _wrapListApiCall<SubtitleSearchResult>(
       () => _http.get(
         '/library/metadata/$ratingKey/subtitles',
         queryParameters: {
           'language': language,
           if (title != null && title.isNotEmpty) 'title': title,
-          'hearingImpaired': hearingImpaired,
-          'forced': forced,
+          if (hearingImpaired != null) 'hearingImpaired': hearingImpaired ? 1 : 0,
+          if (forced != null) 'forced': forced ? 1 : 0,
+          if (perfectMatch != null) 'perfectMatch': perfectMatch ? 1 : 0,
         },
       ),
       (response) {
         final container = _getMediaContainer(response);
         final streams = container?['Stream'] as List? ?? [];
-        return streams.map((s) => PlexSubtitleSearchResult.fromJson(s as Map<String, dynamic>)).toList();
+        return streams.map((s) => SubtitleSearchResult.fromJson(s as Map<String, dynamic>)).toList();
       },
       'Failed to search subtitles',
     );
@@ -1485,29 +1490,53 @@ class PlexClient
 
   /// Download a subtitle from an external provider and add it to the media item.
   /// The server downloads the file asynchronously; the new stream appears after a short delay.
+  @override
   Future<bool> downloadSubtitle(
     String ratingKey, {
     required String key,
-    required String codec,
-    required String language,
-    required bool hearingImpaired,
-    required bool forced,
-    required String providerTitle,
+    String? codec,
+    String? language,
+    bool hearingImpaired = false,
+    bool forced = false,
+    String? providerTitle,
+    int mediaIndex = 0,
+    String? mediaSourceId,
   }) async {
     return _wrapBoolApiCall(
       () => _http.put(
         '/library/metadata/$ratingKey/subtitles',
         queryParameters: {
           'key': key,
-          'codec': codec,
-          'language': language,
+          if (codec != null && codec.isNotEmpty) 'codec': codec,
+          if (language != null && language.isNotEmpty) 'language': language,
           'hearingImpaired': hearingImpaired ? 1 : 0,
           'forced': forced ? 1 : 0,
-          'providerTitle': providerTitle,
+          if (providerTitle != null && providerTitle.isNotEmpty) 'providerTitle': providerTitle,
         },
       ),
       'Failed to download subtitle',
     );
+  }
+
+  @override
+  Future<int?> consumeDownloadedSubtitleStreamId(
+    String ratingKey, {
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  }) async => null;
+
+  @override
+  Future<List<MediaSubtitleTrack>> fetchSourceSubtitleTracks(
+    String ratingKey, {
+    int mediaIndex = 0,
+    String? mediaSourceId,
+  }) async {
+    final data = await getVideoPlaybackData(
+      ratingKey,
+      mediaIndex: mediaIndex,
+      selectedMediaSourceId: mediaSourceId,
+    );
+    return data.mediaInfo?.subtitleTracks ?? const <MediaSubtitleTrack>[];
   }
 
   /// Search across all libraries including individually shared items.

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -1502,20 +1502,23 @@ class PlexClient
     int mediaIndex = 0,
     String? mediaSourceId,
   }) async {
-    return _wrapBoolApiCall(
-      () => _http.put(
-        '/library/metadata/$ratingKey/subtitles',
-        queryParameters: {
-          'key': key,
-          if (codec != null && codec.isNotEmpty) 'codec': codec,
-          if (language != null && language.isNotEmpty) 'language': language,
-          'hearingImpaired': hearingImpaired ? 1 : 0,
-          'forced': forced ? 1 : 0,
-          if (providerTitle != null && providerTitle.isNotEmpty) 'providerTitle': providerTitle,
-        },
-      ),
-      'Failed to download subtitle',
+    final response = await _http.put(
+      '/library/metadata/$ratingKey/subtitles',
+      queryParameters: {
+        'key': key,
+        if (codec != null && codec.isNotEmpty) 'codec': codec,
+        if (language != null && language.isNotEmpty) 'language': language,
+        'hearingImpaired': hearingImpaired ? 1 : 0,
+        'forced': forced ? 1 : 0,
+        if (providerTitle != null && providerTitle.isNotEmpty) 'providerTitle': providerTitle,
+      },
     );
+    throwIfHttpError(response);
+    
+    // Invalidate cache so subsequent metadata fetches see the new subtitle
+    await PlexApiCache.instance.deleteForItem(serverId, ratingKey);
+    
+    return response.statusCode >= 200 && response.statusCode < 300;
   }
 
   @override

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -1922,18 +1922,11 @@ class PlexClient
   /// Get consolidated video playback data in one cache-aware API call.
   /// Request/decode failures throw. Only a valid absent metadata/media/part
   /// shape returns an aggregate without a playable URL.
-  ///
-  /// [forceRefresh] skips the fresh-cache fast path so server-side stream
-  /// changes become observable. Required by pollers (the OpenSubtitles
-  /// download flow watches for a new external stream to appear): without it,
-  /// each successful network fetch re-stamps the shared cache row, so every
-  /// later poll inside the freshness window is served the stale snapshot.
   Future<PlexVideoPlaybackData> getVideoPlaybackData(
     String ratingKey, {
     int mediaIndex = 0,
     String? selectedMediaSourceId,
     String? preferredVersionSignature,
-    bool forceRefresh = false,
   }) async {
     // Fresh-cache-first: the detail screen writes a strict superset of this
     // query shape (includeChapters+includeMarkers+includeOnDeck+checkFiles+
@@ -1943,26 +1936,24 @@ class PlexClient
     // staleness, thin row (getPlaybackExtras' lean fetch overwrites the shared
     // row without includeStreams/checkFiles), or shape failure falls through
     // to the network-first fetch below unchanged.
-    if (!forceRefresh) {
-      final freshRow = await cache.getIfFresh(
-        ServerId(cacheServerId),
-        '/library/metadata/$ratingKey',
-        maxAge: playbackMetadataCacheFreshness,
-      );
-      if (freshRow != null) {
-        try {
-          final cachedMetadataJson = _validatedPlaybackMetadataJson(freshRow);
-          if (cachedMetadataJson != null && _plexMetadataHasStreamDetail(cachedMetadataJson)) {
-            return parseVideoPlaybackDataFromJson(
-              cachedMetadataJson,
-              mediaIndex: mediaIndex,
-              selectedMediaSourceId: selectedMediaSourceId,
-              preferredVersionSignature: preferredVersionSignature,
-            );
-          }
-        } on FormatException {
-          // Malformed cached row: the network fetch below overwrites it.
+    final freshRow = await cache.getIfFresh(
+      ServerId(cacheServerId),
+      '/library/metadata/$ratingKey',
+      maxAge: playbackMetadataCacheFreshness,
+    );
+    if (freshRow != null) {
+      try {
+        final cachedMetadataJson = _validatedPlaybackMetadataJson(freshRow);
+        if (cachedMetadataJson != null && _plexMetadataHasStreamDetail(cachedMetadataJson)) {
+          return parseVideoPlaybackDataFromJson(
+            cachedMetadataJson,
+            mediaIndex: mediaIndex,
+            selectedMediaSourceId: selectedMediaSourceId,
+            preferredVersionSignature: preferredVersionSignature,
+          );
         }
+      } on FormatException {
+        // Malformed cached row: the network fetch below overwrites it.
       }
     }
     final data = await fetchWithCacheFallback<Map<String, dynamic>>(

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -1519,11 +1519,8 @@ class PlexClient
   }
 
   @override
-  Future<int?> consumeDownloadedSubtitleStreamId(
-    String ratingKey, {
-    int mediaIndex = 0,
-    String? mediaSourceId,
-  }) async => null;
+  Future<int?> consumeDownloadedSubtitleStreamId(String ratingKey, {int mediaIndex = 0, String? mediaSourceId}) async =>
+      null;
 
   @override
   Future<List<MediaSubtitleTrack>> fetchSourceSubtitleTracks(
@@ -1531,11 +1528,7 @@ class PlexClient
     int mediaIndex = 0,
     String? mediaSourceId,
   }) async {
-    final data = await getVideoPlaybackData(
-      ratingKey,
-      mediaIndex: mediaIndex,
-      selectedMediaSourceId: mediaSourceId,
-    );
+    final data = await getVideoPlaybackData(ratingKey, mediaIndex: mediaIndex, selectedMediaSourceId: mediaSourceId);
     return data.mediaInfo?.subtitleTracks ?? const <MediaSubtitleTrack>[];
   }
 

--- a/lib/widgets/video_controls/models/track_controls_state.dart
+++ b/lib/widgets/video_controls/models/track_controls_state.dart
@@ -70,11 +70,15 @@ class TrackControlsState {
   /// Item currently playing, used to key scope-persisted player settings
   /// ([ScopedPlayerPrefs]). Null only for embedders without item identity.
   final MediaItem? metadata;
-  final Future<SubtitleDownloadApplyOutcome> Function({required String serverId, required String ratingKey})?
+  final Future<SubtitleDownloadApplyOutcome> Function({
+    required String serverId,
+    required String ratingKey,
+    String? preferredLanguageCode,
+  })?
   onSubtitleDownloaded;
 
-  /// Whether OpenSubtitles search is reachable for this server. The Plex
-  /// server proxies the OpenSubtitles plugin; Jellyfin doesn't expose an
+  /// Whether remote subtitle search is reachable for this server. Plex
+  /// and Emby servers proxy remote subtitle providers; Jellyfin doesn't expose an
   /// equivalent. The track sheet hides the "Search subtitles" tile when
   /// this is false.
   final bool subtitleSearchSupported;
@@ -156,7 +160,7 @@ class TrackControlsState {
       : const <MediaSubtitleTrack>[];
 
   /// External subtitle search needs both a searchable media item and a server
-  /// that can proxy the OpenSubtitles request.
+  /// that can proxy the remote-subtitle request.
   bool get canSearchSubtitles =>
       ratingKey.isNotEmpty && serverId != null && serverId!.isNotEmpty && subtitleSearchSupported;
 

--- a/lib/widgets/video_controls/parts/navigation.dart
+++ b/lib/widgets/video_controls/parts/navigation.dart
@@ -177,7 +177,30 @@ extension _VideoControlsNavigationMethods on _PlexVideoControlsState {
       if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
       if (newTrack == null) return SubtitleDownloadApplyOutcome.timedOut;
       final outcome = await switchSource(newSubtitleChoice: PlaybackSourceSubtitleChoice.source(newTrack.id));
-      return subtitleDownloadApplyOutcomeFor(outcome);
+      final mappedOutcome = subtitleDownloadApplyOutcomeFor(outcome);
+      if (mappedOutcome != SubtitleDownloadApplyOutcome.applied) return mappedOutcome;
+
+      final expectedSelectedStreamId = expectedDownloadedStreamId ?? newTrack.id;
+      for (var attempt = 0; attempt < 4; attempt++) {
+        if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
+        try {
+          final tracks = await client.fetchSourceSubtitleTracks(
+            ratingKey,
+            mediaIndex: widget.selectedMediaIndex,
+          );
+          if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
+          final selectedNow = tracks.any(
+            (track) => track.id == expectedSelectedStreamId && track.selected,
+          );
+          if (selectedNow) return mappedOutcome;
+        } catch (e) {
+          appLogger.w('Failed to verify downloaded subtitle selection state', error: e);
+        }
+        if (attempt < 3) {
+          await Future.delayed(const Duration(seconds: 1));
+        }
+      }
+      return SubtitleDownloadApplyOutcome.timedOut;
     } catch (e) {
       appLogger.w('Failed to refresh subtitles after download', error: e);
       return SubtitleDownloadApplyOutcome.failed;

--- a/lib/widgets/video_controls/parts/navigation.dart
+++ b/lib/widgets/video_controls/parts/navigation.dart
@@ -179,6 +179,7 @@ extension _VideoControlsNavigationMethods on _PlexVideoControlsState {
       final outcome = await switchSource(newSubtitleChoice: PlaybackSourceSubtitleChoice.source(newTrack.id));
       final mappedOutcome = subtitleDownloadApplyOutcomeFor(outcome);
       if (mappedOutcome != SubtitleDownloadApplyOutcome.applied) return mappedOutcome;
+      if (client.backend != MediaBackend.plex) return mappedOutcome;
 
       final expectedSelectedStreamId = expectedDownloadedStreamId ?? newTrack.id;
       for (var attempt = 0; attempt < 4; attempt++) {

--- a/lib/widgets/video_controls/parts/navigation.dart
+++ b/lib/widgets/video_controls/parts/navigation.dart
@@ -141,18 +141,12 @@ extension _VideoControlsNavigationMethods on _PlexVideoControlsState {
 
         try {
           if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
-          final tracks = await client.fetchSourceSubtitleTracks(
-            ratingKey,
-            mediaIndex: widget.selectedMediaIndex,
-          );
+          final tracks = await client.fetchSourceSubtitleTracks(ratingKey, mediaIndex: widget.selectedMediaIndex);
           if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
           if (expectedDownloadedStreamId != null) {
             final exactMatch = tracks.where((track) => track.id == expectedDownloadedStreamId).toList(growable: false);
             if (exactMatch.isNotEmpty) {
-              newTrack = exactMatch.firstWhere(
-                (track) => track.isExternalFile,
-                orElse: () => exactMatch.first,
-              );
+              newTrack = exactMatch.firstWhere((track) => track.isExternalFile, orElse: () => exactMatch.first);
               break;
             }
 

--- a/lib/widgets/video_controls/parts/navigation.dart
+++ b/lib/widgets/video_controls/parts/navigation.dart
@@ -1,6 +1,6 @@
 part of '../video_controls.dart';
 
-extension _PlexVideoControlsNavigationMethods on _PlexVideoControlsState {
+extension _VideoControlsNavigationMethods on _PlexVideoControlsState {
   Widget _buildDesktopControlsListener() {
     final playbackState = context.watch<PlaybackStateProvider>();
     final trackControlsState = _buildTrackControlsState(
@@ -77,14 +77,9 @@ extension _PlexVideoControlsNavigationMethods on _PlexVideoControlsState {
   Future<SubtitleDownloadApplyOutcome> _onSubtitleDownloaded({
     required String serverId,
     required String ratingKey,
+    String? preferredLanguageCode,
   }) async {
     if (!mounted) return SubtitleDownloadApplyOutcome.unavailable;
-
-    // Plex-only: the OpenSubtitles polling flow uses [getVideoPlaybackData]
-    // and the Plex token. Jellyfin has no analogue and the entry point
-    // (`subtitleSearchSupported`) is already gated on backend, but guard
-    // here too in case a future caller wires the same handler elsewhere.
-    if (widget.metadata.backend != MediaBackend.plex) return SubtitleDownloadApplyOutcome.unavailable;
     if (widget.metadata.serverId != serverId || widget.metadata.id != ratingKey) {
       return SubtitleDownloadApplyOutcome.superseded;
     }
@@ -99,14 +94,43 @@ extension _PlexVideoControlsNavigationMethods on _PlexVideoControlsState {
         widget.metadata.id == ratingKey;
 
     try {
-      final client = context.getPlexClientForServer(ServerId(serverId));
+      final client = context.getMediaClientForServer(ServerId(serverId));
+      final expectedDownloadedStreamId = await client.consumeDownloadedSubtitleStreamId(
+        ratingKey,
+        mediaIndex: widget.selectedMediaIndex,
+      );
 
-      // Plex's OpenSubtitles download is asynchronous: the PUT returns immediately
-      // but the new stream entry shows up in metadata seconds later. Poll until it
-      // appears. Up to 15s matches what Plex-web tolerates before giving up.
+      if (expectedDownloadedStreamId != null) {
+        final immediateOutcome = await switchSource(
+          newSubtitleChoice: PlaybackSourceSubtitleChoice.source(expectedDownloadedStreamId),
+        );
+        final mappedImmediateOutcome = subtitleDownloadApplyOutcomeFor(immediateOutcome);
+        if (mappedImmediateOutcome == SubtitleDownloadApplyOutcome.applied) {
+          try {
+            final tracksAfterImmediateApply = await client.fetchSourceSubtitleTracks(
+              ratingKey,
+              mediaIndex: widget.selectedMediaIndex,
+            );
+            final selectedNow = tracksAfterImmediateApply.any(
+              (track) => track.id == expectedDownloadedStreamId && track.selected,
+            );
+            if (selectedNow) {
+              return mappedImmediateOutcome;
+            }
+          } catch (e) {
+            appLogger.w('Failed to verify immediate subtitle apply state', error: e);
+          }
+        }
+      }
+
+      // Server-side subtitle download is asynchronous: apply polls until the
+      // new stream appears on the active media source.
       // Snapshot the authoritative source IDs so we can identify the new
       // download without asking mpv to synchronously open its remote URL.
       final existingSourceIds = widget.sourceSubtitleTracks.map((track) => track.id).toSet();
+      final currentSelectedSourceId = widget.selectedSubtitleChoice?.isOff == false
+          ? widget.selectedSubtitleChoice?.sourceStreamId
+          : null;
 
       final deadline = DateTime.now().add(const Duration(seconds: 15));
       MediaSubtitleTrack? newTrack;
@@ -117,11 +141,38 @@ extension _PlexVideoControlsNavigationMethods on _PlexVideoControlsState {
 
         try {
           if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
-          final data = await client.getVideoPlaybackData(ratingKey);
+          final tracks = await client.fetchSourceSubtitleTracks(
+            ratingKey,
+            mediaIndex: widget.selectedMediaIndex,
+          );
           if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
-          if (data.mediaInfo == null) continue;
+          if (expectedDownloadedStreamId != null) {
+            final exactMatch = tracks.where((track) => track.id == expectedDownloadedStreamId).toList(growable: false);
+            if (exactMatch.isNotEmpty) {
+              newTrack = exactMatch.firstWhere(
+                (track) => track.isExternalFile,
+                orElse: () => exactMatch.first,
+              );
+              break;
+            }
 
-          newTrack = findNewExternalSubtitleTrack(data.mediaInfo!.subtitleTracks, existingSourceIds);
+            final retryOutcome = await switchSource(
+              newSubtitleChoice: PlaybackSourceSubtitleChoice.source(expectedDownloadedStreamId),
+            );
+            final mappedRetryOutcome = subtitleDownloadApplyOutcomeFor(retryOutcome);
+            if (mappedRetryOutcome == SubtitleDownloadApplyOutcome.applied) {
+              // A reload may settle before the refreshed source-track view marks
+              // the downloaded stream selected. Keep polling until selection is
+              // observable to avoid reporting a false success.
+              continue;
+            }
+          }
+          newTrack = findDownloadedExternalSubtitleTrack(
+            tracks,
+            existingSourceIds,
+            preferredLanguageCode: preferredLanguageCode,
+            currentSelectedSourceId: currentSelectedSourceId,
+          );
           if (newTrack != null) break;
         } catch (e) {
           appLogger.w('Subtitle download poll iteration failed', error: e);

--- a/lib/widgets/video_controls/parts/navigation.dart
+++ b/lib/widgets/video_controls/parts/navigation.dart
@@ -117,10 +117,7 @@ extension _PlexVideoControlsNavigationMethods on _PlexVideoControlsState {
 
         try {
           if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
-          // forceRefresh: playback start left a fresh /library/metadata row in
-          // the cache (and each network poll would re-stamp it), so a
-          // cache-eligible read here would never observe the new stream.
-          final data = await client.getVideoPlaybackData(ratingKey, forceRefresh: true);
+          final data = await client.getVideoPlaybackData(ratingKey);
           if (!targetIsCurrent()) return SubtitleDownloadApplyOutcome.superseded;
           if (data.mediaInfo == null) continue;
 

--- a/lib/widgets/video_controls/parts/track_controls.dart
+++ b/lib/widgets/video_controls/parts/track_controls.dart
@@ -225,18 +225,13 @@ extension _PlexVideoControlsTrackMethods on _PlexVideoControlsState {
       ratingKey: widget.metadata.id,
       mediaTitle: widget.metadata.title,
       onSubtitleDownloaded: _onSubtitleDownloaded,
-      // Plex proxies OpenSubtitles via its server-side plugin; Jellyfin
-      // doesn't expose an equivalent so the Search Subtitles tile is hidden
-      // for Jellyfin items. The check uses the registered client type for
-      // this metadata's serverId.
-      subtitleSearchSupported: _isPlexBackedMetadata(),
+      // Search Subtitles is gated by backend capabilities (Plex, Emby).
+      subtitleSearchSupported: _supportsSubtitleSearch(),
     );
   }
 
-  /// True when the active server supports external subtitle search (Plex
-  /// today). Requires a server id because the download callback needs the
-  /// Plex client/token for that server.
-  bool _isPlexBackedMetadata() {
+  /// True when the active server advertises server-side subtitle search.
+  bool _supportsSubtitleSearch() {
     try {
       final serverId = widget.metadata.serverId;
       if (serverId == null) return false;

--- a/lib/widgets/video_controls/sheets/subtitle_search_sheet.dart
+++ b/lib/widgets/video_controls/sheets/subtitle_search_sheet.dart
@@ -9,7 +9,7 @@ import '../../../focus/focusable_text_field.dart';
 import '../../../focus/input_mode_tracker.dart';
 import '../../../i18n/strings.g.dart';
 import '../../../mixins/controller_disposer_mixin.dart';
-import '../../../models/plex/plex_subtitle_search_result.dart';
+import '../../../models/subtitles/subtitle_search_result.dart';
 import '../../../services/settings_service.dart';
 import '../../../utils/language_codes.dart';
 import '../../../utils/provider_extensions.dart';
@@ -32,14 +32,20 @@ String resolveSubtitleSearchLanguageCode({String? savedLanguageCode, required Lo
 class SubtitleSearchSheet extends StatefulWidget {
   final String ratingKey;
   final String serverId;
+  final int mediaIndex;
   final String? mediaTitle;
-  final Future<SubtitleDownloadApplyOutcome> Function({required String serverId, required String ratingKey})?
+  final Future<SubtitleDownloadApplyOutcome> Function({
+    required String serverId,
+    required String ratingKey,
+    String? preferredLanguageCode,
+  })?
   onSubtitleDownloaded;
 
   const SubtitleSearchSheet({
     super.key,
     required this.ratingKey,
     required this.serverId,
+    this.mediaIndex = 0,
     this.mediaTitle,
     this.onSubtitleDownloaded,
   });
@@ -57,7 +63,7 @@ class _SubtitleSearchSheetState extends State<SubtitleSearchSheet> with Controll
   final _firstResultFocusNode = FocusNode(debugLabel: 'SubtitleSearch_firstResult');
   Timer? _debounceTimer;
 
-  List<PlexSubtitleSearchResult>? _results;
+  List<SubtitleSearchResult>? _results;
   bool _isSearching = false;
   String? _error;
   String? _downloadingKey;
@@ -102,7 +108,7 @@ class _SubtitleSearchSheetState extends State<SubtitleSearchSheet> with Controll
     });
 
     try {
-      final client = context.tryGetPlexClientForServer(ServerId(widget.serverId));
+      final client = context.tryGetMediaClientForServer(ServerId(widget.serverId));
       if (client == null) {
         if (!mounted || generation != _searchGeneration) return;
         setState(() => _isSearching = false);
@@ -114,6 +120,7 @@ class _SubtitleSearchSheetState extends State<SubtitleSearchSheet> with Controll
         widget.ratingKey,
         language: language,
         title: title.isEmpty ? null : title,
+        mediaIndex: widget.mediaIndex,
       );
       if (!mounted || generation != _searchGeneration) return;
       setState(() {
@@ -178,12 +185,12 @@ class _SubtitleSearchSheetState extends State<SubtitleSearchSheet> with Controll
     _search();
   }
 
-  Future<void> _downloadSubtitle(PlexSubtitleSearchResult result) async {
+  Future<void> _downloadSubtitle(SubtitleSearchResult result) async {
     if (_downloadingKey != null) return;
     setState(() => _downloadingKey = result.key);
 
     try {
-      final client = context.tryGetPlexClientForServer(ServerId(widget.serverId));
+      final client = context.tryGetMediaClientForServer(ServerId(widget.serverId));
       if (client == null) {
         if (!mounted) return;
         setState(() => _downloadingKey = null);
@@ -197,13 +204,18 @@ class _SubtitleSearchSheetState extends State<SubtitleSearchSheet> with Controll
         hearingImpaired: result.hearingImpaired,
         forced: result.forced,
         providerTitle: result.providerTitle ?? '',
+        mediaIndex: widget.mediaIndex,
       );
 
       if (!mounted) return;
 
       if (success) {
         final outcome =
-            await widget.onSubtitleDownloaded?.call(serverId: widget.serverId, ratingKey: widget.ratingKey) ??
+            await widget.onSubtitleDownloaded?.call(
+              serverId: widget.serverId,
+              ratingKey: widget.ratingKey,
+              preferredLanguageCode: result.languageCode ?? _languageCode,
+            ) ??
             SubtitleDownloadApplyOutcome.unavailable;
         if (!mounted) return;
         if (outcome == SubtitleDownloadApplyOutcome.applied) {

--- a/lib/widgets/video_controls/sheets/track_sheet.dart
+++ b/lib/widgets/video_controls/sheets/track_sheet.dart
@@ -456,6 +456,7 @@ List<Widget> _buildSubtitleSearchFooter(BuildContext context, TrackControlsState
           builder: (_) => SubtitleSearchSheet(
             ratingKey: state.ratingKey,
             serverId: state.serverId!,
+            mediaIndex: state.selectedMediaIndex,
             mediaTitle: state.mediaTitle,
             onSubtitleDownloaded: state.onSubtitleDownloaded,
           ),

--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -44,7 +44,6 @@ import '../../focus/focus_navigation_intent.dart';
 import '../../focus/transport_keys.dart';
 
 import '../../database/app_database.dart';
-import '../../media/media_backend.dart';
 import '../../media/media_item.dart';
 import '../../media/stepped_seek.dart';
 import '../../models/livetv_capture_buffer.dart';
@@ -152,8 +151,39 @@ List<MediaSubtitleTrack> selectableSourceSubtitleTracks(
 @visibleForTesting
 MediaSubtitleTrack? findNewExternalSubtitleTrack(List<MediaSubtitleTrack> tracks, Set<int> existingSourceIds) {
   for (final track in tracks) {
-    if (track.isExternal && !existingSourceIds.contains(track.id)) return track;
+    if (track.isExternalFile && !existingSourceIds.contains(track.id)) return track;
   }
+  return null;
+}
+
+@visibleForTesting
+MediaSubtitleTrack? findDownloadedExternalSubtitleTrack(
+  List<MediaSubtitleTrack> tracks,
+  Set<int> existingSourceIds, {
+  String? preferredLanguageCode,
+  int? currentSelectedSourceId,
+}) {
+  final newTrack = findNewExternalSubtitleTrack(tracks, existingSourceIds);
+  if (newTrack != null) return newTrack;
+
+  final externalFileCandidates = tracks
+      .where((track) => track.isExternalFile && track.id != currentSelectedSourceId)
+      .toList(growable: false);
+  if (externalFileCandidates.isEmpty) return null;
+
+  final normalizedPreferred = preferredLanguageCode?.trim().toLowerCase().split(RegExp('[-_]')).first;
+  if (normalizedPreferred == null || normalizedPreferred.isEmpty) return null;
+
+  final codeMatches = externalFileCandidates
+      .where((track) => track.languageCode?.trim().toLowerCase().split(RegExp('[-_]')).first == normalizedPreferred)
+      .toList(growable: false);
+  if (codeMatches.length == 1) return codeMatches.first;
+
+  final languageMatches = externalFileCandidates
+      .where((track) => track.language?.trim().toLowerCase() == normalizedPreferred)
+      .toList(growable: false);
+  if (languageMatches.length == 1) return languageMatches.first;
+
   return null;
 }
 

--- a/lib/widgets/video_controls/video_controls.dart
+++ b/lib/widgets/video_controls/video_controls.dart
@@ -44,6 +44,7 @@ import '../../focus/focus_navigation_intent.dart';
 import '../../focus/transport_keys.dart';
 
 import '../../database/app_database.dart';
+import '../../media/media_backend.dart';
 import '../../media/media_item.dart';
 import '../../media/stepped_seek.dart';
 import '../../models/livetv_capture_buffer.dart';
@@ -166,8 +167,12 @@ MediaSubtitleTrack? findDownloadedExternalSubtitleTrack(
   final newTrack = findNewExternalSubtitleTrack(tracks, existingSourceIds);
   if (newTrack != null) return newTrack;
 
+  // Plex downloaded subtitles have a `key` but aren't marked as `isExternalFile`.
+  // Include tracks with a non-empty `key` as potential downloaded subtitles.
   final externalFileCandidates = tracks
-      .where((track) => track.isExternalFile && track.id != currentSelectedSourceId)
+      .where((track) => 
+          (track.isExternalFile || (track.key != null && track.key!.isNotEmpty)) 
+          && track.id != currentSelectedSourceId)
       .toList(growable: false);
   if (externalFileCandidates.isEmpty) return null;
 

--- a/test/services/plex_playback_data_request_test.dart
+++ b/test/services/plex_playback_data_request_test.dart
@@ -318,21 +318,6 @@ void main() {
       expect(data.mediaInfo?.subtitleTracks.single.id, 401);
     });
 
-    test('forceRefresh bypasses a fresh stream-rich cached row', () async {
-      // The subtitle-download poller relies on this: it must observe the new
-      // external stream appearing server-side while the shared row is fresh.
-      await PlexApiCache.instance.put(cacheScope, endpoint, richPlaybackPayload());
-      final requests = <Uri>[];
-      final client = makeCountingClient(requests);
-      addTearDown(client.close);
-
-      final data = await client.getVideoPlaybackData('42', forceRefresh: true);
-
-      expect(requests, hasLength(1));
-      expect(requests.single.queryParameters['includeStreams'], '1');
-      expect(data.mediaInfo?.subtitleTracks.single.id, 401);
-    });
-
     test('fresh but stream-less cached row still fetches from the network', () async {
       // getPlaybackExtras' lean fetch overwrites the shared row without
       // includeStreams/checkFiles; that shape must never satisfy playback.


### PR DESCRIPTION
## Summary

Adds Emby subtitle search/download support and wires it through the existing subtitle controls flow.

This also generalizes the previous Plex-only subtitle search path into a backend-neutral model/API so Plex and Emby can use the same UI and apply pipeline.

## What changed

- added Emby remote subtitle search via `/Items/{id}/RemoteSearch/Subtitles/{language}`
- added Emby subtitle download support via the remote subtitle download endpoint
- added post-download apply handling for Emby, including use of `NewIndex` when the server returns it
- generalized subtitle search result handling from Plex-specific to shared subtitle DTOs
- extended the media client interface with shared subtitle search/download/source-track hooks
- updated Plex to use the shared subtitle search abstractions
- gated subtitle search visibility for Emby using user policy flags
- updated track controls/search sheet flow to work against backend capabilities instead of Plex-only assumptions

## Notes

- `TEMPFORDEV` and debugging-only instrumentation were removed and are not part of this change.
- The remaining diff is only product code for the subtitle feature.
- The Emby capability gate now follows the explicit subtitle policy flags instead of Premiere heuristics.

## Validation

- verified Linux build/debug runs during implementation
- validated touched files with `flutter analyze`
- manually tested Emby subtitle search and download flow
- confirmed downloaded subtitles appear in Emby and in Plezy
- confirmed subtitle search gating behavior follows current server policy responses

## Follow-up / caveat

The visibility gate now intentionally trusts Emby’s subtitle policy flags (`EnableSubtitleDownloading` / `EnableSubtitleManagement`). If a non-Premiere server reports those as enabled, Plezy will expose subtitle search accordingly because no stronger Premiere-specific signal was found.