### PR TITLE
feat(seerr): sign in with Jellyfin Quick Connect and accept bare-host URLs

### DIFF
--- a/lib/models/seerr/seerr_session.dart
+++ b/lib/models/seerr/seerr_session.dart
@@ -15,6 +15,11 @@ enum SeerrAuthMethod {
 
   /// `POST /auth/local` with stored email/password.
   local,
+
+  /// `POST /auth/jellyfin/quickconnect/authenticate` (Seerr 3.4+). No stored
+  /// secret — silent re-auth is impossible, so an expired cookie unlinks the
+  /// session and the user reconnects with a fresh code.
+  quickConnect,
 }
 
 /// Which Seerr product the instance runs. The two products disagree on

--- a/lib/screens/settings/seerr_connect_screen.dart
+++ b/lib/screens/settings/seerr_connect_screen.dart
@@ -9,6 +9,7 @@ import '../../mixins/controller_disposer_mixin.dart';
 import '../../models/seerr/seerr_public_settings.dart';
 import '../../models/seerr/seerr_session.dart';
 import '../../providers/seerr_account_provider.dart';
+import '../../services/seerr/seerr_auth_service.dart';
 import '../../services/seerr/seerr_constants.dart';
 import '../../services/seerr/seerr_exceptions.dart';
 import '../../theme/mono_tokens.dart';
@@ -21,10 +22,13 @@ import 'async_form_state_mixin.dart';
 enum _CredentialForm { none, jellyfin, emby, local }
 
 /// Two-step Seerr connect flow:
-///   1. Probe the instance URL (`/settings/public`).
+///   1. Probe the instance URL (`/settings/public`), expanding schemeless
+///      input into https/http/default-port candidates like the MediaBrowser
+///      add-server form.
 ///   2. Sign in with one of the methods the instance supports — one-tap
 ///      Plex (reusing the profile's stored token), Jellyfin/Emby
-///      credentials, or a local Seerr account.
+///      credentials, Jellyfin Quick Connect (Seerr 3.4+), or a local Seerr
+///      account.
 ///
 /// The finished [SeerrSession] is handed to [SeerrAccountProvider.adoptSession]
 /// and the screen pops.
@@ -44,20 +48,31 @@ class _SeerrConnectScreenState extends State<SeerrConnectScreen> with AsyncFormS
   final _changeServerFocus = FocusNode(debugLabel: 'SeerrConnect:ChangeServer');
   final _identifierFocus = FocusNode(debugLabel: 'SeerrConnect:Identifier');
   final _passwordFocus = FocusNode(debugLabel: 'SeerrConnect:Password');
+  final _quickConnectFocus = FocusNode(debugLabel: 'SeerrConnect:QuickConnect');
+  final _cancelQuickConnectFocus = FocusNode(debugLabel: 'SeerrConnect:CancelQuickConnect');
   final _formKey = GlobalKey<FormState>();
 
   SeerrPublicSettings? _instance;
   String _baseUrl = '';
   bool _plexTokenAvailable = false;
   _CredentialForm _form = _CredentialForm.none;
+  SeerrQuickConnectInitiation? _qcInitiation;
+  bool _qcCancelled = false;
+  int _qcAttemptId = 0;
 
   @override
   void dispose() {
+    // Short-circuit any in-flight Quick Connect poll so it doesn't try to
+    // setState after the widget is gone.
+    _qcCancelled = true;
+    _qcAttemptId++;
     _urlFocus.dispose();
     _continueFocus.dispose();
     _changeServerFocus.dispose();
     _identifierFocus.dispose();
     _passwordFocus.dispose();
+    _quickConnectFocus.dispose();
+    _cancelQuickConnectFocus.dispose();
     super.dispose();
   }
 
@@ -85,16 +100,17 @@ class _SeerrConnectScreenState extends State<SeerrConnectScreen> with AsyncFormS
       setErrorText(t.addServer.required);
       return;
     }
