### PR TITLE
feat(explore): open matched items from explore, in library

### DIFF
--- a/lib/i18n/az.i18n.json
+++ b/lib/i18n/az.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Baxış siyahısından silindi",
     "watchlistUpdateFailed": "İzləmə siyahısı yenilənə bilmədi",
     "watchlistNoMatch": "Bu elementi heç bir baxış siyahısı ilə uyğunlaşdırmaq olmadı",
+    "openInLibrary": "Kitabxanada aç",
     "notInLibrary": "Kitabxananızda yoxdur",
     "inTheseLibraries": "Bu kitabxanalarda var",
     "checkingLibrary": "Kitabxananız yoxlanılır...",

--- a/lib/i18n/bg.i18n.json
+++ b/lib/i18n/bg.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Премахнато от списъка за гледане",
     "watchlistUpdateFailed": "Неуспешно обновяване на списъка за гледане",
     "watchlistNoMatch": "Този елемент не можа да бъде съпоставен със списък за гледане",
+    "openInLibrary": "Отвори в библиотеката",
     "notInLibrary": "Не е в твоята библиотека",
     "inTheseLibraries": "В тези библиотеки",
     "checkingLibrary": "Проверка на твоята библиотека...",

--- a/lib/i18n/da.i18n.json
+++ b/lib/i18n/da.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Fjernet fra overvågningslisten",
     "watchlistUpdateFailed": "Kunne ikke opdatere ønskelisten",
     "watchlistNoMatch": "Kunne ikke knytte dette element til en overvågningsliste",
+    "openInLibrary": "Åbn i bibliotek",
     "notInLibrary": "Ikke i dit bibliotek",
     "inTheseLibraries": "I disse biblioteker",
     "checkingLibrary": "Tjekker dit bibliotek...",

--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Von der Watchlist entfernt",
     "watchlistUpdateFailed": "Merkliste konnte nicht aktualisiert werden",
     "watchlistNoMatch": "Dieser Eintrag konnte keiner Watchlist zugeordnet werden",
+    "openInLibrary": "In Mediathek öffnen",
     "notInLibrary": "Nicht in deiner Mediathek",
     "inTheseLibraries": "In diesen Mediatheken",
     "checkingLibrary": "Deine Mediathek wird überprüft …",

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Removed from watchlist",
     "watchlistUpdateFailed": "Couldn't update watchlist",
     "watchlistNoMatch": "Couldn't match this item to a watchlist",
+    "openInLibrary": "Open in library",
     "notInLibrary": "Not in your library",
     "inTheseLibraries": "In these libraries",
     "checkingLibrary": "Checking your library...",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Eliminado de la lista de seguimiento",
     "watchlistUpdateFailed": "No se pudo actualizar la lista de seguimiento",
     "watchlistNoMatch": "No se pudo asociar este elemento con una lista de seguimiento",
+    "openInLibrary": "Abrir en la biblioteca",
     "notInLibrary": "No está en tu biblioteca",
     "inTheseLibraries": "En estas bibliotecas",
     "checkingLibrary": "Comprobando tu biblioteca...",

--- a/lib/i18n/fr.i18n.json
+++ b/lib/i18n/fr.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Retiré de la liste de suivi",
     "watchlistUpdateFailed": "Impossible de mettre à jour la liste de suivi",
     "watchlistNoMatch": "Impossible d’associer cet élément à une liste de suivi",
+    "openInLibrary": "Ouvrir dans la bibliothèque",
     "notInLibrary": "Absent de votre bibliothèque",
     "inTheseLibraries": "Dans ces bibliothèques",
     "checkingLibrary": "Vérification de votre bibliothèque...",

--- a/lib/i18n/hu.i18n.json
+++ b/lib/i18n/hu.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Eltávolítva a figyelőlistáról",
     "watchlistUpdateFailed": "Nem sikerült a Néznivalók frissítése",
     "watchlistNoMatch": "Nem sikerült ezt az elemet figyelőlistához társítani",
+    "openInLibrary": "Megnyitás a könyvtárban",
     "notInLibrary": "Nincs a könyvtáradban",
     "inTheseLibraries": "Ezekben a könyvtárakban",
     "checkingLibrary": "Könyvtár ellenőrzése...",

--- a/lib/i18n/it.i18n.json
+++ b/lib/i18n/it.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Rimosso dalla lista titoli",
     "watchlistUpdateFailed": "Impossibile aggiornare la lista da guardare",
     "watchlistNoMatch": "Impossibile associare questo elemento a una lista titoli",
+    "openInLibrary": "Apri nella libreria",
     "notInLibrary": "Non è nella tua libreria",
     "inTheseLibraries": "In queste librerie",
     "checkingLibrary": "Ricerca nella tua libreria...",

--- a/lib/i18n/ja.i18n.json
+++ b/lib/i18n/ja.i18n.json
@@ -1235,6 +1235,7 @@
     "removedFromWatchlist": "ウォッチリストから削除しました",
     "watchlistUpdateFailed": "ウォッチリストを更新できませんでした",
     "watchlistNoMatch": "このアイテムに一致するウォッチリスト項目が見つかりませんでした",
+    "openInLibrary": "ライブラリで開く",
     "notInLibrary": "ライブラリにありません",
     "inTheseLibraries": "これらのライブラリにあります",
     "checkingLibrary": "ライブラリを確認中…",

--- a/lib/i18n/kk.i18n.json
+++ b/lib/i18n/kk.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Көру тізімінен алынды",
     "watchlistUpdateFailed": "Көру тізімін жаңарту мүмкін болмады",
     "watchlistNoMatch": "Бұл элементті көру тізімімен сәйкестендіру мүмкін болмады",
+    "openInLibrary": "Кітапханада ашу",
     "notInLibrary": "Кітапханаңызда жоқ",
     "inTheseLibraries": "Осы кітапханаларда бар",
     "checkingLibrary": "Кітапхана тексерілуде...",

--- a/lib/i18n/ko.i18n.json
+++ b/lib/i18n/ko.i18n.json
@@ -1235,6 +1235,7 @@
     "removedFromWatchlist": "관심 목록에서 삭제했습니다",
     "watchlistUpdateFailed": "관심 목록을 업데이트하지 못했습니다",
     "watchlistNoMatch": "이 항목을 관심 목록과 연결할 수 없습니다",
+    "openInLibrary": "라이브러리에서 열기",
     "notInLibrary": "라이브러리에 없음",
     "inTheseLibraries": "이 라이브러리에 있음",
     "checkingLibrary": "라이브러리 확인 중...",

--- a/lib/i18n/nb.i18n.json
+++ b/lib/i18n/nb.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Fjernet fra overvåkningslisten",
     "watchlistUpdateFailed": "Kunne ikke oppdatere ønskelisten",
     "watchlistNoMatch": "Kunne ikke koble dette elementet til en overvåkningsliste",
+    "openInLibrary": "Åpne i bibliotek",
     "notInLibrary": "Ikke i biblioteket ditt",
     "inTheseLibraries": "I disse bibliotekene",
     "checkingLibrary": "Sjekker biblioteket ditt...",

--- a/lib/i18n/nl.i18n.json
+++ b/lib/i18n/nl.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Uit kijklijst verwijderd",
     "watchlistUpdateFailed": "Kon kijklijst niet bijwerken",
     "watchlistNoMatch": "Kon dit item niet aan een kijklijst koppelen",
+    "openInLibrary": "Openen in bibliotheek",
     "notInLibrary": "Niet in je bibliotheek",
     "inTheseLibraries": "In deze bibliotheken",
     "checkingLibrary": "Je bibliotheek controleren...",

--- a/lib/i18n/pl.i18n.json
+++ b/lib/i18n/pl.i18n.json
@@ -1253,6 +1253,7 @@
     "removedFromWatchlist": "Usunięto z listy do obejrzenia",
     "watchlistUpdateFailed": "Nie udało się zaktualizować listy do obejrzenia",
     "watchlistNoMatch": "Nie udało się dopasować tej pozycji do listy do obejrzenia",
+    "openInLibrary": "Otwórz w bibliotece",
     "notInLibrary": "Nie ma tego w Twojej bibliotece",
     "inTheseLibraries": "W tych bibliotekach",
     "checkingLibrary": "Sprawdzanie Twojej biblioteki...",

--- a/lib/i18n/pt.i18n.json
+++ b/lib/i18n/pt.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Removido da lista de interesses",
     "watchlistUpdateFailed": "Não foi possível atualizar a lista para assistir",
     "watchlistNoMatch": "Não foi possível associar este item a uma lista de interesses",
+    "openInLibrary": "Abrir na biblioteca",
     "notInLibrary": "Não está na sua biblioteca",
     "inTheseLibraries": "Nestas bibliotecas",
     "checkingLibrary": "Verificando sua biblioteca...",

--- a/lib/i18n/ru.i18n.json
+++ b/lib/i18n/ru.i18n.json
@@ -1253,6 +1253,7 @@
     "removedFromWatchlist": "Удалено из списка просмотра",
     "watchlistUpdateFailed": "Не удалось обновить список для просмотра",
     "watchlistNoMatch": "Не удалось сопоставить этот элемент со списком просмотра",
