### PR TITLE
Small Update de.i18n.json

### DIFF
--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -1034,7 +1034,7 @@
       "productionYear": "Produktionsjahr",
       "runtime": "Laufzeit",
       "officialRating": "Offizielle Bewertung",
-      "premiereDate": "Premierendatum",
+      "premiereDate": "Veröffentlichungsdatum",
       "startDate": "Startdatum",
       "airTime": "Sendezeit",
       "studio": "Studio",


### PR DESCRIPTION
The german word for the premieredate is better known as "Veröffentlichungsdatum".

Premierendatum is more "Date of the premier", while "Veröffentlichungsdatum" is more like "Date of the release".

Emby uses "Veröffentlichungsdatum", Plex uses "Erscheinungsdatum", which is closer to "Date of arrival". Both Erscheinungsdatum and Veröffentlichungsdatum are better known and are white pattern-search for the filter thats behind it, as service like AV, NF and similar also use one of those.