### PR TITLE
feat(player): enable clickVideoTogglesPlayback by default on desktop

### DIFF
--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -473,7 +473,10 @@ class SettingsService extends BaseSharedPreferencesService {
   /// selections instead of carrying the current choice over (#1717).
   static const followServerTrackSelections = BoolPref('follow_server_track_selections');
   static const showChapterMarkersOnTimeline = BoolPref('show_chapter_markers_on_timeline', defaultValue: true);
-  static const clickVideoTogglesPlayback = BoolPref('click_video_toggles_playback');
+  static const clickVideoTogglesPlayback = BoolPref(
+    'click_video_toggles_playback',
+    defaultValueProvider: PlatformDetector.isDesktopOS,
+  );
   static const autoSkipIntro = BoolPref('auto_skip_intro');
   static const autoSkipCredits = BoolPref('auto_skip_credits');
   static const forceSkipMarkerFallback = BoolPref('force_skip_marker_fallback');

--- a/test/services/settings_service_test.dart
+++ b/test/services/settings_service_test.dart
@@ -20,6 +20,7 @@ void main() {
   tearDown(() {
     TvDetectionService.debugSetAppleTVOverride(null);
     TvDetectionService.debugSetAutomotiveOverride(null);
+    PlatformDetector.debugSetIsDesktopOSOverride(null);
   });
 
   group('SettingsService.parseMpvConfigText', () {
@@ -192,6 +193,21 @@ void main() {
 
       await settings.write(SettingsService.audioPassthrough, false);
       expect(settings.read(SettingsService.audioPassthrough), isFalse);
+    });
+
+    test('click to toggle playback defaults on for desktop only and keeps an explicit opt-out', () async {
+      final settings = await SettingsService.getInstance();
+
+      PlatformDetector.debugSetIsDesktopOSOverride(true);
+      expect(settings.read(SettingsService.clickVideoTogglesPlayback), isTrue);
+
+      PlatformDetector.debugSetIsDesktopOSOverride(false);
+      expect(settings.read(SettingsService.clickVideoTogglesPlayback), isFalse);
+
+      // A desktop user who turned it off before the default flipped stays off.
+      PlatformDetector.debugSetIsDesktopOSOverride(true);
+      await settings.write(SettingsService.clickVideoTogglesPlayback, false);
+      expect(settings.read(SettingsService.clickVideoTogglesPlayback), isFalse);
     });
 
     test('forces external player off on Apple TV even when stored enabled', () async {


### PR DESCRIPTION
enables click to play/pause on Desktop Clients by default

For the first months of using Plezy I really missed being able to just click on the video to play/pause. I only just found out that this is implemented but disabled by default.
IMO such an intuitive control should be enabled by default, as it is how users interact with other players too.