+    "openInLibrary": "Открыть в библиотеке",
     "notInLibrary": "Нет в вашей библиотеке",
     "inTheseLibraries": "В этих библиотеках",
     "checkingLibrary": "Проверка вашей библиотеки...",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 22
-/// Strings: 43560 (1980 per locale)
+/// Strings: 43582 (1981 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_az.g.dart
+++ b/lib/i18n/strings_az.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$az extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Baxış siyahısından silindi';
 	@override String get watchlistUpdateFailed => 'İzləmə siyahısı yenilənə bilmədi';
 	@override String get watchlistNoMatch => 'Bu elementi heç bir baxış siyahısı ilə uyğunlaşdırmaq olmadı';
+	@override String get openInLibrary => 'Kitabxanada aç';
 	@override String get notInLibrary => 'Kitabxananızda yoxdur';
 	@override String get inTheseLibraries => 'Bu kitabxanalarda var';
 	@override String get checkingLibrary => 'Kitabxananız yoxlanılır...';
@@ -4059,6 +4060,7 @@ extension on TranslationsAz {
 			'explore.removedFromWatchlist' => 'Baxış siyahısından silindi',
 			'explore.watchlistUpdateFailed' => 'İzləmə siyahısı yenilənə bilmədi',
 			'explore.watchlistNoMatch' => 'Bu elementi heç bir baxış siyahısı ilə uyğunlaşdırmaq olmadı',
+			'explore.openInLibrary' => 'Kitabxanada aç',
 			'explore.notInLibrary' => 'Kitabxananızda yoxdur',
 			'explore.inTheseLibraries' => 'Bu kitabxanalarda var',
 			'explore.checkingLibrary' => 'Kitabxananız yoxlanılır...',
@@ -4468,9 +4470,9 @@ extension on TranslationsAz {
 			'downloads.syncAllItems' => 'Bütün elementlər eyniləşdirilir',
 			'downloads.syncUnwatchedItems' => 'Baxılmayan elementlər eyniləşdirilir',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Əlçatandır',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Əlçatandır',
 			'downloads.syncRuleOffline' => 'Oflayn',
 			'downloads.syncRuleSignInRequired' => 'Daxil olmaq tələb olunur',
 			'downloads.syncRuleNotAvailableForProfile' => 'Cari profil üçün əlçatan deyil',

--- a/lib/i18n/strings_bg.g.dart
+++ b/lib/i18n/strings_bg.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$bg extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Премахнато от списъка за гледане';
 	@override String get watchlistUpdateFailed => 'Неуспешно обновяване на списъка за гледане';
 	@override String get watchlistNoMatch => 'Този елемент не можа да бъде съпоставен със списък за гледане';
+	@override String get openInLibrary => 'Отвори в библиотеката';
 	@override String get notInLibrary => 'Не е в твоята библиотека';
 	@override String get inTheseLibraries => 'В тези библиотеки';
 	@override String get checkingLibrary => 'Проверка на твоята библиотека...';
@@ -4059,6 +4060,7 @@ extension on TranslationsBg {
 			'explore.removedFromWatchlist' => 'Премахнато от списъка за гледане',
 			'explore.watchlistUpdateFailed' => 'Неуспешно обновяване на списъка за гледане',
 			'explore.watchlistNoMatch' => 'Този елемент не можа да бъде съпоставен със списък за гледане',
+			'explore.openInLibrary' => 'Отвори в библиотеката',
 			'explore.notInLibrary' => 'Не е в твоята библиотека',
 			'explore.inTheseLibraries' => 'В тези библиотеки',
 			'explore.checkingLibrary' => 'Проверка на твоята библиотека...',
@@ -4468,9 +4470,9 @@ extension on TranslationsBg {
 			'downloads.syncAllItems' => 'Синхронизират се всички елементи',
 			'downloads.syncUnwatchedItems' => 'Синхронизират се негледаните елементи',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Сървър: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Налично',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Налично',
 			'downloads.syncRuleOffline' => 'Офлайн',
 			'downloads.syncRuleSignInRequired' => 'Изисква се вход',
 			'downloads.syncRuleNotAvailableForProfile' => 'Не е налично за текущия профил',

--- a/lib/i18n/strings_da.g.dart
+++ b/lib/i18n/strings_da.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$da extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Fjernet fra overvågningslisten';
 	@override String get watchlistUpdateFailed => 'Kunne ikke opdatere ønskelisten';
 	@override String get watchlistNoMatch => 'Kunne ikke knytte dette element til en overvågningsliste';
+	@override String get openInLibrary => 'Åbn i bibliotek';
 	@override String get notInLibrary => 'Ikke i dit bibliotek';
 	@override String get inTheseLibraries => 'I disse biblioteker';
 	@override String get checkingLibrary => 'Tjekker dit bibliotek...';
@@ -4059,6 +4060,7 @@ extension on TranslationsDa {
 			'explore.removedFromWatchlist' => 'Fjernet fra overvågningslisten',
 			'explore.watchlistUpdateFailed' => 'Kunne ikke opdatere ønskelisten',
 			'explore.watchlistNoMatch' => 'Kunne ikke knytte dette element til en overvågningsliste',
+			'explore.openInLibrary' => 'Åbn i bibliotek',
 			'explore.notInLibrary' => 'Ikke i dit bibliotek',
 			'explore.inTheseLibraries' => 'I disse biblioteker',
 			'explore.checkingLibrary' => 'Tjekker dit bibliotek...',
@@ -4468,9 +4470,9 @@ extension on TranslationsDa {
 			'downloads.syncAllItems' => 'Synkroniserer alle elementer',
 			'downloads.syncUnwatchedItems' => 'Synkroniserer usete elementer',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Tilgængelig',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Tilgængelig',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Login påkrævet',
 			'downloads.syncRuleNotAvailableForProfile' => 'Ikke tilgængelig for nuværende profil',

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$de extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Von der Watchlist entfernt';
 	@override String get watchlistUpdateFailed => 'Merkliste konnte nicht aktualisiert werden';
 	@override String get watchlistNoMatch => 'Dieser Eintrag konnte keiner Watchlist zugeordnet werden';
+	@override String get openInLibrary => 'In Mediathek öffnen';
 	@override String get notInLibrary => 'Nicht in deiner Mediathek';
 	@override String get inTheseLibraries => 'In diesen Mediatheken';
 	@override String get checkingLibrary => 'Deine Mediathek wird überprüft …';
@@ -4059,6 +4060,7 @@ extension on TranslationsDe {
 			'explore.removedFromWatchlist' => 'Von der Watchlist entfernt',
 			'explore.watchlistUpdateFailed' => 'Merkliste konnte nicht aktualisiert werden',
 			'explore.watchlistNoMatch' => 'Dieser Eintrag konnte keiner Watchlist zugeordnet werden',
+			'explore.openInLibrary' => 'In Mediathek öffnen',
 			'explore.notInLibrary' => 'Nicht in deiner Mediathek',
 			'explore.inTheseLibraries' => 'In diesen Mediatheken',
 			'explore.checkingLibrary' => 'Deine Mediathek wird überprüft …',
@@ -4468,9 +4470,9 @@ extension on TranslationsDe {
 			'downloads.syncAllItems' => 'Alle Elemente synchronisieren',
 			'downloads.syncUnwatchedItems' => 'Ungesehene Elemente synchronisieren',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Verfügbar',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Verfügbar',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Anmeldung erforderlich',
 			'downloads.syncRuleNotAvailableForProfile' => 'Für das aktuelle Profil nicht verfügbar',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -3381,6 +3381,9 @@ class Translations$explore$en {
 	/// en: 'Couldn't match this item to a watchlist'
 	String get watchlistNoMatch => 'Couldn\'t match this item to a watchlist';
 
+	/// en: 'Open in library'
+	String get openInLibrary => 'Open in library';
+
 	/// en: 'Not in your library'
 	String get notInLibrary => 'Not in your library';
 
@@ -8020,6 +8023,7 @@ extension on Translations {
 			'explore.removedFromWatchlist' => 'Removed from watchlist',
 			'explore.watchlistUpdateFailed' => 'Couldn\'t update watchlist',
 			'explore.watchlistNoMatch' => 'Couldn\'t match this item to a watchlist',
+			'explore.openInLibrary' => 'Open in library',
 			'explore.notInLibrary' => 'Not in your library',
 			'explore.inTheseLibraries' => 'In these libraries',
 			'explore.checkingLibrary' => 'Checking your library...',
@@ -8429,9 +8433,9 @@ extension on Translations {
 			'downloads.syncAllItems' => 'Syncing all items',
 			'downloads.syncUnwatchedItems' => 'Syncing unwatched items',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Available',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Available',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Sign in required',
 			'downloads.syncRuleNotAvailableForProfile' => 'Not available for current profile',

--- a/lib/i18n/strings_es.g.dart
+++ b/lib/i18n/strings_es.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$es extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Eliminado de la lista de seguimiento';
 	@override String get watchlistUpdateFailed => 'No se pudo actualizar la lista de seguimiento';
 	@override String get watchlistNoMatch => 'No se pudo asociar este elemento con una lista de seguimiento';
+	@override String get openInLibrary => 'Abrir en la biblioteca';
 	@override String get notInLibrary => 'No está en tu biblioteca';
 	@override String get inTheseLibraries => 'En estas bibliotecas';
 	@override String get checkingLibrary => 'Comprobando tu biblioteca...';
@@ -4059,6 +4060,7 @@ extension on TranslationsEs {
 			'explore.removedFromWatchlist' => 'Eliminado de la lista de seguimiento',
 			'explore.watchlistUpdateFailed' => 'No se pudo actualizar la lista de seguimiento',
 			'explore.watchlistNoMatch' => 'No se pudo asociar este elemento con una lista de seguimiento',
+			'explore.openInLibrary' => 'Abrir en la biblioteca',
 			'explore.notInLibrary' => 'No está en tu biblioteca',
 			'explore.inTheseLibraries' => 'En estas bibliotecas',
 			'explore.checkingLibrary' => 'Comprobando tu biblioteca...',
@@ -4468,9 +4470,9 @@ extension on TranslationsEs {
 			'downloads.syncAllItems' => 'Sincronizando todos los elementos',
 			'downloads.syncUnwatchedItems' => 'Sincronizando elementos no vistos',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Servidor: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Disponible',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Disponible',
 			'downloads.syncRuleOffline' => 'Sin conexión',
 			'downloads.syncRuleSignInRequired' => 'Se requiere iniciar sesión',
 			'downloads.syncRuleNotAvailableForProfile' => 'No disponible para el perfil actual',

--- a/lib/i18n/strings_fr.g.dart
+++ b/lib/i18n/strings_fr.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$fr extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Retiré de la liste de suivi';
 	@override String get watchlistUpdateFailed => 'Impossible de mettre à jour la liste de suivi';
 	@override String get watchlistNoMatch => 'Impossible d’associer cet élément à une liste de suivi';
+	@override String get openInLibrary => 'Ouvrir dans la bibliothèque';
 	@override String get notInLibrary => 'Absent de votre bibliothèque';
 	@override String get inTheseLibraries => 'Dans ces bibliothèques';
 	@override String get checkingLibrary => 'Vérification de votre bibliothèque...';
@@ -4059,6 +4060,7 @@ extension on TranslationsFr {
 			'explore.removedFromWatchlist' => 'Retiré de la liste de suivi',
 			'explore.watchlistUpdateFailed' => 'Impossible de mettre à jour la liste de suivi',
 			'explore.watchlistNoMatch' => 'Impossible d’associer cet élément à une liste de suivi',
+			'explore.openInLibrary' => 'Ouvrir dans la bibliothèque',
 			'explore.notInLibrary' => 'Absent de votre bibliothèque',
 			'explore.inTheseLibraries' => 'Dans ces bibliothèques',
 			'explore.checkingLibrary' => 'Vérification de votre bibliothèque...',
@@ -4468,9 +4470,9 @@ extension on TranslationsFr {
 			'downloads.syncAllItems' => 'Synchronisation de tous les éléments',
 			'downloads.syncUnwatchedItems' => 'Synchronisation des éléments non vus',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Serveur : ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Disponible',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Disponible',
 			'downloads.syncRuleOffline' => 'Hors ligne',
 			'downloads.syncRuleSignInRequired' => 'Connexion requise',
 			'downloads.syncRuleNotAvailableForProfile' => 'Non disponible pour le profil actuel',

--- a/lib/i18n/strings_hu.g.dart
+++ b/lib/i18n/strings_hu.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$hu extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Eltávolítva a figyelőlistáról';
 	@override String get watchlistUpdateFailed => 'Nem sikerült a Néznivalók frissítése';
 	@override String get watchlistNoMatch => 'Nem sikerült ezt az elemet figyelőlistához társítani';
+	@override String get openInLibrary => 'Megnyitás a könyvtárban';
 	@override String get notInLibrary => 'Nincs a könyvtáradban';
 	@override String get inTheseLibraries => 'Ezekben a könyvtárakban';
 	@override String get checkingLibrary => 'Könyvtár ellenőrzése...';
@@ -4059,6 +4060,7 @@ extension on TranslationsHu {
 			'explore.removedFromWatchlist' => 'Eltávolítva a figyelőlistáról',
 			'explore.watchlistUpdateFailed' => 'Nem sikerült a Néznivalók frissítése',
 			'explore.watchlistNoMatch' => 'Nem sikerült ezt az elemet figyelőlistához társítani',
+			'explore.openInLibrary' => 'Megnyitás a könyvtárban',
 			'explore.notInLibrary' => 'Nincs a könyvtáradban',
 			'explore.inTheseLibraries' => 'Ezekben a könyvtárakban',
 			'explore.checkingLibrary' => 'Könyvtár ellenőrzése...',
@@ -4468,9 +4470,9 @@ extension on TranslationsHu {
 			'downloads.syncAllItems' => 'Minden elem szinkronizálása',
 			'downloads.syncUnwatchedItems' => 'Nem látott elemek szinkronizálása',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Szerver: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Elérhető',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Elérhető',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Bejelentkezés szükséges',
 			'downloads.syncRuleNotAvailableForProfile' => 'Nem érhető el a jelenlegi profilhoz',

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$it extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Rimosso dalla lista titoli';
 	@override String get watchlistUpdateFailed => 'Impossibile aggiornare la lista da guardare';
 	@override String get watchlistNoMatch => 'Impossibile associare questo elemento a una lista titoli';
+	@override String get openInLibrary => 'Apri nella libreria';
 	@override String get notInLibrary => 'Non è nella tua libreria';
 	@override String get inTheseLibraries => 'In queste librerie';
 	@override String get checkingLibrary => 'Ricerca nella tua libreria...';
@@ -4059,6 +4060,7 @@ extension on TranslationsIt {
 			'explore.removedFromWatchlist' => 'Rimosso dalla lista titoli',
 			'explore.watchlistUpdateFailed' => 'Impossibile aggiornare la lista da guardare',
 			'explore.watchlistNoMatch' => 'Impossibile associare questo elemento a una lista titoli',
+			'explore.openInLibrary' => 'Apri nella libreria',
 			'explore.notInLibrary' => 'Non è nella tua libreria',
 			'explore.inTheseLibraries' => 'In queste librerie',
 			'explore.checkingLibrary' => 'Ricerca nella tua libreria...',
@@ -4468,9 +4470,9 @@ extension on TranslationsIt {
 			'downloads.syncAllItems' => 'Sincronizzazione di tutti gli elementi',
 			'downloads.syncUnwatchedItems' => 'Sincronizzazione degli elementi non visti',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Disponibile',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Disponibile',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Accesso richiesto',
 			'downloads.syncRuleNotAvailableForProfile' => 'Non disponibile per il profilo attuale',

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -1397,6 +1397,7 @@ class _Translations$explore$ja extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'ウォッチリストから削除しました';
 	@override String get watchlistUpdateFailed => 'ウォッチリストを更新できませんでした';
 	@override String get watchlistNoMatch => 'このアイテムに一致するウォッチリスト項目が見つかりませんでした';
+	@override String get openInLibrary => 'ライブラリで開く';
 	@override String get notInLibrary => 'ライブラリにありません';
 	@override String get inTheseLibraries => 'これらのライブラリにあります';
 	@override String get checkingLibrary => 'ライブラリを確認中…';
@@ -4049,6 +4050,7 @@ extension on TranslationsJa {
 			'explore.removedFromWatchlist' => 'ウォッチリストから削除しました',
 			'explore.watchlistUpdateFailed' => 'ウォッチリストを更新できませんでした',
 			'explore.watchlistNoMatch' => 'このアイテムに一致するウォッチリスト項目が見つかりませんでした',
+			'explore.openInLibrary' => 'ライブラリで開く',
 			'explore.notInLibrary' => 'ライブラリにありません',
 			'explore.inTheseLibraries' => 'これらのライブラリにあります',
 			'explore.checkingLibrary' => 'ライブラリを確認中…',
@@ -4458,9 +4460,9 @@ extension on TranslationsJa {
 			'downloads.syncAllItems' => 'すべてのアイテムを同期中',
 			'downloads.syncUnwatchedItems' => '未視聴のアイテムを同期中',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'サーバー: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => '利用可能',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => '利用可能',
 			'downloads.syncRuleOffline' => 'オフライン',
 			'downloads.syncRuleSignInRequired' => 'サインインが必要',
 			'downloads.syncRuleNotAvailableForProfile' => '現在のプロフィールでは利用できません',

--- a/lib/i18n/strings_kk.g.dart
+++ b/lib/i18n/strings_kk.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$kk extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Көру тізімінен алынды';
 	@override String get watchlistUpdateFailed => 'Көру тізімін жаңарту мүмкін болмады';
 	@override String get watchlistNoMatch => 'Бұл элементті көру тізімімен сәйкестендіру мүмкін болмады';
+	@override String get openInLibrary => 'Кітапханада ашу';
 	@override String get notInLibrary => 'Кітапханаңызда жоқ';
 	@override String get inTheseLibraries => 'Осы кітапханаларда бар';
 	@override String get checkingLibrary => 'Кітапхана тексерілуде...';
@@ -4059,6 +4060,7 @@ extension on TranslationsKk {
 			'explore.removedFromWatchlist' => 'Көру тізімінен алынды',
 			'explore.watchlistUpdateFailed' => 'Көру тізімін жаңарту мүмкін болмады',
 			'explore.watchlistNoMatch' => 'Бұл элементті көру тізімімен сәйкестендіру мүмкін болмады',
+			'explore.openInLibrary' => 'Кітапханада ашу',
 			'explore.notInLibrary' => 'Кітапханаңызда жоқ',
 			'explore.inTheseLibraries' => 'Осы кітапханаларда бар',
 			'explore.checkingLibrary' => 'Кітапхана тексерілуде...',
@@ -4468,9 +4470,9 @@ extension on TranslationsKk {
 			'downloads.syncAllItems' => 'Барлық элементтер синхрондалады',
 			'downloads.syncUnwatchedItems' => 'Көрілмеген элементтер синхрондалады',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Сервер: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Қолжетімді',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Қолжетімді',
 			'downloads.syncRuleOffline' => 'Офлайн',
 			'downloads.syncRuleSignInRequired' => 'Кіру қажет',
 			'downloads.syncRuleNotAvailableForProfile' => 'Ағымдағы профиль үшін қолжетімсіз',

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -1397,6 +1397,7 @@ class _Translations$explore$ko extends Translations$explore$en {
 	@override String get removedFromWatchlist => '관심 목록에서 삭제했습니다';
 	@override String get watchlistUpdateFailed => '관심 목록을 업데이트하지 못했습니다';
 	@override String get watchlistNoMatch => '이 항목을 관심 목록과 연결할 수 없습니다';
+	@override String get openInLibrary => '라이브러리에서 열기';
 	@override String get notInLibrary => '라이브러리에 없음';
 	@override String get inTheseLibraries => '이 라이브러리에 있음';
 	@override String get checkingLibrary => '라이브러리 확인 중...';
@@ -4049,6 +4050,7 @@ extension on TranslationsKo {
 			'explore.removedFromWatchlist' => '관심 목록에서 삭제했습니다',
 			'explore.watchlistUpdateFailed' => '관심 목록을 업데이트하지 못했습니다',
 			'explore.watchlistNoMatch' => '이 항목을 관심 목록과 연결할 수 없습니다',
+			'explore.openInLibrary' => '라이브러리에서 열기',
 			'explore.notInLibrary' => '라이브러리에 없음',
 			'explore.inTheseLibraries' => '이 라이브러리에 있음',
 			'explore.checkingLibrary' => '라이브러리 확인 중...',
@@ -4458,9 +4460,9 @@ extension on TranslationsKo {
 			'downloads.syncAllItems' => '모든 항목 동기화 중',
 			'downloads.syncUnwatchedItems' => '시청하지 않은 항목 동기화 중',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => '서버: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => '사용 가능',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => '사용 가능',
 			'downloads.syncRuleOffline' => '오프라인',
 			'downloads.syncRuleSignInRequired' => '로그인 필요',
 			'downloads.syncRuleNotAvailableForProfile' => '현재 프로필에서 사용할 수 없음',

--- a/lib/i18n/strings_nb.g.dart
+++ b/lib/i18n/strings_nb.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$nb extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Fjernet fra overvåkningslisten';
 	@override String get watchlistUpdateFailed => 'Kunne ikke oppdatere ønskelisten';
 	@override String get watchlistNoMatch => 'Kunne ikke koble dette elementet til en overvåkningsliste';
+	@override String get openInLibrary => 'Åpne i bibliotek';
 	@override String get notInLibrary => 'Ikke i biblioteket ditt';
 	@override String get inTheseLibraries => 'I disse bibliotekene';
 	@override String get checkingLibrary => 'Sjekker biblioteket ditt...';
@@ -4059,6 +4060,7 @@ extension on TranslationsNb {
 			'explore.removedFromWatchlist' => 'Fjernet fra overvåkningslisten',
 			'explore.watchlistUpdateFailed' => 'Kunne ikke oppdatere ønskelisten',
 			'explore.watchlistNoMatch' => 'Kunne ikke koble dette elementet til en overvåkningsliste',
+			'explore.openInLibrary' => 'Åpne i bibliotek',
 			'explore.notInLibrary' => 'Ikke i biblioteket ditt',
 			'explore.inTheseLibraries' => 'I disse bibliotekene',
 			'explore.checkingLibrary' => 'Sjekker biblioteket ditt...',
@@ -4468,9 +4470,9 @@ extension on TranslationsNb {
 			'downloads.syncAllItems' => 'Synkroniserer alle elementer',
 			'downloads.syncUnwatchedItems' => 'Synkroniserer usette elementer',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Tilgjengelig',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Tilgjengelig',
 			'downloads.syncRuleOffline' => 'Frakoblet',
 			'downloads.syncRuleSignInRequired' => 'Innlogging kreves',
 			'downloads.syncRuleNotAvailableForProfile' => 'Ikke tilgjengelig for gjeldende profil',

--- a/lib/i18n/strings_nl.g.dart
+++ b/lib/i18n/strings_nl.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$nl extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Uit kijklijst verwijderd';
 	@override String get watchlistUpdateFailed => 'Kon kijklijst niet bijwerken';
 	@override String get watchlistNoMatch => 'Kon dit item niet aan een kijklijst koppelen';
+	@override String get openInLibrary => 'Openen in bibliotheek';
 	@override String get notInLibrary => 'Niet in je bibliotheek';
 	@override String get inTheseLibraries => 'In deze bibliotheken';
 	@override String get checkingLibrary => 'Je bibliotheek controleren...';
@@ -4059,6 +4060,7 @@ extension on TranslationsNl {
 			'explore.removedFromWatchlist' => 'Uit kijklijst verwijderd',
 			'explore.watchlistUpdateFailed' => 'Kon kijklijst niet bijwerken',
 			'explore.watchlistNoMatch' => 'Kon dit item niet aan een kijklijst koppelen',
+			'explore.openInLibrary' => 'Openen in bibliotheek',
 			'explore.notInLibrary' => 'Niet in je bibliotheek',
 			'explore.inTheseLibraries' => 'In deze bibliotheken',
 			'explore.checkingLibrary' => 'Je bibliotheek controleren...',
@@ -4468,9 +4470,9 @@ extension on TranslationsNl {
 			'downloads.syncAllItems' => 'Alle items synchroniseren',
 			'downloads.syncUnwatchedItems' => 'Ongekeken items synchroniseren',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Beschikbaar',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Beschikbaar',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Inloggen vereist',
 			'downloads.syncRuleNotAvailableForProfile' => 'Niet beschikbaar voor huidig profiel',

--- a/lib/i18n/strings_pl.g.dart
+++ b/lib/i18n/strings_pl.g.dart
@@ -1415,6 +1415,7 @@ class _Translations$explore$pl extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Usunięto z listy do obejrzenia';
 	@override String get watchlistUpdateFailed => 'Nie udało się zaktualizować listy do obejrzenia';
 	@override String get watchlistNoMatch => 'Nie udało się dopasować tej pozycji do listy do obejrzenia';
+	@override String get openInLibrary => 'Otwórz w bibliotece';
 	@override String get notInLibrary => 'Nie ma tego w Twojej bibliotece';
 	@override String get inTheseLibraries => 'W tych bibliotekach';
 	@override String get checkingLibrary => 'Sprawdzanie Twojej biblioteki...';
@@ -4079,6 +4080,7 @@ extension on TranslationsPl {
 			'explore.removedFromWatchlist' => 'Usunięto z listy do obejrzenia',
 			'explore.watchlistUpdateFailed' => 'Nie udało się zaktualizować listy do obejrzenia',
 			'explore.watchlistNoMatch' => 'Nie udało się dopasować tej pozycji do listy do obejrzenia',
+			'explore.openInLibrary' => 'Otwórz w bibliotece',
 			'explore.notInLibrary' => 'Nie ma tego w Twojej bibliotece',
 			'explore.inTheseLibraries' => 'W tych bibliotekach',
 			'explore.checkingLibrary' => 'Sprawdzanie Twojej biblioteki...',
@@ -4488,9 +4490,9 @@ extension on TranslationsPl {
 			'downloads.syncAllItems' => 'Synchronizacja wszystkich elementów',
 			'downloads.syncUnwatchedItems' => 'Synchronizacja nieobejrzanych elementów',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Serwer: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Dostępne',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Dostępne',
 			'downloads.syncRuleOffline' => 'Brak połączenia',
 			'downloads.syncRuleSignInRequired' => 'Wymagane logowanie',
 			'downloads.syncRuleNotAvailableForProfile' => 'Niedostępne dla bieżącego profilu',

--- a/lib/i18n/strings_pt.g.dart
+++ b/lib/i18n/strings_pt.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$pt extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Removido da lista de interesses';
 	@override String get watchlistUpdateFailed => 'Não foi possível atualizar a lista para assistir';
 	@override String get watchlistNoMatch => 'Não foi possível associar este item a uma lista de interesses';
+	@override String get openInLibrary => 'Abrir na biblioteca';
 	@override String get notInLibrary => 'Não está na sua biblioteca';
 	@override String get inTheseLibraries => 'Nestas bibliotecas';
 	@override String get checkingLibrary => 'Verificando sua biblioteca...';
@@ -4059,6 +4060,7 @@ extension on TranslationsPt {
 			'explore.removedFromWatchlist' => 'Removido da lista de interesses',
 			'explore.watchlistUpdateFailed' => 'Não foi possível atualizar a lista para assistir',
 			'explore.watchlistNoMatch' => 'Não foi possível associar este item a uma lista de interesses',
+			'explore.openInLibrary' => 'Abrir na biblioteca',
 			'explore.notInLibrary' => 'Não está na sua biblioteca',
 			'explore.inTheseLibraries' => 'Nestas bibliotecas',
 			'explore.checkingLibrary' => 'Verificando sua biblioteca...',
@@ -4468,9 +4470,9 @@ extension on TranslationsPt {
 			'downloads.syncAllItems' => 'Sincronizando todos os itens',
 			'downloads.syncUnwatchedItems' => 'Sincronizando itens não assistidos',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Servidor: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Disponível',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Disponível',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'É necessário entrar',
 			'downloads.syncRuleNotAvailableForProfile' => 'Indisponível para o perfil atual',

--- a/lib/i18n/strings_ru.g.dart
+++ b/lib/i18n/strings_ru.g.dart
@@ -1415,6 +1415,7 @@ class _Translations$explore$ru extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Удалено из списка просмотра';
 	@override String get watchlistUpdateFailed => 'Не удалось обновить список для просмотра';
 	@override String get watchlistNoMatch => 'Не удалось сопоставить этот элемент со списком просмотра';
+	@override String get openInLibrary => 'Открыть в библиотеке';
 	@override String get notInLibrary => 'Нет в вашей библиотеке';
 	@override String get inTheseLibraries => 'В этих библиотеках';
 	@override String get checkingLibrary => 'Проверка вашей библиотеки...';
@@ -4079,6 +4080,7 @@ extension on TranslationsRu {
 			'explore.removedFromWatchlist' => 'Удалено из списка просмотра',
 			'explore.watchlistUpdateFailed' => 'Не удалось обновить список для просмотра',
 			'explore.watchlistNoMatch' => 'Не удалось сопоставить этот элемент со списком просмотра',
+			'explore.openInLibrary' => 'Открыть в библиотеке',
 			'explore.notInLibrary' => 'Нет в вашей библиотеке',
 			'explore.inTheseLibraries' => 'В этих библиотеках',
 			'explore.checkingLibrary' => 'Проверка вашей библиотеки...',
@@ -4488,9 +4490,9 @@ extension on TranslationsRu {
 			'downloads.syncAllItems' => 'Синхронизация всех элементов',
 			'downloads.syncUnwatchedItems' => 'Синхронизация непросмотренных элементов',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Сервер: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Доступен',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Доступен',
 			'downloads.syncRuleOffline' => 'Офлайн',
 			'downloads.syncRuleSignInRequired' => 'Требуется вход',
 			'downloads.syncRuleNotAvailableForProfile' => 'Недоступно для текущего профиля',

--- a/lib/i18n/strings_sv.g.dart
+++ b/lib/i18n/strings_sv.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$sv extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Borttagen från bevakningslistan';
 	@override String get watchlistUpdateFailed => 'Det gick inte att uppdatera bevakningslistan';
 	@override String get watchlistNoMatch => 'Det gick inte att matcha det här objektet mot en bevakningslista';
+	@override String get openInLibrary => 'Öppna i bibliotek';
 	@override String get notInLibrary => 'Finns inte i ditt bibliotek';
 	@override String get inTheseLibraries => 'I dessa bibliotek';
 	@override String get checkingLibrary => 'Kontrollerar ditt bibliotek...';
@@ -4059,6 +4060,7 @@ extension on TranslationsSv {
 			'explore.removedFromWatchlist' => 'Borttagen från bevakningslistan',
 			'explore.watchlistUpdateFailed' => 'Det gick inte att uppdatera bevakningslistan',
 			'explore.watchlistNoMatch' => 'Det gick inte att matcha det här objektet mot en bevakningslista',
+			'explore.openInLibrary' => 'Öppna i bibliotek',
 			'explore.notInLibrary' => 'Finns inte i ditt bibliotek',
 			'explore.inTheseLibraries' => 'I dessa bibliotek',
 			'explore.checkingLibrary' => 'Kontrollerar ditt bibliotek...',
@@ -4468,9 +4470,9 @@ extension on TranslationsSv {
 			'downloads.syncAllItems' => 'Synkroniserar alla objekt',
 			'downloads.syncUnwatchedItems' => 'Synkroniserar osedda objekt',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Tillgänglig',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Tillgänglig',
 			'downloads.syncRuleOffline' => 'Offline',
 			'downloads.syncRuleSignInRequired' => 'Inloggning krävs',
 			'downloads.syncRuleNotAvailableForProfile' => 'Inte tillgänglig för aktuell profil',

--- a/lib/i18n/strings_tr.g.dart
+++ b/lib/i18n/strings_tr.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$tr extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'İzleme listesinden kaldırıldı';
 	@override String get watchlistUpdateFailed => 'İzleme listesi güncellenemedi';
 	@override String get watchlistNoMatch => 'Bu öğe bir izleme listesiyle eşleştirilemedi';
+	@override String get openInLibrary => 'Kitaplıkta aç';
 	@override String get notInLibrary => 'Kitaplığınızda yok';
 	@override String get inTheseLibraries => 'Bu kitaplıklarda var';
 	@override String get checkingLibrary => 'Kitaplığınız kontrol ediliyor...';
@@ -4059,6 +4060,7 @@ extension on TranslationsTr {
 			'explore.removedFromWatchlist' => 'İzleme listesinden kaldırıldı',
 			'explore.watchlistUpdateFailed' => 'İzleme listesi güncellenemedi',
 			'explore.watchlistNoMatch' => 'Bu öğe bir izleme listesiyle eşleştirilemedi',
+			'explore.openInLibrary' => 'Kitaplıkta aç',
 			'explore.notInLibrary' => 'Kitaplığınızda yok',
 			'explore.inTheseLibraries' => 'Bu kitaplıklarda var',
 			'explore.checkingLibrary' => 'Kitaplığınız kontrol ediliyor...',
@@ -4468,9 +4470,9 @@ extension on TranslationsTr {
 			'downloads.syncAllItems' => 'Tüm ögeler eşitleniyor',
 			'downloads.syncUnwatchedItems' => 'İzlenmeyen ögeler eşitleniyor',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Sunucu: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Kullanılabilir',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Kullanılabilir',
 			'downloads.syncRuleOffline' => 'Çevrimdışı',
 			'downloads.syncRuleSignInRequired' => 'Giriş gerekli',
 			'downloads.syncRuleNotAvailableForProfile' => 'Mevcut profil için kullanılamaz',

--- a/lib/i18n/strings_uz.g.dart
+++ b/lib/i18n/strings_uz.g.dart
@@ -1403,6 +1403,7 @@ class _Translations$explore$uz extends Translations$explore$en {
 	@override String get removedFromWatchlist => 'Tomosha roʻyxatidan olib tashlandi';
 	@override String get watchlistUpdateFailed => 'Tomosha roʻyxatini yangilab boʻlmadi';
 	@override String get watchlistNoMatch => 'Bu elementni tomosha roʻyxatiga moslab boʻlmadi';
+	@override String get openInLibrary => 'Kutubxonada ochish';
 	@override String get notInLibrary => 'Kutubxonangizda yoʻq';
 	@override String get inTheseLibraries => 'Ushbu kutubxonalarda bor';
 	@override String get checkingLibrary => 'Kutubxona tekshirilmoqda...';
@@ -4059,6 +4060,7 @@ extension on TranslationsUz {
 			'explore.removedFromWatchlist' => 'Tomosha roʻyxatidan olib tashlandi',
 			'explore.watchlistUpdateFailed' => 'Tomosha roʻyxatini yangilab boʻlmadi',
 			'explore.watchlistNoMatch' => 'Bu elementni tomosha roʻyxatiga moslab boʻlmadi',
+			'explore.openInLibrary' => 'Kutubxonada ochish',
 			'explore.notInLibrary' => 'Kutubxonangizda yoʻq',
 			'explore.inTheseLibraries' => 'Ushbu kutubxonalarda bor',
 			'explore.checkingLibrary' => 'Kutubxona tekshirilmoqda...',
@@ -4468,9 +4470,9 @@ extension on TranslationsUz {
 			'downloads.syncAllItems' => 'Barcha elementlar sinxronlanadi',
 			'downloads.syncUnwatchedItems' => 'Koʻrilmagan elementlar sinxronlanadi',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => 'Server: ${server} • ${status}',
-			'downloads.syncRuleAvailable' => 'Mavjud',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => 'Mavjud',
 			'downloads.syncRuleOffline' => 'Oflayn',
 			'downloads.syncRuleSignInRequired' => 'Kirish talab etiladi',
 			'downloads.syncRuleNotAvailableForProfile' => 'Joriy profil uchun mavjud emas',

--- a/lib/i18n/strings_zh.g.dart
+++ b/lib/i18n/strings_zh.g.dart
@@ -1397,6 +1397,7 @@ class Translations$explore$zh extends Translations$explore$en {
 	@override String get removedFromWatchlist => '已从待看列表中移除';
 	@override String get watchlistUpdateFailed => '无法更新想看列表';
 	@override String get watchlistNoMatch => '无法将此项目与待看列表匹配';
+	@override String get openInLibrary => '在媒体库中打开';
 	@override String get notInLibrary => '不在你的媒体库中';
 	@override String get inTheseLibraries => '在这些媒体库中';
 	@override String get checkingLibrary => '正在检查你的媒体库…';
@@ -4049,6 +4050,7 @@ extension on TranslationsZh {
 			'explore.removedFromWatchlist' => '已从待看列表中移除',
 			'explore.watchlistUpdateFailed' => '无法更新想看列表',
 			'explore.watchlistNoMatch' => '无法将此项目与待看列表匹配',
+			'explore.openInLibrary' => '在媒体库中打开',
 			'explore.notInLibrary' => '不在你的媒体库中',
 			'explore.inTheseLibraries' => '在这些媒体库中',
 			'explore.checkingLibrary' => '正在检查你的媒体库…',
@@ -4458,9 +4460,9 @@ extension on TranslationsZh {
 			'downloads.syncAllItems' => '同步所有项目',
 			'downloads.syncUnwatchedItems' => '同步未观看项目',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => '服务器：${server} • ${status}',
-			'downloads.syncRuleAvailable' => '可用',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => '可用',
 			'downloads.syncRuleOffline' => '离线',
 			'downloads.syncRuleSignInRequired' => '需要登录',
 			'downloads.syncRuleNotAvailableForProfile' => '当前用户资料不可用',

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -1398,6 +1398,7 @@ class _Translations$explore$zh_Hant extends Translations$explore$zh {
 	@override String get removedFromWatchlist => '已從待看清單移除';
 	@override String get watchlistUpdateFailed => '無法更新待看清單';
 	@override String get watchlistNoMatch => '無法將此項目與待看清單配對';
+	@override String get openInLibrary => '在媒體庫中開啟';
 	@override String get notInLibrary => '不在您的媒體庫中';
 	@override String get inTheseLibraries => '在這些媒體庫中';
 	@override String get checkingLibrary => '正在檢查您的媒體庫…';
@@ -4050,6 +4051,7 @@ extension on TranslationsZhHant {
 			'explore.removedFromWatchlist' => '已從待看清單移除',
 			'explore.watchlistUpdateFailed' => '無法更新待看清單',
 			'explore.watchlistNoMatch' => '無法將此項目與待看清單配對',
+			'explore.openInLibrary' => '在媒體庫中開啟',
 			'explore.notInLibrary' => '不在您的媒體庫中',
 			'explore.inTheseLibraries' => '在這些媒體庫中',
 			'explore.checkingLibrary' => '正在檢查您的媒體庫…',
@@ -4459,9 +4461,9 @@ extension on TranslationsZhHant {
 			'downloads.syncAllItems' => '同步所有項目',
 			'downloads.syncUnwatchedItems' => '同步未觀看項目',
 			'downloads.syncRuleServerContext' => ({required Object server, required Object status}) => '伺服器：${server} • ${status}',
-			'downloads.syncRuleAvailable' => '可用',
 			_ => null,
 		} ?? switch (path) {
+			'downloads.syncRuleAvailable' => '可用',
 			'downloads.syncRuleOffline' => '離線',
 			'downloads.syncRuleSignInRequired' => '需要登入',
 			'downloads.syncRuleNotAvailableForProfile' => '目前使用者設定檔無法使用',

--- a/lib/i18n/sv.i18n.json
+++ b/lib/i18n/sv.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Borttagen från bevakningslistan",
     "watchlistUpdateFailed": "Det gick inte att uppdatera bevakningslistan",
     "watchlistNoMatch": "Det gick inte att matcha det här objektet mot en bevakningslista",
+    "openInLibrary": "Öppna i bibliotek",
     "notInLibrary": "Finns inte i ditt bibliotek",
     "inTheseLibraries": "I dessa bibliotek",
     "checkingLibrary": "Kontrollerar ditt bibliotek...",

--- a/lib/i18n/tr.i18n.json
+++ b/lib/i18n/tr.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "İzleme listesinden kaldırıldı",
     "watchlistUpdateFailed": "İzleme listesi güncellenemedi",
     "watchlistNoMatch": "Bu öğe bir izleme listesiyle eşleştirilemedi",
+    "openInLibrary": "Kitaplıkta aç",
     "notInLibrary": "Kitaplığınızda yok",
     "inTheseLibraries": "Bu kitaplıklarda var",
     "checkingLibrary": "Kitaplığınız kontrol ediliyor...",

--- a/lib/i18n/uz.i18n.json
+++ b/lib/i18n/uz.i18n.json
@@ -1241,6 +1241,7 @@
     "removedFromWatchlist": "Tomosha roʻyxatidan olib tashlandi",
     "watchlistUpdateFailed": "Tomosha roʻyxatini yangilab boʻlmadi",
     "watchlistNoMatch": "Bu elementni tomosha roʻyxatiga moslab boʻlmadi",
+    "openInLibrary": "Kutubxonada ochish",
     "notInLibrary": "Kutubxonangizda yoʻq",
     "inTheseLibraries": "Ushbu kutubxonalarda bor",
     "checkingLibrary": "Kutubxona tekshirilmoqda...",

--- a/lib/i18n/zh-Hant.i18n.json
+++ b/lib/i18n/zh-Hant.i18n.json
@@ -1235,6 +1235,7 @@
     "removedFromWatchlist": "已從待看清單移除",
     "watchlistUpdateFailed": "無法更新待看清單",
     "watchlistNoMatch": "無法將此項目與待看清單配對",
+    "openInLibrary": "在媒體庫中開啟",
     "notInLibrary": "不在您的媒體庫中",
     "inTheseLibraries": "在這些媒體庫中",
     "checkingLibrary": "正在檢查您的媒體庫…",

--- a/lib/i18n/zh.i18n.json
+++ b/lib/i18n/zh.i18n.json
@@ -1235,6 +1235,7 @@
     "removedFromWatchlist": "已从待看列表中移除",
     "watchlistUpdateFailed": "无法更新想看列表",
     "watchlistNoMatch": "无法将此项目与待看列表匹配",
+    "openInLibrary": "在媒体库中打开",
     "notInLibrary": "不在你的媒体库中",
     "inTheseLibraries": "在这些媒体库中",
     "checkingLibrary": "正在检查你的媒体库…",

--- a/lib/media/media_backend.dart
+++ b/lib/media/media_backend.dart
@@ -17,6 +17,12 @@ enum MediaBackend {
     MediaBackend.emby => 'emby',
   };
 
+  String get productName => switch (this) {
+    MediaBackend.plex => 'Plex',
+    MediaBackend.jellyfin => 'Jellyfin',
+    MediaBackend.emby => 'Emby',
+  };
+
   static MediaBackend fromId(String id) => switch (id) {
     'plex' => MediaBackend.plex,
     'jellyfin' => MediaBackend.jellyfin,

--- a/lib/screens/catalog_item_detail_screen.dart
+++ b/lib/screens/catalog_item_detail_screen.dart
@@ -564,8 +564,7 @@ class _CatalogItemDetailScreenState extends State<CatalogItemDetailScreen> {
     return details.isEmpty ? null : details.join(' • ');
   }
 
-  String _libraryMatchTitle(MediaItem match) =>
-      match.libraryTitle ?? match.serverName ?? match.backend.dialect?.productName ?? 'Plex';
+  String _libraryMatchTitle(MediaItem match) => match.libraryTitle ?? match.serverName ?? match.backend.productName;
 
   Future<void> _openLibraryItem(BuildContext hostContext) async {
     final matches = _matches;

--- a/lib/screens/catalog_item_detail_screen.dart
+++ b/lib/screens/catalog_item_detail_screen.dart
@@ -43,6 +43,7 @@ import '../utils/rating_utils.dart';
 import '../utils/snackbar_helper.dart';
 import '../widgets/app_bar_back_button.dart';
 import '../widgets/app_icon.dart';
+import '../widgets/app_menu.dart';
 import '../widgets/backend_badge.dart';
 import '../widgets/cast_member_strip.dart';
 import '../widgets/focusable_list_tile.dart';
@@ -68,6 +69,7 @@ class CatalogItemDetailScreen extends StatefulWidget {
 
 class _CatalogItemDetailScreenState extends State<CatalogItemDetailScreen> {
   final _actionBarKey = GlobalKey<FocusableActionBarState>();
+  final _libraryActionKey = GlobalKey();
   final _backButtonFocusNode = FocusNode(debugLabel: 'catalog_detail_back');
   final _castSectionKey = GlobalKey();
   final _castStripKey = GlobalKey<CastMemberStripState>();
@@ -298,7 +300,7 @@ class _CatalogItemDetailScreenState extends State<CatalogItemDetailScreen> {
   /// arrive with the detail fetch (see initState), so read the enriched item.
   bool get _canRequest => _requestSource != null && _item.ids.tmdb != null;
 
-  bool get _hasActions => _watchlistSource != null || _canRequest || _hasTrailer;
+  bool get _hasActions => _hasLibraryMatches || _watchlistSource != null || _canRequest || _hasTrailer;
 
   bool get _hasLibraryMatches => _libraryMatchFocusNodes.isNotEmpty;
 
@@ -557,16 +559,60 @@ class _CatalogItemDetailScreenState extends State<CatalogItemDetailScreen> {
     return best?.displayLabel;
   }
 
+  String? _libraryMatchSubtitle(MediaItem match) {
+    final details = [?_libraryMatchQuality(match), ?(match.libraryTitle == null ? null : match.serverName)];
+    return details.isEmpty ? null : details.join(' • ');
+  }
+
+  String _libraryMatchTitle(MediaItem match) =>
+      match.libraryTitle ?? match.serverName ?? match.backend.dialect?.productName ?? 'Plex';
+
+  Future<void> _openLibraryItem(BuildContext hostContext) async {
+    final matches = _matches;
+    if (matches == null || matches.isEmpty) return;
+
+    MediaItem? match;
+    if (matches.length == 1) {
+      match = matches.single;
+    } else {
+      final renderBox = _libraryActionKey.currentContext?.findRenderObject() as RenderBox?;
+      if (renderBox == null) return;
+      match = await showAdaptiveAppMenu<MediaItem>(
+        hostContext,
+        title: t.explore.openInLibrary,
+        anchorRect: renderBox.localToGlobal(Offset.zero) & renderBox.size,
+        focusFirstItem: InputModeTracker.isKeyboardMode(hostContext, listen: false),
+        isScrollControlled: true,
+        minWidth: 280,
+        entries: [
+          for (final match in matches)
+            AppMenuItem(
+              value: match,
+              leading: BackendBadge(backend: match.backend, size: 24),
+              label: match.serverName ?? match.backend.productName,
+              subtitle: _libraryMatchQuality(match),
+              trailing: const AppIcon(Symbols.chevron_right_rounded, fill: 1),
+            ),
+        ],
+      );
+    }
+    if (match == null || !mounted) return;
+    if (!hostContext.mounted) return;
+    await navigateToMediaItemDetails(hostContext, match);
+  }
+
   Widget _buildLibraryMatchTile(MediaItem match, int index) {
     // Plex matches carry their library title; MediaBrowser search-based lookup
     // only does when the ancestors call succeeded, so fall back to the server
     // name alone. The subtitle carries whatever else tells two copies apart.
-    final details = [?_libraryMatchQuality(match), ?(match.libraryTitle == null ? null : match.serverName)];
     return FocusableListTile(
       focusNode: _libraryMatchFocusNodes[index],
       leading: BackendBadge(backend: match.backend, size: 24),
-      title: Text(match.libraryTitle ?? match.serverName ?? match.backend.dialect?.productName ?? 'Plex'),
-      subtitle: details.isEmpty ? null : Text(details.join(' • ')),
+      title: Text(_libraryMatchTitle(match)),
+      subtitle: switch (_libraryMatchSubtitle(match)) {
+        final subtitle? => Text(subtitle),
+        null => null,
+      },
       trailing: const AppIcon(Symbols.chevron_right_rounded, fill: 1),
       onTap: () => unawaited(navigateToMediaItemDetails(context, match)),
     );
@@ -1300,6 +1346,17 @@ class _CatalogItemDetailScreenState extends State<CatalogItemDetailScreen> {
                                           key: _actionBarKey,
                                           onNavigateDown: _focusSectionBelowActions,
                                           actions: [
+                                            if (_hasLibraryMatches)
+                                              FocusableAction(
+                                                debugLabel: 'catalog_open_library',
+                                                onPressed: () => unawaited(_openLibraryItem(hostContext)),
+                                                child: IconButton(
+                                                  key: _libraryActionKey,
+                                                  icon: const AppIcon(Symbols.video_library_rounded, fill: 1),
+                                                  tooltip: t.explore.openInLibrary,
+                                                  onPressed: () => unawaited(_openLibraryItem(hostContext)),
+                                                ),
+                                              ),
                                             if (_watchlistSource != null)
                                               FocusableAction(
                                                 // Stable identities so the focused binding survives the

--- a/lib/widgets/app_menu.dart
+++ b/lib/widgets/app_menu.dart
@@ -78,6 +78,7 @@ Future<T?> showAppMenu<T>(
   Rect? anchorRect,
   AppMenuAnchorAlignment anchorAlignment = AppMenuAnchorAlignment.start,
   bool focusFirstItem = false,
+  double minWidth = 220,
 }) {
   assert(position != null || anchorRect != null, 'showAppMenu requires a position or anchorRect');
 
@@ -93,6 +94,7 @@ Future<T?> showAppMenu<T>(
       anchorRect: anchorRect,
       anchorAlignment: anchorAlignment,
       focusFirstItem: focusFirstItem,
+      minWidth: minWidth,
     ),
     transitionBuilder: (dialogContext, animation, _, child) {
       final curved = CurvedAnimation(parent: animation, curve: Curves.easeOutCubic, reverseCurve: Curves.easeInCubic);
@@ -124,6 +126,7 @@ Future<T?> showAdaptiveAppMenu<T>(
   AppMenuAnchorAlignment anchorAlignment = AppMenuAnchorAlignment.start,
   bool focusFirstItem = false,
   bool isScrollControlled = false,
+  double minWidth = 220,
 }) {
   // ThemeData.platform follows the real target platform by default, including
   // Android TV and tvOS, while remaining overrideable in widget tests.
@@ -144,6 +147,7 @@ Future<T?> showAdaptiveAppMenu<T>(
     anchorRect: anchorRect,
     anchorAlignment: anchorAlignment,
     focusFirstItem: focusFirstItem,
+    minWidth: minWidth,
   );
 }
 
@@ -564,6 +568,7 @@ class _AppMenuPopup<T> extends StatefulWidget {
   final Rect? anchorRect;
   final AppMenuAnchorAlignment anchorAlignment;
   final bool focusFirstItem;
+  final double minWidth;
 
   const _AppMenuPopup({
     required this.entries,
@@ -571,6 +576,7 @@ class _AppMenuPopup<T> extends StatefulWidget {
     required this.anchorRect,
     required this.anchorAlignment,
     required this.focusFirstItem,
+    required this.minWidth,
   });
 
   @override
@@ -578,14 +584,13 @@ class _AppMenuPopup<T> extends StatefulWidget {
 }
 
 class _AppMenuPopupState<T> extends State<_AppMenuPopup<T>> {
-  static const double _minMenuWidth = 220;
-
   @override
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.sizeOf(context);
     const edgePadding = 8.0;
-    final desiredWidth = math.max(_minMenuWidth, _estimateMenuWidth(context));
-    final menuWidth = desiredWidth.clamp(_minMenuWidth, math.max(_minMenuWidth, screenSize.width - edgePadding * 2));
+    final minMenuWidth = widget.minWidth;
+    final desiredWidth = math.max(minMenuWidth, _estimateMenuWidth(context));
+    final menuWidth = desiredWidth.clamp(minMenuWidth, math.max(minMenuWidth, screenSize.width - edgePadding * 2));
     final estimatedHeight = _estimateMenuHeight(widget.entries);
     final availableHeight = math.max(0.0, screenSize.height - edgePadding * 2);
     final menuHeight = estimatedHeight.clamp(0.0, availableHeight).toDouble();
@@ -673,7 +678,7 @@ class _AppMenuPopupState<T> extends State<_AppMenuPopup<T>> {
         longest = math.max(longest, entry.label?.length ?? 0);
       }
     }
-    return math.min(360, math.max(_minMenuWidth, 96 + longest * 7.5));
+    return math.min(360, math.max(widget.minWidth, 96 + longest * 7.5));
   }
 }
 

--- a/lib/widgets/rating_bottom_sheet.dart
+++ b/lib/widgets/rating_bottom_sheet.dart
@@ -542,7 +542,7 @@ class _RatingBottomSheetState extends State<RatingBottomSheet> {
     return () => nodes[index].requestFocus();
   }
 
-  String _backendLabel(MediaBackend backend) => backend.dialect?.productName ?? 'Plex';
+  String _backendLabel(MediaBackend backend) => backend.productName;
 }
 
 const _serverKey = 'server';

--- a/test/screens/catalog_item_detail_screen_test.dart
+++ b/test/screens/catalog_item_detail_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:plezy/focus/focusable_action_bar.dart';
+import 'package:plezy/focus/input_mode_tracker.dart';
 import 'package:plezy/i18n/strings.g.dart';
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/media/media_rating.dart';
@@ -29,11 +30,12 @@ import 'package:plezy/services/seerr/seerr_constants.dart';
 import 'package:plezy/services/settings_service.dart';
 import 'package:plezy/theme/mono_theme.dart';
 import 'package:plezy/utils/platform_detector.dart';
-import 'package:plezy/widgets/overlay_sheet.dart';
+import 'package:plezy/widgets/app_menu.dart';
 import 'package:plezy/widgets/hub_section.dart';
 import 'package:plezy/widgets/focusable_list_tile.dart';
 import 'package:plezy/widgets/media_card.dart';
 import 'package:plezy/widgets/optimized_media_image.dart';
+import 'package:plezy/widgets/overlay_sheet.dart';
 import 'package:provider/provider.dart';
 
 import '../test_helpers/media_items.dart';
@@ -170,6 +172,15 @@ class _FakeCatalogLibraryMatcher extends CatalogLibraryMatcher {
   Future<List<MediaItem>> match(CatalogItem item) async => matches;
 }
 
+class _PendingCatalogLibraryMatcher extends CatalogLibraryMatcher {
+  _PendingCatalogLibraryMatcher(super.multiServer, this.completer);
+
+  final Completer<List<MediaItem>> completer;
+
+  @override
+  Future<List<MediaItem>> match(CatalogItem item) => completer.future;
+}
+
 /// Matches only items that carry an external id, the way a real lookup for a
 /// Plex Discover row does (#1715): the bare rating-key form misses, the
 /// detail-enriched form hits.
@@ -221,10 +232,11 @@ MediaItem _libraryCopy({
   required String id,
   String? libraryTitle,
   String? videoResolution,
+  String serverId = 'server-1',
   String? serverName = 'Living Room',
 }) => testMediaItem(
   id: id,
-  serverId: 'server-1',
+  serverId: serverId,
   serverName: serverName,
   libraryId: libraryTitle == null ? null : id,
   libraryTitle: libraryTitle,
@@ -249,6 +261,7 @@ Future<void> _pumpDetail(
   CatalogItem item = _item,
   CatalogLibraryMatcher Function(MultiServerProvider multiServer)? matcherBuilder,
   SeerrCatalogSource? seerr,
+  bool settle = true,
 }) async {
   final sources = _FakeCatalogSourcesProvider(source, seerr: seerr);
   final serverManager = MultiServerManager();
@@ -261,30 +274,36 @@ Future<void> _pumpDetail(
 
   await tester.pumpWidget(
     TranslationProvider(
-      child: MultiProvider(
-        providers: [
-          Provider<CatalogLibraryMatcher>.value(value: matcher),
-          ChangeNotifierProvider<CatalogSourcesProvider>.value(value: sources),
-        ],
-        child: MaterialApp(
-          theme: monoTheme(dark: true),
-          home: pushedRoute
-              ? Builder(
-                  builder: (context) => Scaffold(
-                    body: TextButton(
-                      onPressed: () => Navigator.of(
-                        context,
-                      ).push(MaterialPageRoute<void>(builder: (_) => CatalogItemDetailScreen(item: item))),
-                      child: const Text('Open catalog'),
+      child: InputModeTracker(
+        child: MultiProvider(
+          providers: [
+            Provider<CatalogLibraryMatcher>.value(value: matcher),
+            ChangeNotifierProvider<CatalogSourcesProvider>.value(value: sources),
+          ],
+          child: MaterialApp(
+            theme: monoTheme(dark: true),
+            home: pushedRoute
+                ? Builder(
+                    builder: (context) => Scaffold(
+                      body: TextButton(
+                        onPressed: () => Navigator.of(
+                          context,
+                        ).push(MaterialPageRoute<void>(builder: (_) => CatalogItemDetailScreen(item: item))),
+                        child: const Text('Open catalog'),
+                      ),
                     ),
-                  ),
-                )
-              : CatalogItemDetailScreen(item: item),
+                  )
+                : CatalogItemDetailScreen(item: item),
+          ),
         ),
       ),
     ),
   );
-  await tester.pumpAndSettle();
+  if (settle) {
+    await tester.pumpAndSettle();
+  } else {
+    await tester.pump();
+  }
   if (pushedRoute) {
     await tester.tap(find.text('Open catalog'));
     await tester.pumpAndSettle();
@@ -404,6 +423,69 @@ void main() {
       await _pumpDetail(tester, source, seerr: _seerrSource(permissions: 0));
 
       expect(find.byTooltip(t.seerr.request), findsNothing);
+    });
+  });
+
+  group('open in library action', () {
+    testWidgets('stays hidden while matches are loading and when none are found', (tester) async {
+      final completer = Completer<List<MediaItem>>();
+      await _pumpDetail(
+        tester,
+        _FakeCatalogSource(),
+        matcherBuilder: (multiServer) => _PendingCatalogLibraryMatcher(multiServer, completer),
+        settle: false,
+      );
+
+      expect(find.byTooltip(t.explore.openInLibrary), findsNothing);
+
+      completer.complete(const []);
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip(t.explore.openInLibrary), findsNothing);
+    });
+
+    testWidgets('multiple matches open a chooser with every individual copy', (tester) async {
+      await _pumpDetail(
+        tester,
+        _FakeCatalogSource(),
+        matches: [
+          _libraryCopy(id: 'hd-copy', libraryTitle: 'Movies', videoResolution: '1080', serverName: 'Bedroom'),
+          _libraryCopy(id: 'uhd-copy', libraryTitle: '4K Movies', videoResolution: '4k'),
+        ],
+      );
+
+      await tester.tap(find.byTooltip(t.explore.openInLibrary));
+      await tester.pumpAndSettle();
+
+      final chooser = find.byWidgetPredicate((widget) => widget is AppMenuSheet<MediaItem>);
+      expect(chooser, findsOneWidget);
+      expect(find.descendant(of: chooser, matching: find.text('Bedroom')), findsOneWidget);
+      expect(find.descendant(of: chooser, matching: find.text('Living Room')), findsOneWidget);
+      expect(find.descendant(of: chooser, matching: find.text('Movies')), findsNothing);
+      expect(find.descendant(of: chooser, matching: find.text('4K Movies')), findsNothing);
+      expect(find.descendant(of: chooser, matching: find.textContaining('1080p')), findsOneWidget);
+      expect(find.descendant(of: chooser, matching: find.textContaining('4K')), findsWidgets);
+    });
+
+    testWidgets('D-pad opens the chooser with its first copy focused', (tester) async {
+      await _pumpDetail(
+        tester,
+        _FakeCatalogSource(),
+        matches: [
+          _libraryCopy(id: 'hd-copy', libraryTitle: 'Movies', videoResolution: '1080'),
+          _libraryCopy(id: 'uhd-copy', libraryTitle: '4K Movies', videoResolution: '4k'),
+        ],
+      );
+
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'catalog_watchlist');
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'catalog_open_library');
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pumpAndSettle();
+
+      expect(find.byWidgetPredicate((widget) => widget is AppMenuSheet<MediaItem>), findsOneWidget);
+      expect(FocusManager.instance.primaryFocus?.debugLabel, 'AppMenuInitialFocus');
     });
   });
 


### PR DESCRIPTION
Closes #1917 

## Summary
Adds an “Open in library” action to Explore catalog item details when Plezy finds matching items on connected media servers.

This reuses the existing `CatalogLibraryMatcher` results rather than introducing another lookup path.

## Behavior
- The action stays hidden while matches are loading or when no matches exist.
- One match opens its normal server-specific media detail page directly.
- Multiple matches open a chooser containing every individual media copy.
- Chooser entries show the server name with quality information underneath.
- No Play or Download action is added. (issue was directly asking for this feature, but that doesn't fit how media clients work)

Used GPT 5.6 Sol to help with development.

https://github.com/user-attachments/assets/bbd11a59-c919-4e61-9d1e-37b07c057d66

---

Note:
I left the "In these libraries" section alone. In theory it *could* be removed.
<img width="446" height="126" alt="CleanShot 2026-08-28 at 04 00 57" src="https://github.com/user-attachments/assets/3c517cc8-69f5-47ac-a480-fed64d881279" />
