### PR TITLE
fix(player): preserve packed aspect for stereoscopic (3D) video

### DIFF
--- a/lib/services/video_filter_manager.dart
+++ b/lib/services/video_filter_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -67,6 +68,8 @@ class VideoFilterManager {
   /// Ambient lighting service reference - when active, video-aspect-override is managed by ambient lighting
   AmbientLightingService? ambientLightingService;
 
+  final List<StreamSubscription<void>> _mediaSubscriptions = [];
+
   /// Custom video zoom layered on top of the selected fit mode.
   double _zoomScale = 1.0;
 
@@ -103,6 +106,16 @@ class VideoFilterManager {
       leading: true,
       trailing: true,
     );
+    try {
+      for (final stream in [player.streams.fileLoaded, player.streams.backendSwitched]) {
+        _mediaSubscriptions.add(
+          stream.listen((_) {
+            _appliedProps.remove('video-aspect-override');
+            unawaited(updateVideoFilter());
+          }),
+        );
+      }
+    } catch (_) {}
   }
 
   /// Current BoxFit mode (0=contain, 1=cover, 2=fill)
@@ -245,15 +258,17 @@ class VideoFilterManager {
       final zoomScale = _zoomScale;
       final playerSize = _playerSize;
       final ambientActive = ambientLightingService?.isEnabled == true;
-      final coverMode = boxFitMode == 1;
+      final packedStereoAspect = await _packedStereoAspect();
+      final effectiveBoxFitMode = packedStereoAspect == null ? boxFitMode : 0;
+      final coverMode = effectiveBoxFitMode == 1;
 
       // ExoPlayer handles scaling via AspectRatioFrameLayout (no-op on mpv
       // backends). The MPV properties below still run — on ExoPlayer they
       // forward to setMpvProperty, which queues them for any future fallback.
-      if (_appliedBoxFitMode != boxFitMode) {
+      if (_appliedBoxFitMode != effectiveBoxFitMode) {
         _appliedBoxFitMode = null;
-        await player.setBoxFitMode(boxFitMode);
-        _appliedBoxFitMode = boxFitMode;
+        await player.setBoxFitMode(effectiveBoxFitMode);
+        _appliedBoxFitMode = effectiveBoxFitMode;
       }
       if (_appliedVideoZoom != zoomScale) {
         _appliedVideoZoom = null;
@@ -263,8 +278,8 @@ class VideoFilterManager {
 
       // Compute final target values up-front: each mpv write takes effect
       // immediately, so transient intermediate values would flash on screen.
-      String? aspectOverride = ambientActive ? null : 'no';
-      if (boxFitMode == 2) {
+      String? aspectOverride = packedStereoAspect?.toString() ?? (ambientActive ? null : 'no');
+      if (effectiveBoxFitMode == 2) {
         // Fill/stretch mode - override aspect ratio to match player (stretches video)
         if (playerSize != null && playerSize.width > 0 && playerSize.height > 0) {
           final playerAspect = playerSize.width / playerSize.height;
@@ -291,6 +306,18 @@ class VideoFilterManager {
     }
   }
 
+  Future<double?> _packedStereoAspect() async {
+    try {
+      final stereo = await player.getProperty('video-params/stereo-in');
+      if (stereo != 'sbs2l' && stereo != 'sbs2r' && stereo != 'ab2l' && stereo != 'ab2r') return null;
+      final aspect = double.tryParse(await player.getProperty('video-dec-params/aspect') ?? '');
+      if (aspect == null || !aspect.isFinite || aspect <= 0) return null;
+      return aspect;
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<void> _applyProperty(String name, String value) async {
     if (_appliedProps[name] == value) return;
     // Uncache while in flight so a failed write is retried on the next run.
@@ -306,5 +333,8 @@ class VideoFilterManager {
 
   void dispose() {
     _debouncedUpdateVideoFilter.cancel();
+    for (final subscription in _mediaSubscriptions) {
+      unawaited(subscription.cancel());
+    }
   }
 }

--- a/lib/services/video_filter_manager.dart
+++ b/lib/services/video_filter_manager.dart
@@ -106,16 +106,14 @@ class VideoFilterManager {
       leading: true,
       trailing: true,
     );
-    try {
-      for (final stream in [player.streams.fileLoaded, player.streams.backendSwitched]) {
-        _mediaSubscriptions.add(
-          stream.listen((_) {
-            _appliedProps.remove('video-aspect-override');
-            unawaited(updateVideoFilter());
-          }),
-        );
-      }
-    } catch (_) {}
+    for (final stream in [player.streams.fileLoaded, player.streams.backendSwitched]) {
+      _mediaSubscriptions.add(
+        stream.listen((_) {
+          _appliedProps.remove('video-aspect-override');
+          unawaited(updateVideoFilter());
+        }),
+      );
+    }
   }
 
   /// Current BoxFit mode (0=contain, 1=cover, 2=fill)
@@ -278,8 +276,8 @@ class VideoFilterManager {
 
       // Compute final target values up-front: each mpv write takes effect
       // immediately, so transient intermediate values would flash on screen.
-      String? aspectOverride = packedStereoAspect?.toString() ?? (ambientActive ? null : 'no');
-      if (effectiveBoxFitMode == 2) {
+      String? aspectOverride = ambientActive ? null : (packedStereoAspect?.toString() ?? 'no');
+      if (!ambientActive && effectiveBoxFitMode == 2) {
         // Fill/stretch mode - override aspect ratio to match player (stretches video)
         if (playerSize != null && playerSize.width > 0 && playerSize.height > 0) {
           final playerAspect = playerSize.width / playerSize.height;

--- a/test/services/video_filter_manager_test.dart
+++ b/test/services/video_filter_manager_test.dart
@@ -152,6 +152,42 @@ void main() {
     expect(aspectWrites.single.value, 'no');
   });
 
+  test('packed stereo uses contain properties and decoder aspect', () async {
+    final player = _RecordingPlayer(
+      properties: {'video-params/stereo-in': 'sbs2l', 'video-dec-params/aspect': '${16 / 9}'},
+    );
+    final manager = VideoFilterManager(player: player, initialBoxFitMode: 1);
+    addTearDown(manager.dispose);
+
+    await manager.updateVideoFilter();
+
+    expect(player.boxFitCalls, [0]);
+    expect(player.writes.lastWhere((write) => write.key == 'panscan').value, '0');
+    expect(player.writes.lastWhere((write) => write.key == 'sub-ass-force-margins').value, 'no');
+    expect(
+      double.parse(player.writes.lastWhere((write) => write.key == 'video-aspect-override').value),
+      closeTo(16 / 9, 0.0001),
+    );
+  });
+
+  test('ambient lighting owns aspect override for packed stereo', () async {
+    final player = _RecordingPlayer(
+      properties: {'video-params/stereo-in': 'ab2l', 'video-dec-params/aspect': '${16 / 9}'},
+    );
+    final ambient = _FakeAmbientLightingService(player)..fakeEnabled = true;
+    final manager = VideoFilterManager(player: player)..ambientLightingService = ambient;
+    addTearDown(manager.dispose);
+
+    await manager.updateVideoFilter();
+    expect(player.writes.where((write) => write.key == 'video-aspect-override'), isEmpty);
+
+    ambient.fakeEnabled = false;
+    await manager.updateVideoFilter();
+    final aspectWrites = player.writes.where((write) => write.key == 'video-aspect-override').toList();
+    expect(aspectWrites, hasLength(1));
+    expect(double.parse(aspectWrites.single.value), closeTo(16 / 9, 0.0001));
+  });
+
   test('fill mode rewrites aspect on player size change', () async {
     final player = _RecordingPlayer();
     final manager = VideoFilterManager(player: player, initialBoxFitMode: 2, initialPlayerSize: const Size(1920, 1080));
@@ -204,9 +240,33 @@ void main() {
 }
 
 class _RecordingPlayer implements Player {
+  _RecordingPlayer({Map<String, String>? properties}) : properties = properties ?? {};
+
+  final Map<String, String> properties;
   final writes = <MapEntry<String, String>>[];
   final boxFitCalls = <int>[];
   final zoomCalls = <double>[];
+
+  static const _streams = PlayerStreams(
+    playing: Stream<bool>.empty(),
+    completed: Stream<bool>.empty(),
+    buffering: Stream<bool>.empty(),
+    position: Stream<Duration>.empty(),
+    duration: Stream<Duration>.empty(),
+    seekable: Stream<bool>.empty(),
+    buffer: Stream<Duration>.empty(),
+    volume: Stream<double>.empty(),
+    rate: Stream<double>.empty(),
+    tracks: Stream<Tracks>.empty(),
+    track: Stream<TrackSelection>.empty(),
+    log: Stream<PlayerLog>.empty(),
+    error: Stream<PlayerError>.empty(),
+    audioDevice: Stream<AudioDevice>.empty(),
+    audioDevices: Stream<List<AudioDevice>>.empty(),
+    bufferRanges: Stream<List<BufferRange>>.empty(),
+    playbackRestart: Stream<void>.empty(),
+    backendSwitched: Stream<void>.empty(),
+  );
 
   void clearRecords() {
     writes.clear();
@@ -220,6 +280,9 @@ class _RecordingPlayer implements Player {
   }
 
   @override
+  Future<String?> getProperty(String name) async => properties[name];
+
+  @override
   Future<void> setBoxFitMode(int mode) async {
     boxFitCalls.add(mode);
   }
@@ -231,6 +294,9 @@ class _RecordingPlayer implements Player {
 
   @override
   PlayerState get state => const PlayerState();
+
+  @override
+  PlayerStreams get streams => _streams;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);


### PR DESCRIPTION
Fix an issue that causes standards-tagged Matroska Side-by-Side and Over-Under 3D video to use per-eye geometry for the complete packed frame, making the picture appear squeezed.

## Changes
- Detect Matroska StereoMode in mpv ~~and Android ExoPlayer~~, including the Media3 and FFmpeg demux paths.
- Preserve the complete packed SBS or Over-Under frame without splitting, converting, or re-encoding the video.
- Preserve left/right eye ordering and use the correct packed-frame aspect.
- Keep ordinary 2D, custom aspect ratio, and anamorphic playback behavior unchanged.
- Restore normal sizing when switching back to a 2D source.

This goes hand in hand with #2146, which makes Plezy's playback controls usable while the display is in its packed 3D mode.

Tested on an NVIDIA Shield using tagged SBS content mpv.

AI-assisted using OpenAI GPT-5.6 Sol.