-    // Bare hosts are common ("seerr.example.com") — default to https.
-    final url = input.contains('://') ? input : 'https://$input';
     await runAsync<void>(() async {
       final account = context.read<SeerrAccountProvider>();
-      final settings = await account.authService.probe(url);
+      // Bare hosts are common ("seerr.example.com") — race https, plain http
+      // and the default install port, like the MediaBrowser add-server form.
+      final reached = await account.authService.probeFirstReachable(input);
+      final settings = reached.settings;
       final plexToken = await account.resolvePlexToken();
       if (!mounted) return;
       setState(() {
         _instance = settings;
-        _baseUrl = url;
+        _baseUrl = reached.baseUrl;
         _plexTokenAvailable = plexToken != null && plexToken.isNotEmpty;
         // With exactly one credential form on offer, skip the method list.
         final mediaForm = _mediaServerForm;
@@ -146,6 +162,62 @@ class _SeerrConnectScreenState extends State<SeerrConnectScreen> with AsyncFormS
     }, errorMapper: _describeError);
   }
 
+  Future<void> _startQuickConnect() async {
+    final attemptId = ++_qcAttemptId;
+    setState(() => _qcCancelled = false);
+    await runAsync<void>(
+      () async {
+        final account = context.read<SeerrAccountProvider>();
+        final initiation = await account.authService.initiateQuickConnect(_baseUrl);
+        if (!_isCurrentQuickConnectAttempt(attemptId)) return;
+        // Show the waiting panel without a spinner — opt out of busy mid-flow
+        // so the visible state matches "we're polling, nothing for you to do".
+        setState(() => _qcInitiation = initiation);
+        _requestFocusAfterFrame(_cancelQuickConnectFocus);
+        setBusy(false);
+
+        final session = await account.authService.signInWithQuickConnect(
+          baseUrl: _baseUrl,
+          secret: initiation.secret,
+          shouldCancel: () => _qcCancelled || attemptId != _qcAttemptId,
+        );
+        if (!_isCurrentQuickConnectAttempt(attemptId)) return;
+        if (session == null) {
+          // Either the user cancelled or the secret expired before approval.
+          // Cancellation is silent; expiry surfaces an error.
+          setState(() => _qcInitiation = null);
+          if (!_qcCancelled) setErrorText(t.auth.quickConnectExpired);
+          return;
+        }
+        await _finish(account, session);
+      },
+      errorMapper: _describeError,
+      shouldApplyState: () => attemptId == _qcAttemptId,
+    );
+    // Clear the QC panel after any error so the form re-shows.
+    if (_isCurrentQuickConnectAttempt(attemptId) && errorText != null && _qcInitiation != null) {
+      setState(() => _qcInitiation = null);
+    }
+  }
+
+  bool _isCurrentQuickConnectAttempt(int attemptId) => mounted && attemptId == _qcAttemptId;
+
+  void _cancelQuickConnect() {
+    _qcAttemptId++;
+    setState(() {
+      _qcCancelled = true;
+      _qcInitiation = null;
+    });
+    setBusy(false);
+  }
+
+  void _requestFocusAfterFrame(FocusNode node) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !node.canRequestFocus) return;
+      node.requestFocus();
+    });
+  }
+
   Future<void> _finish(SeerrAccountProvider account, SeerrSession session) async {
     // The probe already answered /settings/public; carry its label and the
     // product discriminator (MediaStatus 6/7 decode per product) into the
@@ -167,18 +239,27 @@ class _SeerrConnectScreenState extends State<SeerrConnectScreen> with AsyncFormS
     return FocusedScrollScaffold(
       title: Text(t.seerr.connectTitle),
       slivers: [
-        SliverPadding(
-          padding: const EdgeInsets.all(16),
-          sliver: SliverToBoxAdapter(
-            child: Form(
-              key: _formKey,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: _instance == null ? _buildUrlStep(theme) : _buildSignInStep(theme),
+        if (_qcInitiation != null)
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(24, 24, 24, 24 + MediaQuery.paddingOf(context).bottom),
+              child: Center(child: _buildQuickConnectPanel(theme)),
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.all(16),
+            sliver: SliverToBoxAdapter(
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: _instance == null ? _buildUrlStep(theme) : _buildSignInStep(theme),
+                ),
               ),
             ),
           ),
-        ),
       ],
     );
   }
