### PR TITLE
fix(profiles): show the resume profile picker over active playback

### DIFF
--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -98,28 +98,24 @@ bool shouldHandleDesktopRootEscape({
 ///
 /// Mobile-only: on desktop `resumed` fires on every window focus gain
 /// (alt-tab, click), which is far too frequent — the startup prompt is
-/// sufficient there. Never during active video playback: waking the device
-/// mid-stream must resume the stream, not stack the root-navigator picker
-/// over the live player route, whose focus self-heal fights the picker for
-/// the remote (#2034) — the playback session already belongs to the profile
-/// that started it. Likewise never during a live companion-remote session:
-/// a phone driving another device backgrounds and sleeps constantly, and
-/// the picker + PIN would bury a session that already belongs to the
-/// profile that started it (#2087).
+/// sufficient there. The picker still shows over an active player: the user
+/// enabled "ask on open" precisely so a different person cannot resume their
+/// session, and #2034's focus fix keeps it responsive. Never during a live
+/// companion-remote session: a phone driving another device backgrounds and
+/// sleeps constantly, and the picker + PIN would bury a session that already
+/// belongs to the profile that started it (#2087).
 @visibleForTesting
 bool shouldShowProfileSelectionOnResume({
   required bool resumedFromBackground,
   required bool isOffline,
   required bool alreadyShowingProfileSelection,
   required bool isMobilePlatform,
-  required bool hasActiveVideoPlayback,
   required bool hasActiveCompanionRemoteSession,
 }) {
   return resumedFromBackground &&
       !isOffline &&
       !alreadyShowingProfileSelection &&
       isMobilePlatform &&
-      !hasActiveVideoPlayback &&
       !hasActiveCompanionRemoteSession;
 }
 
@@ -1151,7 +1147,6 @@ class _MainScreenState extends State<MainScreen>
       isOffline: _isOffline,
       alreadyShowingProfileSelection: _isShowingProfileSelection,
       isMobilePlatform: Platform.isAndroid || Platform.isIOS,
-      hasActiveVideoPlayback: VideoPlayerScreenState.activeGlobalKey != null,
       // Short-circuit on resumedFromBackground: the provider is lazy and
       // otherwise unused on phones, so an unconditional read would create it
       // on the first lifecycle event for users who never open the remote.

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -140,7 +140,11 @@ class ProfileSelectionResumeGate {
   /// Feeds one lifecycle transition through the gate. Returns true exactly
   /// once per backgrounding: on the first `resumed` after the sequence
   /// reached `hidden`/`paused`/`detached`. Consuming resets the latch.
-  bool consumePromptOn(AppLifecycleState state) {
+  ///
+  /// `pipContinuation` (read at the backgrounding, not at resume, since PiP can
+  /// end before the resume arrives): the session keeps playing in Picture in
+  /// Picture, so it never left the user's sight and must not prompt (#2195).
+  bool consumePromptOn(AppLifecycleState state, {bool pipContinuation = false}) {
     switch (state) {
       case AppLifecycleState.resumed:
         final shouldPrompt = _wasBackgrounded;
@@ -149,7 +153,7 @@ class ProfileSelectionResumeGate {
       case AppLifecycleState.hidden:
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:
-        _wasBackgrounded = true;
+        if (!pipContinuation) _wasBackgrounded = true;
         return false;
       case AppLifecycleState.inactive:
         return false;
@@ -1135,7 +1139,10 @@ class _MainScreenState extends State<MainScreen>
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     // Always consume: the gates latch backgrounding on every lifecycle event.
-    final resumedFromBackground = _profileSelectionResumeGate.consumePromptOn(state);
+    final resumedFromBackground = _profileSelectionResumeGate.consumePromptOn(
+      state,
+      pipContinuation: VideoPlayerScreenState.activePlayerContinuesInPip,
+    );
     final refreshStaleContent = _contentRefreshResumeGate.consumeRefreshOn(state);
     // Seerr authority is independent of media-server reachability and stale
     // content. A grant must recover hidden Request actions on any real resume.

--- a/lib/screens/video_player/media_controls_screen_controller.dart
+++ b/lib/screens/video_player/media_controls_screen_controller.dart
@@ -26,6 +26,7 @@ class MediaControlsScreenController {
     required this._manager,
     required this._player,
     required this._isMounted,
+    required this._isRouteCurrent,
     required this.isLive,
     required this._shouldSkipForPip,
     required this._isPlayerInitialized,
@@ -46,6 +47,7 @@ class MediaControlsScreenController {
   final MediaControlsManager? Function() _manager;
   final Player? Function() _player;
   final bool Function() _isMounted;
+  final bool Function() _isRouteCurrent;
   final bool isLive;
   final bool Function() _shouldSkipForPip;
   final bool Function() _isPlayerInitialized;
@@ -157,8 +159,15 @@ class MediaControlsScreenController {
     if (wasPlayingBeforeInactive) {
       try {
         await seekBackForRewind(currentPlayer);
-        await _play(currentPlayer);
-        appLogger.d('Video resumed after returning from inactive state');
+        // A picker (e.g. the resume profile selection) can cover the player on
+        // resume; do not restart audio and the server session under it until
+        // the user is back on the player route (#2195).
+        if (_isRouteCurrent()) {
+          await _play(currentPlayer);
+          appLogger.d('Video resumed after returning from inactive state');
+        } else {
+          appLogger.d('Player covered on resume; staying paused');
+        }
       } catch (e) {
         appLogger.w('Failed to resume playback after returning from inactive state', error: e);
       } finally {

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -2177,7 +2177,10 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
   /// or a hardware media key). Mirrors the controls path: rewind-on-resume,
   /// then play/pause with playback intent, then announce.
   Future<void> _remoteTransport(TransportCommand command, {required String source}) async {
-    if (!mounted || ModalRoute.of(context)?.isCurrent != true) return;
+    // isRouteChainCurrent, not the naive isCurrent: a root-navigator picker over
+    // the nested player leaves the player's own route current, so a hardware
+    // play/pause would otherwise resume the covered, PIN-protected session (#2195).
+    if (!mounted || !isRouteChainCurrent(context)) return;
 
     final currentPlayer = player;
     if (!_isPlayerInitialized || currentPlayer == null) {

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -82,6 +82,7 @@ import '../utils/player_utils.dart';
 import '../utils/orientation_helper.dart';
 import '../utils/platform_detector.dart';
 import '../utils/provider_extensions.dart';
+import '../utils/route_visibility.dart';
 import '../utils/snackbar_helper.dart';
 import '../utils/stream_buffer_sizing.dart';
 import '../utils/video_player_navigation.dart';
@@ -444,6 +445,15 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
 
   static bool isNavigationActive(VideoPlayerLaunchIdentity identity) => _activeRouteGuard.blocks(identity);
 
+  /// Whether the active player keeps its session alive across a background
+  /// (iOS/macOS auto-PiP, or PiP already active). Read at the `paused`
+  /// transition so the resume profile prompt stays off a session that never
+  /// left the user's sight (#2195, mirrors the companion-remote exemption).
+  static bool get activePlayerContinuesInPip {
+    final owner = _activeRouteGuard.owner;
+    return owner is VideoPlayerScreenState ? owner._shouldSkipForPip : false;
+  }
+
   Player? player;
   VideoVolumeController? _volumeController;
   bool _isPlayerInitialized = false;
@@ -739,6 +749,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
     manager: () => _mediaControlsManager,
     player: () => player,
     isMounted: () => mounted && !_shuttingDown,
+    isRouteCurrent: () => isRouteChainCurrent(context),
     isLive: widget.isLive,
     shouldSkipForPip: () => _shouldSkipForPip,
     isPlayerInitialized: () => _isPlayerInitialized,

--- a/lib/utils/route_visibility.dart
+++ b/lib/utils/route_visibility.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+/// Returns true when no route in the nested navigator chain covers [context].
+bool isRouteChainCurrent(BuildContext context) {
+  ModalRoute<Object?>? route = ModalRoute.of(context);
+  while (route != null) {
+    if (!route.isCurrent) return false;
+    final navigator = route.navigator;
+    if (navigator == null) break;
+    route = ModalRoute.of(navigator.context);
+  }
+  return true;
+}

--- a/lib/utils/video_player_navigation.dart
+++ b/lib/utils/video_player_navigation.dart
@@ -105,6 +105,9 @@ class VideoPlayerActiveRouteGuard {
 
   String? get activeGlobalKey => _identity?.globalKey;
 
+  /// The State that currently owns the active player route, if any.
+  Object? get owner => _owner;
+
   VideoPlayerLaunchIdentity? identityFor(Object owner) => identical(_owner, owner) ? _identity : null;
 
   bool blocks(VideoPlayerLaunchIdentity identity) => _identity == identity;

--- a/test/screens/main_screen_layout_test.dart
+++ b/test/screens/main_screen_layout_test.dart
@@ -213,6 +213,23 @@ void main() {
       final gate = ProfileSelectionResumeGate();
       expect(gate.consumePromptOn(AppLifecycleState.resumed), isFalse);
     });
+
+    test('does not prompt when the session keeps playing in PiP (#2195)', () {
+      final gate = ProfileSelectionResumeGate();
+      expect(gate.consumePromptOn(AppLifecycleState.hidden, pipContinuation: true), isFalse);
+      expect(gate.consumePromptOn(AppLifecycleState.paused, pipContinuation: true), isFalse);
+      expect(gate.wasBackgrounded, isFalse);
+      expect(gate.consumePromptOn(AppLifecycleState.resumed), isFalse);
+    });
+
+    test('a non-PiP frame still arms even if a later frame reports PiP', () {
+      final gate = ProfileSelectionResumeGate();
+      expect(gate.consumePromptOn(AppLifecycleState.paused), isFalse);
+      expect(gate.wasBackgrounded, isTrue);
+      // A later PiP-reporting frame must not clear an already-armed latch.
+      expect(gate.consumePromptOn(AppLifecycleState.hidden, pipContinuation: true), isFalse);
+      expect(gate.consumePromptOn(AppLifecycleState.resumed), isTrue);
+    });
   });
 
   group('ContentRefreshResumeGate', () {

--- a/test/screens/main_screen_layout_test.dart
+++ b/test/screens/main_screen_layout_test.dart
@@ -147,13 +147,12 @@ void main() {
     );
   });
 
-  test('resume prompt is suppressed during playback (#2034) and companion sessions (#2087)', () {
+  test('resume prompt shows over playback but not during companion sessions (#2087)', () {
     bool should({
       bool resumedFromBackground = true,
       bool isOffline = false,
       bool alreadyShowingProfileSelection = false,
       bool isMobilePlatform = true,
-      bool hasActiveVideoPlayback = false,
       bool hasActiveCompanionRemoteSession = false,
     }) {
       return shouldShowProfileSelectionOnResume(
@@ -161,15 +160,13 @@ void main() {
         isOffline: isOffline,
         alreadyShowingProfileSelection: alreadyShowingProfileSelection,
         isMobilePlatform: isMobilePlatform,
-        hasActiveVideoPlayback: hasActiveVideoPlayback,
         hasActiveCompanionRemoteSession: hasActiveCompanionRemoteSession,
       );
     }
 
+    // A paused show must not let another person resume the session, so the
+    // picker still shows over an active player when "ask on open" is set.
     expect(should(), isTrue);
-    // Waking the device mid-stream resumes the stream; the picker would
-    // fight the player's focus self-heal for the remote.
-    expect(should(hasActiveVideoPlayback: true), isFalse);
     // A phone driving another device backgrounds constantly; the picker +
     // PIN would bury the live remote session.
     expect(should(hasActiveCompanionRemoteSession: true), isFalse);


### PR DESCRIPTION
"Ask for profile on app open" used to raise the picker on resume; #2034 stopped it whenever a video player was open, by adding a blanket resume-time exemption for active playback. That is the case the setting exists for — a show left paused overnight lets anyone resume the session on a PIN-protected profile.

Drops the `hasActiveVideoPlayback` exemption from `shouldShowProfileSelectionOnResume`. The picker still only pushes when `requiresSelectionOnOpen` holds (setting on, ≥2 profiles), so users without the setting are unaffected. #2034's focus fix (`isRouteChainCurrent`) is independent and stays, so the picker is responsive over the player.

Verified on a Fire TV Cube: with the setting on and a show playing, "Alexa, go home" → reopen shows the picker; an Alexa overlay ("what's the weather") still does not (#1990); `flutter test` green (6435 pass).