@@ -323,7 +404,79 @@ class _SeerrConnectScreenState extends State<SeerrConnectScreen> with AsyncFormS
         ),
       ),
       const SizedBox(height: 12),
+      // Seerr proxies Jellyfin Quick Connect from 3.4 on — and only for
+      // Jellyfin: the server rejects it for Emby. Older instances answer the
+      // initiate with a 404 the error text surfaces.
+      if (_form == _CredentialForm.jellyfin) ...[
+        FocusableButton(
+          focusNode: _quickConnectFocus,
+          useBackgroundFocus: true,
+          onPressed: busy ? null : _startQuickConnect,
+          child: OutlinedButton.icon(
+            onPressed: busy ? null : _startQuickConnect,
+            icon: const AppIcon(Symbols.tap_and_play_rounded, fill: 1),
+            label: Text(t.auth.useQuickConnect),
+          ),
+        ),
+        const SizedBox(height: 12),
+      ],
     ];
+  }
+
+  Widget _buildQuickConnectPanel(ThemeData theme) {
+    final code = _qcInitiation!.code;
+    final muted = theme.colorScheme.onSurface.withValues(alpha: 0.7);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 420),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            t.auth.quickConnectInstructions,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge?.copyWith(color: muted),
+          ),
+          const SizedBox(height: 32),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Padding(
+              // letterSpacing adds a trailing gap after the last glyph;
+              // matching left padding keeps the code optically centered.
+              padding: const EdgeInsets.only(left: 12),
+              child: Text(
+                code,
+                style: theme.textTheme.displayLarge?.copyWith(
+                  fontFamily: 'monospace',
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 12,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 32),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const LoadingIndicatorBox(size: 16),
+              const SizedBox(width: 10),
+              Text(t.auth.quickConnectWaiting, style: theme.textTheme.bodyMedium?.copyWith(color: muted)),
+            ],
+          ),
+          const SizedBox(height: 32),
+          FocusableButton(
+            focusNode: _cancelQuickConnectFocus,
+            useBackgroundFocus: true,
+            onPressed: _cancelQuickConnect,
+            child: OutlinedButton.icon(
+              onPressed: _cancelQuickConnect,
+              icon: const AppIcon(Symbols.close_rounded, fill: 1),
+              label: Text(t.auth.quickConnectCancel),
+            ),
+          ),
+          ...buildInlineError(theme, gap: 16, center: true),
+        ],
+      ),
+    );
   }
 
   Widget _buildInstanceCard(ThemeData theme, SeerrPublicSettings instance) {

--- a/lib/screens/settings/seerr_settings_screen.dart
+++ b/lib/screens/settings/seerr_settings_screen.dart
@@ -51,6 +51,7 @@ class SeerrSettingsScreen extends StatelessWidget {
           SeerrAuthMethod.jellyfin => 'Jellyfin',
           SeerrAuthMethod.emby => 'Emby',
           SeerrAuthMethod.local => t.seerr.email,
+          SeerrAuthMethod.quickConnect => 'Quick Connect',
         };
         return SettingsPage(
           title: Text(t.seerr.title),

--- a/lib/services/seerr/seerr_auth_service.dart
+++ b/lib/services/seerr/seerr_auth_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:http/http.dart' as http;
 
 import '../../i18n/strings.g.dart';
@@ -5,20 +7,92 @@ import '../../models/seerr/seerr_public_settings.dart';
 import '../../models/seerr/seerr_session.dart';
 import '../../models/seerr/seerr_user.dart';
 import '../../utils/app_logger.dart';
+import '../../utils/poll_with_backoff.dart';
+import '../../utils/url_utils.dart';
 import 'seerr_constants.dart';
 import 'seerr_exceptions.dart';
 import 'seerr_http_client.dart';
+
+/// Result of `POST /auth/jellyfin/quickconnect/initiate`. The [code] is shown
+/// to the user to approve inside Jellyfin; the [secret] drives the poll and
+/// the final exchange.
+class SeerrQuickConnectInitiation {
+  final String code;
+  final String secret;
+
+  const SeerrQuickConnectInitiation({required this.code, required this.secret});
+}
 
 /// Sign-in flows against a Seerr instance. Every flow ends with a captured
 /// `connect.sid` cookie and the Seerr-side [SeerrUser], packed into a
 /// [SeerrSession].
 class SeerrAuthService {
+  /// Default Seerr install port, tried last for bare-host input.
+  static const int defaultPort = 5055;
+
+  static final RegExp _schemePattern = RegExp(r'^[A-Za-z][A-Za-z\d+.-]*://');
+
   final http.Client Function()? httpClientFactory;
 
   SeerrAuthService({this.httpClientFactory});
 
   SeerrHttpClient _client(String baseUrl, {String? cookie}) =>
       SeerrHttpClient(baseUrl: baseUrl, httpClient: httpClientFactory?.call(), cookie: cookie);
+
+  /// Expand a user-typed instance URL into probe candidates, mirroring the
+  /// MediaBrowser add-server rules: an explicit scheme is authoritative, a
+  /// bare host tries https, plain http, and the Seerr default port, and a
+  /// host with an explicit port tries both schemes. Guesses are for
+  /// discovery only; only the winning candidate is persisted.
+  static List<String> expandUrlCandidates(String input) {
+    final trimmed = canonicalizeBaseUrl(input);
+    if (trimmed.isEmpty) return const [];
+    if (_schemePattern.hasMatch(trimmed)) return List.unmodifiable([trimmed]);
+
+    final parsed = Uri.tryParse('http://$trimmed');
+    if (parsed == null || parsed.host.isEmpty) return List.unmodifiable(['https://$trimmed']);
+
+    final candidates = <String>[];
+    void add(Uri uri) {
+      final normalized = stripTrailingSlash(uri.replace(query: null, fragment: null).toString());
+      if (normalized.isNotEmpty && !candidates.contains(normalized)) candidates.add(normalized);
+    }
+
+    add(parsed.replace(scheme: 'https'));
+    add(parsed.replace(scheme: 'http'));
+    if (!parsed.hasPort) add(parsed.replace(scheme: 'http', port: defaultPort));
+    return List.unmodifiable(candidates);
+  }
+
+  /// Probe every [expandUrlCandidates] guess for [input] concurrently and
+  /// return the first that answers as an initialized Seerr. When none does,
+  /// rethrow the primary (first) candidate's failure — that is the URL the
+  /// error message should name.
+  Future<({String baseUrl, SeerrPublicSettings settings})> probeFirstReachable(String input) async {
+    final candidates = expandUrlCandidates(input);
+    if (candidates.isEmpty) {
+      throw SeerrUrlException('No Seerr instance URL entered', display: t.addServer.required);
+    }
+    final completer = Completer<({String baseUrl, SeerrPublicSettings settings})>();
+    final errors = List<Object?>.filled(candidates.length, null);
+    var pending = candidates.length;
+    for (final (i, candidate) in candidates.indexed) {
+      unawaited(
+        probe(candidate)
+            .then((settings) {
+              if (!completer.isCompleted) completer.complete((baseUrl: candidate, settings: settings));
+            })
+            .catchError((Object e) {
+              errors[i] = e;
+              pending -= 1;
+              if (pending == 0 && !completer.isCompleted) {
+                completer.completeError(errors.firstWhere((err) => err != null)!);
+              }
+            }),
+      );
+    }
+    return completer.future;
+  }
 
   /// Validate that [baseUrl] points at a running, initialized Seerr and
   /// collect the metadata the connect flow needs. Throws [SeerrUrlException]
@@ -91,6 +165,107 @@ class SeerrAuthService {
         identifier: email,
         secret: password,
       );
+
+  /// `POST /auth/jellyfin/quickconnect/initiate` (Seerr 3.4+): start a
+  /// Jellyfin Quick Connect session proxied through the instance. Throws
+  /// [SeerrAuthException] when the route is missing (older Seerr) or the
+  /// linked Jellyfin has Quick Connect disabled.
+  Future<SeerrQuickConnectInitiation> initiateQuickConnect(String baseUrl) async {
+    final client = _client(baseUrl);
+    try {
+      final res = await client.send(
+        'POST',
+        '/auth/jellyfin/quickconnect/initiate',
+        timeout: SeerrConstants.authTimeout,
+        authenticated: false,
+      );
+      final data = res.data;
+      final message = data is Map<String, dynamic> ? data['message'] as String? : null;
+      if (res.statusCode >= 400) {
+        throw SeerrAuthException(
+          message ?? 'Quick Connect rejected (HTTP ${res.statusCode})',
+          statusCode: res.statusCode,
+          display: t.addServer.quickConnectFailed(error: message ?? 'HTTP ${res.statusCode}'),
+        );
+      }
+      final code = data is Map<String, dynamic> ? data['code'] : null;
+      final secret = data is Map<String, dynamic> ? data['secret'] : null;
+      if (code is! String || code.isEmpty || secret is! String || secret.isEmpty) {
+        throw SeerrAuthException(
+          'Quick Connect response is missing a code or secret',
+          display: t.addServer.quickConnectMissingFields,
+        );
+      }
+      return SeerrQuickConnectInitiation(code: code, secret: secret);
+    } finally {
+      client.dispose();
+    }
+  }
+
+  /// Poll `GET /auth/jellyfin/quickconnect/check` until the user approves the
+  /// code inside Jellyfin, then `POST …/authenticate` to mint the Seerr
+  /// session. Returns null on cancel, poll timeout, or server-side secret
+  /// expiry (404 mid-poll). Transient poll errors retry until [timeout].
+  Future<SeerrSession?> signInWithQuickConnect({
+    required String baseUrl,
+    required String secret,
+    bool Function()? shouldCancel,
+    Duration timeout = const Duration(minutes: 5),
+  }) async {
+    // One client across the loop — no TCP churn on a minutes-long window.
+    final pollClient = _client(baseUrl);
+    bool? approved;
+    try {
+      approved = await pollWithBackoff<bool>(
+        endTime: DateTime.now().add(timeout),
+        shouldCancel: shouldCancel,
+        initial: SeerrConstants.quickConnectPollInterval,
+        maxBackoff: SeerrConstants.quickConnectPollInterval,
+        probe: () async {
+          final SeerrResponse res;
+          try {
+            res = await pollClient.send(
+              'GET',
+              '/auth/jellyfin/quickconnect/check',
+              query: {'secret': secret},
+              timeout: SeerrConstants.authTimeout,
+              authenticated: false,
+            );
+          } catch (e) {
+            appLogger.d('Seerr: Quick Connect poll blip', error: e);
+            return null;
+          }
+          // 404 mid-poll = secret expired or revoked server-side. Terminal.
+          if (res.statusCode == 404) throw const PollTerminatedSignal();
+          if (res.statusCode == 401 || res.statusCode == 403) {
+            final message = res.data is Map<String, dynamic>
+                ? (res.data as Map<String, dynamic>)['message'] as String?
+                : null;
+            throw SeerrAuthException(
+              message ?? 'Quick Connect poll rejected',
+              statusCode: res.statusCode,
+              display: t.addServer.quickConnectPollRejected,
+            );
+          }
+          SeerrHttpClient.throwForStatus(res);
+          final data = res.data;
+          return data is Map<String, dynamic> && data['authenticated'] == true ? true : null;
+        },
+      );
+    } finally {
+      pollClient.dispose();
+    }
+    if (approved != true) return null;
+
+    return _signIn(
+      baseUrl: baseUrl,
+      method: SeerrAuthMethod.quickConnect,
+      path: '/auth/jellyfin/quickconnect/authenticate',
+      body: {'secret': secret},
+      identifier: '',
+      secret: '',
+    );
+  }
 
   /// Silent re-login using the credentials carried by [session]
   /// ([plexToken] for plex-method sessions). Returns the refreshed session.

--- a/lib/services/seerr/seerr_constants.dart
+++ b/lib/services/seerr/seerr_constants.dart
@@ -9,6 +9,9 @@ abstract final class SeerrConstants {
   static const Duration probeTimeout = Duration(seconds: 8);
   static const Duration authTimeout = Duration(seconds: 20);
   static const Duration requestTimeout = Duration(seconds: 30);
+
+  /// Fixed Quick Connect poll cadence, matching the Seerr web UI's 2000ms.
+  static const Duration quickConnectPollInterval = Duration(seconds: 2);
 }
 
 /// Seerr `MediaServerType` values (server/constants/server.ts), sent as

--- a/scripts/checks/hardcoded_strings_allowlist.json
+++ b/scripts/checks/hardcoded_strings_allowlist.json
@@ -4,6 +4,7 @@
     "Jellyfin": "Brand name",
     "Emby": "Brand name",
     "Plezy": "Brand name",
+    "Quick Connect": "Jellyfin feature name",
     "Simkl": "Brand name",
     "BL": "Technical token",
     "EL": "Technical token",

--- a/test/services/seerr/seerr_client_test.dart
+++ b/test/services/seerr/seerr_client_test.dart
@@ -611,4 +611,125 @@ void main() {
       expect(SeerrRequestStatus.fromCode(null), SeerrRequestStatus.pending);
     });
   });
+
+  group('SeerrAuthService.expandUrlCandidates', () {
+    test('keeps an explicit scheme as the only candidate, canonicalized', () {
+      expect(SeerrAuthService.expandUrlCandidates('HTTPS://seerr.example.com/'), ['https://seerr.example.com']);
+      expect(SeerrAuthService.expandUrlCandidates('http://192.168.1.5:5055'), ['http://192.168.1.5:5055']);
+    });
+
+    test('tries https, http, and the default port for a bare host', () {
+      expect(SeerrAuthService.expandUrlCandidates('seerr.example.com'), [
+        'https://seerr.example.com',
+        'http://seerr.example.com',
+        'http://seerr.example.com:5055',
+      ]);
+    });
+
+    test('tries https then http for a host with an explicit port', () {
+      expect(SeerrAuthService.expandUrlCandidates('192.168.1.5:5055'), [
+        'https://192.168.1.5:5055',
+        'http://192.168.1.5:5055',
+      ]);
+    });
+
+    test('preserves a sub-path on every candidate', () {
+      expect(SeerrAuthService.expandUrlCandidates('example.com/seerr'), [
+        'https://example.com/seerr',
+        'http://example.com/seerr',
+        'http://example.com:5055/seerr',
+      ]);
+    });
+
+    test('returns no candidates for blank input', () {
+      expect(SeerrAuthService.expandUrlCandidates('   '), isEmpty);
+    });
+  });
+
+  group('SeerrAuthService.probeFirstReachable', () {
+    test('falls back to plain http on the default port when https is unreachable', () async {
+      final auth = SeerrAuthService(
+        httpClientFactory: () => MockClient((request) async {
+          if (request.url.port != 5055) throw http.ClientException('connection refused');
+          return _json({'initialized': true, 'mediaServerType': 2});
+        }),
+      );
+      final result = await auth.probeFirstReachable('seerr.example.com');
+      expect(result.baseUrl, 'http://seerr.example.com:5055');
+      expect(result.settings.product, SeerrProduct.jellyseerr);
+    });
+
+    test('reports the primary candidate when nothing answers', () async {
+      final auth = SeerrAuthService(
+        httpClientFactory: () => MockClient((request) async => throw http.ClientException('connection refused')),
+      );
+      expect(
+        () => auth.probeFirstReachable('seerr.example.com'),
+        throwsA(isA<SeerrUrlException>().having((e) => e.message, 'message', contains('https://seerr.example.com'))),
+      );
+    });
+  });
+
+  group('SeerrAuthService quick connect', () {
+    test('initiate posts unauthenticated and surfaces the code and secret', () async {
+      String? cookie;
+      final auth = SeerrAuthService(
+        httpClientFactory: () => MockClient((request) async {
+          expect(request.method, 'POST');
+          expect(request.url.path, '/api/v1/auth/jellyfin/quickconnect/initiate');
+          cookie = request.headers['Cookie'];
+          return _json({'code': 'ABC123', 'secret': 'deadbeef'});
+        }),
+      );
+      final initiation = await auth.initiateQuickConnect('https://seerr.example.com');
+      expect(initiation.code, 'ABC123');
+      expect(initiation.secret, 'deadbeef');
+      expect(cookie, isNull);
+    });
+
+    test('sign-in polls the secret until approved, then exchanges it for a session', () async {
+      final paths = <String>[];
+      final auth = SeerrAuthService(
+        httpClientFactory: () => MockClient((request) async {
+          paths.add(request.url.path);
+          if (request.url.path == '/api/v1/auth/jellyfin/quickconnect/check') {
+            expect(request.url.queryParameters['secret'], 'deadbeef');
+            return _json({'authenticated': true});
+          }
+          expect(request.url.path, '/api/v1/auth/jellyfin/quickconnect/authenticate');
+          expect(jsonDecode(request.body), {'secret': 'deadbeef'});
+          return _json(_user(), headers: {'set-cookie': '${SeerrConstants.sessionCookieName}=fresh; Path=/'});
+        }),
+      );
+      final session = await auth.signInWithQuickConnect(baseUrl: 'https://seerr.example.com/', secret: 'deadbeef');
+      expect(session, isNotNull);
+      expect(session!.method, SeerrAuthMethod.quickConnect);
+      expect(session.cookie, 'fresh');
+      expect(session.identifier, isEmpty);
+      expect(session.secret, isEmpty);
+      expect(session.displayName, 'Alice');
+      expect(paths, ['/api/v1/auth/jellyfin/quickconnect/check', '/api/v1/auth/jellyfin/quickconnect/authenticate']);
+    });
+
+    test('sign-in returns null when the secret expires mid-poll', () async {
+      final paths = <String>[];
+      final auth = SeerrAuthService(
+        httpClientFactory: () => MockClient((request) async {
+          paths.add(request.url.path);
+          return _json({'message': 'Invalid Quick Connect secret.'}, status: 404);
+        }),
+      );
+      final session = await auth.signInWithQuickConnect(baseUrl: 'https://seerr.example.com', secret: 'deadbeef');
+      expect(session, isNull);
+      expect(paths, ['/api/v1/auth/jellyfin/quickconnect/check']);
+    });
+
+    test('quick connect sessions have no silent re-auth', () {
+      final auth = SeerrAuthService(httpClientFactory: () => MockClient((request) async => _json({})));
+      expect(
+        () => auth.reauth(_session(method: SeerrAuthMethod.quickConnect, secret: '')),
+        throwsA(isA<SeerrAuthException>()),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## What

Two fixes to linking a Seerr instance, both on the Jellyfin path:

**Quick Connect sign-in.** The Jellyfin sign-in form gains a "Use Quick Connect" button that shows the same full-screen code panel as the Jellyfin/Emby add-server flow — large code, "waiting for approval", cancel — and finishes the link once the code is approved inside Jellyfin. Until now the only way to link Seerr with a Jellyfin account was typing a username and password, which on a TV remote is miserable.

**Forgiving URL entry.** The URL step prepended `https://` to anything without a scheme, so a plain-HTTP instance on the LAN failed with "could not reach" unless the user knew to type the scheme — `192.168.1.5:5055` and bare hosts on Seerr's default port both fell into this. Schemeless input is now expanded into candidates and raced, the same way the MediaBrowser add-server form already treats server URLs.

## Screenshots

<img width="2854" height="646" alt="image" src="https://github.com/user-attachments/assets/5f6756d5-a258-44af-a924-24923a2531c2" />

## How

- `SeerrAuthService.expandUrlCandidates` (pure, static, unit-tested) mirrors `JellyfinEndpointDiscovery`'s rules: an explicit scheme is authoritative, `host:port` tries `https://` then `http://`, and a bare host tries `https://host`, `http://host`, `http://host:5055` (Seerr's default port). Sub-paths are preserved on every candidate. `probeFirstReachable` probes the candidates concurrently and takes the first that answers `/settings/public` as an initialized instance; when none does it rethrows the *first* candidate's error so the message names the URL the user meant. Guesses stay discovery-only — only the winning URL reaches the session.
- Quick Connect goes through Seerr's own proxy routes (added in Seerr 3.4.0, seerr-team/seerr#2212): `POST /auth/jellyfin/quickconnect/initiate` → `{code, secret}`, then `GET …/check?secret=` polled through the shared `pollWithBackoff` at Seerr's own 2s cadence — a 404 mid-poll means the secret expired and is terminal — then `POST …/authenticate`, which returns the user and `connect.sid` through the existing `_signIn` path. Attempt-id and cancel guarding mirror `AddJellyfinScreen` so a dismissed screen can't setState late.
- New `SeerrAuthMethod.quickConnect`. Sessions serialize the method by name, so appending is safe, and this method deliberately stores no secret: silent re-auth is impossible by construction, so an expired cookie lands in the existing "no stored credentials" arm and unlinks the session, prompting a fresh code instead of retrying forever.
- The button is limited to the Jellyfin credential form — Seerr rejects Quick Connect for Emby. It is deliberately **not** auto-started on TV (unlike `AddJellyfinScreen`, which auto-jumps): Seerr exposes no "Quick Connect enabled" capability in `/settings/public`, so auto-firing would blind-hit instances that can't serve it. On a pre-3.4 instance the initiate call 404s and the error surfaces inline under the form. Happy to switch to an explicit version check if you'd rather gate it that way.
- No new i18n keys: the panel reuses `auth.useQuickConnect` / `auth.quickConnect*` and the `addServer.quickConnect*` error strings. "Quick Connect" is added to the hardcoded-strings allowlist for the settings-screen method label.

## Testing

- 10 new unit tests in `test/services/seerr/seerr_client_test.dart` covering candidate expansion (scheme, bare host, explicit port, sub-path, blank), the http/default-port fallback race and the all-candidates-fail error, initiate, poll-then-authenticate, secret expiry mid-poll, and that a `quickConnect` session refuses silent re-auth.
- Manually verified on Windows desktop against a live Seerr instance backed by Jellyfin: Quick Connect sign-in completes end to end after approving the code in Jellyfin.
- `flutter analyze` clean, `dart format` (page width 120) applied, `scripts/checks/clean_translations.py --check --strict` and `scripts/checks/check_hardcoded_strings.py` pass, and the full `flutter test` suite is green apart from failures that reproduce identically on an unmodified checkout of this base.

AI-assisted: implemented with Claude Fable 5 via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
