### PR TITLE
configurable home rows: merge libraries, collection rows (#1652)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Package managers:
 ### <img src="assets/readme_icons/browse.svg" height="20" alt="" align="center" /> Browse & Discover
 - Libraries, collections, and playlists — video and audio
 - Discover hub — Continue Watching, Next Up, trending, and recommendations
+- Configurable Home rows: merge Recently Added / Recently Released across whichever libraries you pick, or a collections row scoped to specific libraries or collections
 - Cross-server search across every connected Plex, Jellyfin, and Emby server
 - Filtering, sorting, and alphabetical jump navigation
 - Folder browsing and folder playback — home-video libraries open in folder view

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -95,6 +95,7 @@ import 'services/sensitive_prefs.dart';
 import 'services/startup_diagnostics.dart';
 import 'utils/dialogs.dart';
 import 'widgets/dialog_action_button.dart';
+import 'widgets/hover_preview/hover_preview_player_controller.dart';
 import 'widgets/startup_failure_view.dart';
 
 const bool _enableSentry = bool.fromEnvironment('ENABLE_SENTRY', defaultValue: false);
@@ -1600,6 +1601,18 @@ class _MainAppState extends State<MainApp> with WidgetsBindingObserver {
             return MultiServerProvider(_serverManager, _aggregationService);
           },
         ),
+        // App-wide singleton — Windows' native video plugin only backs one
+        // process-wide video core, so every hero row's hover-preview
+        // trailer, on any screen (Home, a library's own Recommended tab),
+        // has to share this one controller/Player. Two independently-owned
+        // controllers (one per screen) fight over that same native core the
+        // moment both are alive at once — even with only one on screen,
+        // Flutter's normal tab/route caching can keep the other mounted in
+        // the background — which showed up as a black, silently-failing
+        // video surface on whichever screen lost the race (reported
+        // 2026-09-10). Registered at the app root, not owned or disposed by
+        // any individual screen.
+        ChangeNotifierProvider<HoverPreviewPlayerController>(create: (_) => HoverPreviewPlayerController()),
         ChangeNotifierProxyProvider<MultiServerProvider, OfflineModeProvider>(
           create: (context) {
             final provider = OfflineModeProvider(

--- a/lib/media/media_hub.dart
+++ b/lib/media/media_hub.dart
@@ -31,6 +31,18 @@ class MediaHub {
   final String? serverId;
   final String? serverName;
 
+  /// Renders this row as a full-width rotating hero card instead of a
+  /// poster shelf. Resolved once when the hub is built (see
+  /// `home_section_builder.dart`) from either [HomeSectionConfig.heroStyle]
+  /// (custom rows) or the `managedHubHeroOverrides` setting (Plex-managed
+  /// rows and Continue Watching), so rendering code never has to re-derive
+  /// which store a given hub's hero flag lives in.
+  final bool heroStyle;
+
+  /// Plays a trailer/scene clip in the hero card. Meaningless without
+  /// [heroStyle] — same rule as the config types this is resolved from.
+  final bool heroTrailerPreview;
+
   const MediaHub({
     required this.id,
     required this.title,
@@ -42,6 +54,8 @@ class MediaHub {
     this.libraryId,
     this.serverId,
     this.serverName,
+    this.heroStyle = false,
+    this.heroTrailerPreview = false,
   });
 
   /// True for hubs that represent the user's resumable Continue Watching row.
@@ -59,7 +73,7 @@ class MediaHub {
     return hubIdentifier != null && matches(hubIdentifier);
   }
 
-  MediaHub copyWith({List<MediaItem>? items, int? size}) {
+  MediaHub copyWith({List<MediaItem>? items, int? size, bool? heroStyle, bool? heroTrailerPreview}) {
     return MediaHub(
       id: id,
       identifier: identifier,
@@ -71,6 +85,8 @@ class MediaHub {
       libraryId: libraryId,
       serverId: serverId,
       serverName: serverName,
+      heroStyle: heroStyle ?? this.heroStyle,
+      heroTrailerPreview: heroTrailerPreview ?? this.heroTrailerPreview,
     );
   }
 }

--- a/lib/models/home_section_config.dart
+++ b/lib/models/home_section_config.dart
@@ -1,0 +1,111 @@
+import '../media/media_kind.dart';
+
+/// A source category for a configurable Home row.
+enum HomeSectionKind {
+  recentlyAdded,
+  recentlyReleased,
+  movieCollections,
+  showCollections;
+
+  String get id => switch (this) {
+    HomeSectionKind.recentlyAdded => 'recently_added',
+    HomeSectionKind.recentlyReleased => 'recently_released',
+    HomeSectionKind.movieCollections => 'movie_collections',
+    HomeSectionKind.showCollections => 'show_collections',
+  };
+
+  static HomeSectionKind fromId(String? id) => switch (id) {
+    'recently_added' => HomeSectionKind.recentlyAdded,
+    'recently_released' => HomeSectionKind.recentlyReleased,
+    'movie_collections' => HomeSectionKind.movieCollections,
+    'show_collections' => HomeSectionKind.showCollections,
+    _ => HomeSectionKind.recentlyAdded,
+  };
+
+  bool get isCollectionRow => this == HomeSectionKind.movieCollections || this == HomeSectionKind.showCollections;
+
+  MediaKind? get collectionKind => switch (this) {
+    HomeSectionKind.movieCollections => MediaKind.movie,
+    HomeSectionKind.showCollections => MediaKind.show,
+    _ => null,
+  };
+}
+
+/// One user-defined Home row. Keys are global library/collection keys.
+class HomeSectionConfig {
+  const HomeSectionConfig({
+    required this.id,
+    required this.title,
+    required this.kind,
+    this.libraryKeys = const [],
+    this.collectionKeys = const [],
+    this.enabled = true,
+    this.keepSourceRows = false,
+    this.showInLibraryRecommended = true,
+    this.showOnHome = true,
+    this.showOnFriendsHome = false,
+  });
+
+  final String id;
+  final String title;
+  final HomeSectionKind kind;
+  final List<String> libraryKeys;
+  final List<String> collectionKeys;
+  final bool enabled;
+  final bool keepSourceRows;
+  final bool showInLibraryRecommended;
+  final bool showOnHome;
+  final bool showOnFriendsHome;
+
+  bool get isCollectionRow => kind.isCollectionRow;
+
+  HomeSectionConfig copyWith({
+    String? id,
+    String? title,
+    HomeSectionKind? kind,
+    List<String>? libraryKeys,
+    List<String>? collectionKeys,
+    bool? enabled,
+    bool? keepSourceRows,
+    bool? showInLibraryRecommended,
+    bool? showOnHome,
+    bool? showOnFriendsHome,
+  }) => HomeSectionConfig(
+    id: id ?? this.id,
+    title: title ?? this.title,
+    kind: kind ?? this.kind,
+    libraryKeys: libraryKeys ?? this.libraryKeys,
+    collectionKeys: collectionKeys ?? this.collectionKeys,
+    enabled: enabled ?? this.enabled,
+    keepSourceRows: keepSourceRows ?? this.keepSourceRows,
+    showInLibraryRecommended: showInLibraryRecommended ?? this.showInLibraryRecommended,
+    showOnHome: showOnHome ?? this.showOnHome,
+    showOnFriendsHome: showOnFriendsHome ?? this.showOnFriendsHome,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'kind': kind.id,
+    'libraryKeys': libraryKeys,
+    'collectionKeys': collectionKeys,
+    'enabled': enabled,
+    'keepSourceRows': keepSourceRows,
+    'showInLibraryRecommended': showInLibraryRecommended,
+    'showOnHome': showOnHome,
+    'showOnFriendsHome': showOnFriendsHome,
+  };
+
+  static HomeSectionConfig fromJson(Map<String, dynamic> json) => HomeSectionConfig(
+    id: json['id'] as String? ?? 'home_section',
+    title: json['title'] as String? ?? 'Home',
+    kind: HomeSectionKind.fromId(json['kind'] as String?),
+    libraryKeys: (json['libraryKeys'] as List?)?.whereType<String>().toList() ?? const [],
+    collectionKeys: (json['collectionKeys'] as List?)?.whereType<String>().toList() ?? const [],
+    enabled: json['enabled'] as bool? ?? true,
+    keepSourceRows: json['keepSourceRows'] as bool? ?? false,
+    showInLibraryRecommended: json['showInLibraryRecommended'] as bool? ?? true,
+    showOnHome: json['showOnHome'] as bool? ?? true,
+    showOnFriendsHome: json['showOnFriendsHome'] as bool? ?? false,
+  );
+}

--- a/lib/models/home_section_config.dart
+++ b/lib/models/home_section_config.dart
@@ -44,6 +44,8 @@ class HomeSectionConfig {
     this.showInLibraryRecommended = true,
     this.showOnHome = true,
     this.showOnFriendsHome = false,
+    this.heroStyle = false,
+    this.heroTrailerPreview = false,
   });
 
   final String id;
@@ -57,7 +59,27 @@ class HomeSectionConfig {
   final bool showOnHome;
   final bool showOnFriendsHome;
 
+  /// Renders this row as a single full-width rotating hero card instead of
+  /// a poster shelf. A collection row only supports this when it resolves
+  /// to one collection's actual contents (see [supportsHeroStyle]) — with
+  /// two or more collections selected the row shows one tile per
+  /// collection, and there is no single title to rotate through.
+  final bool heroStyle;
+
+  /// Plays a trailer/scene-clip in the hero card's video zone instead of
+  /// static backdrop art. Meaningless without [heroStyle] — callers must
+  /// force this false whenever heroStyle is false, the same way the
+  /// Organizer UI greys the toggle out rather than letting it float
+  /// independently true.
+  final bool heroTrailerPreview;
+
   bool get isCollectionRow => kind.isCollectionRow;
+
+  /// Whether hero-card styling (and, in turn, trailer preview) is even an
+  /// option for this row's current configuration. False for a collection
+  /// row selecting anything other than exactly one collection, since that
+  /// case has no single title/queue to render as a hero.
+  bool get supportsHeroStyle => !isCollectionRow || collectionKeys.length == 1;
 
   HomeSectionConfig copyWith({
     String? id,
@@ -70,6 +92,8 @@ class HomeSectionConfig {
     bool? showInLibraryRecommended,
     bool? showOnHome,
     bool? showOnFriendsHome,
+    bool? heroStyle,
+    bool? heroTrailerPreview,
   }) => HomeSectionConfig(
     id: id ?? this.id,
     title: title ?? this.title,
@@ -81,6 +105,8 @@ class HomeSectionConfig {
     showInLibraryRecommended: showInLibraryRecommended ?? this.showInLibraryRecommended,
     showOnHome: showOnHome ?? this.showOnHome,
     showOnFriendsHome: showOnFriendsHome ?? this.showOnFriendsHome,
+    heroStyle: heroStyle ?? this.heroStyle,
+    heroTrailerPreview: heroTrailerPreview ?? this.heroTrailerPreview,
   );
 
   Map<String, dynamic> toJson() => {
@@ -94,6 +120,8 @@ class HomeSectionConfig {
     'showInLibraryRecommended': showInLibraryRecommended,
     'showOnHome': showOnHome,
     'showOnFriendsHome': showOnFriendsHome,
+    'heroStyle': heroStyle,
+    'heroTrailerPreview': heroTrailerPreview,
   };
 
   static HomeSectionConfig fromJson(Map<String, dynamic> json) => HomeSectionConfig(
@@ -107,5 +135,7 @@ class HomeSectionConfig {
     showInLibraryRecommended: json['showInLibraryRecommended'] as bool? ?? true,
     showOnHome: json['showOnHome'] as bool? ?? true,
     showOnFriendsHome: json['showOnFriendsHome'] as bool? ?? false,
+    heroStyle: json['heroStyle'] as bool? ?? false,
+    heroTrailerPreview: json['heroTrailerPreview'] as bool? ?? false,
   );
 }

--- a/lib/models/plex/plex_managed_hub.dart
+++ b/lib/models/plex/plex_managed_hub.dart
@@ -1,0 +1,44 @@
+/// A recommendation row returned by Plex's Home manager endpoint.
+class PlexManagedHub {
+  final String identifier;
+  final String title;
+  final String? hubKey;
+  final String? metadataItemId;
+  final bool promoted;
+  final bool promotedToRecommended;
+  final bool promotedToOwnHome;
+  final bool promotedToSharedHome;
+  final bool deletable;
+
+  const PlexManagedHub({
+    required this.identifier,
+    required this.title,
+    this.hubKey,
+    this.metadataItemId,
+    this.promoted = false,
+    this.promotedToRecommended = false,
+    this.promotedToOwnHome = false,
+    this.promotedToSharedHome = false,
+    this.deletable = false,
+  });
+
+  factory PlexManagedHub.fromJson(Map<String, dynamic> json) {
+    bool flag(String key) {
+      final value = json[key];
+      return value == true || value == 1 || value == '1' || value == 'true';
+    }
+
+    final identifier = '${json['identifier'] ?? json['hubIdentifier'] ?? json['key'] ?? ''}';
+    return PlexManagedHub(
+      identifier: identifier,
+      title: '${json['title'] ?? json['name'] ?? identifier}',
+      hubKey: json['hubKey']?.toString() ?? json['key']?.toString(),
+      metadataItemId: json['metadataItemId']?.toString() ?? json['ratingKey']?.toString(),
+      promoted: flag('promoted'),
+      promotedToRecommended: flag('promotedToRecommended'),
+      promotedToOwnHome: flag('promotedToOwnHome'),
+      promotedToSharedHome: flag('promotedToSharedHome'),
+      deletable: flag('deletable'),
+    );
+  }
+}

--- a/lib/models/plex/plex_managed_hub.dart
+++ b/lib/models/plex/plex_managed_hub.dart
@@ -42,3 +42,29 @@ class PlexManagedHub {
     );
   }
 }
+
+/// Plezy-local hero/trailer preference for one native Plex-managed hub.
+///
+/// Unlike [PlexManagedHub] itself, Plex has no concept of "hero style" or
+/// "trailer preview" — there is nothing to fetch this from or write it back
+/// to on the server, so it lives entirely in local settings
+/// (`SettingsService.managedHubHeroOverrides`), keyed by
+/// `'${library.globalKey}::${hub.identifier}'`.
+class ManagedHubHeroOverride {
+  const ManagedHubHeroOverride({this.heroStyle = false, this.heroTrailerPreview = false});
+
+  final bool heroStyle;
+  final bool heroTrailerPreview;
+
+  ManagedHubHeroOverride copyWith({bool? heroStyle, bool? heroTrailerPreview}) => ManagedHubHeroOverride(
+    heroStyle: heroStyle ?? this.heroStyle,
+    heroTrailerPreview: heroTrailerPreview ?? this.heroTrailerPreview,
+  );
+
+  Map<String, dynamic> toJson() => {'heroStyle': heroStyle, 'heroTrailerPreview': heroTrailerPreview};
+
+  static ManagedHubHeroOverride fromJson(Map<String, dynamic> json) => ManagedHubHeroOverride(
+    heroStyle: json['heroStyle'] as bool? ?? false,
+    heroTrailerPreview: json['heroTrailerPreview'] as bool? ?? false,
+  );
+}

--- a/lib/providers/discover_provider.dart
+++ b/lib/providers/discover_provider.dart
@@ -6,10 +6,10 @@ import '../media/ids.dart';
 import '../media/media_hub.dart';
 import '../media/media_item.dart';
 import '../media/media_kind.dart';
+import '../models/home_section_config.dart';
 import '../media/media_server_client.dart';
 import '../mixins/disposable_change_notifier_mixin.dart';
 import '../mixins/event_aware.dart';
-import '../models/home_section_config.dart';
 import '../services/settings_service.dart';
 import '../services/data_aggregation_service.dart';
 import '../services/system_shelf_service.dart';
@@ -103,6 +103,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     if (settings != null) {
       _homeLayoutListenable = settings.listenable(SettingsService.homeSections);
       _homeLayoutListenable!.addListener(_onHomeLayoutChanged);
+      _homeRowOrderListenable = settings.listenable(SettingsService.homeRowOrder);
+      _homeRowOrderListenable!.addListener(_onHomeLayoutChanged);
     }
     _watchStateSubscription = subscribeToHierarchicalEvents<WatchStateEvent>(
       notifier: WatchStateNotifier(),
@@ -176,6 +178,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
 
   StreamSubscription<WatchStateEvent>? _watchStateSubscription;
   Listenable? _homeLayoutListenable;
+  Listenable? _homeRowOrderListenable;
   StreamSubscription<DeletionEvent>? _deletionSubscription;
 
   List<MediaItem> _onDeck = [];
@@ -375,6 +378,10 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       final collectionsFuture = homeSections.any((s) => s.isCollectionRow)
           ? aggregation.getCollectionsFromAllServers(hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys)
           : null;
+      // A collection row scoped to exactly one collection is more useful as
+      // that collection's actual contents than as a single folder tile —
+      // fetch those contents up front so the builder can inline them.
+      final singleCollectionFuture = _fetchSingleCollectionContents(homeSections);
 
       // A pass in which zero servers succeeded is never authoritative: it
       // must not wipe existing content, and it may only commit "loaded,
@@ -449,12 +456,14 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       }
 
       final fetchedCollections = collectionsFuture == null ? null : await collectionsFuture;
+      final singleCollectionContents = await singleCollectionFuture;
       final filteredHubs = buildConfiguredHomeSections(
         sourceHubs: _filterDiscoverHubs(fetchedHubs.hubs),
         collections: fetchedCollections?.collections ?? const [],
         sections: homeSections,
         rowOrder: settings.read(SettingsService.homeRowOrder),
         collectionLibraryKinds: {for (final library in _libraries.libraries) library.globalKey: library.kind},
+        singleCollectionContents: singleCollectionContents,
       );
 
       appLogger.d('DiscoverProvider: ${_onDeck.length} on-deck items, ${filteredHubs.length} hubs');
@@ -626,6 +635,27 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   }
 
   /// Playback-progress hubs duplicate the top Continue Watching row.
+  Future<Map<String, List<MediaItem>>> _fetchSingleCollectionContents(List<HomeSectionConfig> sections) async {
+    final singleCollectionSections = sections.where((s) => s.isCollectionRow && s.collectionKeys.length == 1);
+    if (singleCollectionSections.isEmpty) return const {};
+    final result = <String, List<MediaItem>>{};
+    await Future.wait(
+      singleCollectionSections.map((section) async {
+        final parsed = parseGlobalKey(section.collectionKeys.single);
+        if (parsed == null) return;
+        final client = _multiServer.getClientForServer(parsed.serverId);
+        if (client == null) return;
+        try {
+          final page = await client.fetchCollectionPage(parsed.ratingKey, start: 0, size: 50);
+          result[section.id] = page.items;
+        } catch (e) {
+          appLogger.w('Failed to fetch contents for single-collection row "${section.title}"', error: e);
+        }
+      }),
+    );
+    return result;
+  }
+
   List<MediaHub> _filterDiscoverHubs(List<MediaHub> hubs) {
     return hubs.where((hub) {
       final hubId = hub.identifier?.toLowerCase() ?? '';
@@ -1021,6 +1051,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     _hiddenLibraries.removeListener(_onHiddenLibrariesChanged);
     _libraries.removeListener(_onLibrariesChanged);
     _homeLayoutListenable?.removeListener(_onHomeLayoutChanged);
+    _homeRowOrderListenable?.removeListener(_onHomeLayoutChanged);
     _watchStateSubscription?.cancel();
     _watchStateSubscription = null;
     _deletionSubscription?.cancel();

--- a/lib/providers/discover_provider.dart
+++ b/lib/providers/discover_provider.dart
@@ -5,9 +5,11 @@ import 'package:flutter/foundation.dart';
 import '../media/ids.dart';
 import '../media/media_hub.dart';
 import '../media/media_item.dart';
+import '../media/media_kind.dart';
 import '../media/media_server_client.dart';
 import '../mixins/disposable_change_notifier_mixin.dart';
 import '../mixins/event_aware.dart';
+import '../models/home_section_config.dart';
 import '../services/settings_service.dart';
 import '../services/data_aggregation_service.dart';
 import '../services/system_shelf_service.dart';
@@ -17,6 +19,7 @@ import '../utils/deletion_notifier.dart';
 import '../utils/media_event_keys.dart';
 import '../utils/global_key_utils.dart';
 import '../utils/media_hub_ordering.dart';
+import '../utils/home_section_builder.dart';
 import '../utils/watch_state_notifier.dart';
 import 'hidden_libraries_provider.dart';
 import 'libraries_provider.dart';
@@ -96,6 +99,11 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     _hiddenLibraries.addListener(_onHiddenLibrariesChanged);
     _lastSeenLibraryOrderKeys = _libraryOrderKeys();
     _libraries.addListener(_onLibrariesChanged);
+    final settings = SettingsService.instanceOrNull;
+    if (settings != null) {
+      _homeLayoutListenable = settings.listenable(SettingsService.homeSections);
+      _homeLayoutListenable!.addListener(_onHomeLayoutChanged);
+    }
     _watchStateSubscription = subscribeToHierarchicalEvents<WatchStateEvent>(
       notifier: WatchStateNotifier(),
       mounted: () => !isDisposed,
@@ -167,6 +175,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   final Future<void> Function(String profileId, List<MediaServerClient> clients)? _syncServerSourcesOverride;
 
   StreamSubscription<WatchStateEvent>? _watchStateSubscription;
+  Listenable? _homeLayoutListenable;
   StreamSubscription<DeletionEvent>? _deletionSubscription;
 
   List<MediaItem> _onDeck = [];
@@ -336,6 +345,22 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       // The watermark is captured immediately before the requests, after
       // every preparatory await: a patch recorded later has a higher sequence
       // and must survive this pass's observations.
+      final homeSections = settings.read(SettingsService.homeSections);
+      // A configured "Recently Added"/"Recently Released" row (#1652) needs a
+      // matching hub in sourceHubs for every library it merges, but Plex's
+      // global/promoted hub endpoint only surfaces "promoted" libraries' rows
+      // — a library never promoted on the Plex server itself is silently
+      // absent from that endpoint, which reads to the user as the custom row
+      // "just disappearing". Force an explicit per-library fetch for
+      // movie/show libraries in that case, the same way music libraries
+      // already get appended below for the same structural reason.
+      final needsRecentHubsPerLibrary = homeSections.any(
+        (s) =>
+            s.enabled &&
+            s.showOnHome &&
+            !s.isCollectionRow &&
+            (s.kind == HomeSectionKind.recentlyAdded || s.kind == HomeSectionKind.recentlyReleased),
+      );
       observation = _beginObservation();
       final onDeckFuture = aggregation.getOnDeckFromAllServers(
         limit: _continueWatchingProbeLimit,
@@ -345,7 +370,11 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
         hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys,
         useGlobalHubs: useGlobalHubs,
         includePlaybackHubs: false,
+        additionalLibraryHubKinds: needsRecentHubsPerLibrary ? const {MediaKind.movie, MediaKind.show} : const {},
       );
+      final collectionsFuture = homeSections.any((s) => s.isCollectionRow)
+          ? aggregation.getCollectionsFromAllServers(hiddenLibraryKeys: _hiddenLibraries.hiddenLibraryKeys)
+          : null;
 
       // A pass in which zero servers succeeded is never authoritative: it
       // must not wipe existing content, and it may only commit "loaded,
@@ -419,8 +448,14 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
         return;
       }
 
-      final filteredHubs = _filterDiscoverHubs(fetchedHubs.hubs);
-      sortMediaHubsByLibraryOrder(filteredHubs, _libraries.libraries);
+      final fetchedCollections = collectionsFuture == null ? null : await collectionsFuture;
+      final filteredHubs = buildConfiguredHomeSections(
+        sourceHubs: _filterDiscoverHubs(fetchedHubs.hubs),
+        collections: fetchedCollections?.collections ?? const [],
+        sections: homeSections,
+        rowOrder: settings.read(SettingsService.homeRowOrder),
+        collectionLibraryKinds: {for (final library in _libraries.libraries) library.globalKey: library.kind},
+      );
 
       appLogger.d('DiscoverProvider: ${_onDeck.length} on-deck items, ${filteredHubs.length} hubs');
       _replaceHubs(filteredHubs);
@@ -564,7 +599,6 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
           ..._hubs.where((hub) => hub.serverId == null || !succeededHubIds.contains(hub.serverId)),
           ..._filterDiscoverHubs(freshHubs.hubs),
         ];
-        sortMediaHubsByLibraryOrder(mergedHubs, _libraries.libraries);
         _replaceHubs(mergedHubs);
         _loadedHubServerIds = {..._loadedHubServerIds, ...succeededHubIds}
           ..removeAll(freshHubs.failedServerIds)
@@ -877,6 +911,11 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     unawaited(refreshContinueWatching());
   }
 
+  void _onHomeLayoutChanged() {
+    if (isDisposed) return;
+    unawaited(load());
+  }
+
   void _onHiddenLibrariesChanged() {
     final currentKeys = _hiddenLibraries.hiddenLibraryKeys;
     if (currentKeys.length == _lastSeenHiddenKeys.length && currentKeys.containsAll(_lastSeenHiddenKeys)) {
@@ -981,6 +1020,7 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     _multiServer.removeOnlineServersListener(syncToOnlineServers);
     _hiddenLibraries.removeListener(_onHiddenLibrariesChanged);
     _libraries.removeListener(_onLibrariesChanged);
+    _homeLayoutListenable?.removeListener(_onHomeLayoutChanged);
     _watchStateSubscription?.cancel();
     _watchStateSubscription = null;
     _deletionSubscription?.cancel();

--- a/lib/providers/discover_provider.dart
+++ b/lib/providers/discover_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import '../i18n/strings.g.dart';
 import '../media/ids.dart';
 import '../media/media_hub.dart';
 import '../media/media_item.dart';
@@ -105,6 +106,10 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
       _homeLayoutListenable!.addListener(_onHomeLayoutChanged);
       _homeRowOrderListenable = settings.listenable(SettingsService.homeRowOrder);
       _homeRowOrderListenable!.addListener(_onHomeLayoutChanged);
+      _continueWatchingOnHomeListenable = settings.listenable(SettingsService.continueWatchingOnHome);
+      _continueWatchingOnHomeListenable!.addListener(_onHomeLayoutChanged);
+      _managedHubHeroOverridesListenable = settings.listenable(SettingsService.managedHubHeroOverrides);
+      _managedHubHeroOverridesListenable!.addListener(_onHomeLayoutChanged);
     }
     _watchStateSubscription = subscribeToHierarchicalEvents<WatchStateEvent>(
       notifier: WatchStateNotifier(),
@@ -179,6 +184,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   StreamSubscription<WatchStateEvent>? _watchStateSubscription;
   Listenable? _homeLayoutListenable;
   Listenable? _homeRowOrderListenable;
+  Listenable? _continueWatchingOnHomeListenable;
+  Listenable? _managedHubHeroOverridesListenable;
   StreamSubscription<DeletionEvent>? _deletionSubscription;
 
   List<MediaItem> _onDeck = [];
@@ -216,6 +223,20 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
   List<MediaItem> get onDeck => _onDeck;
   List<MediaHub> get hubs => _hubs;
   bool get hasMoreContinueWatching => _hasMoreContinueWatching;
+
+  /// The synthesized Continue Watching row. Folded into [hubs] by
+  /// [buildConfiguredHomeSections] (as a normal, reorderable/removable
+  /// Organizer row) rather than rendered as a screen-level fixture — see
+  /// `SettingsService.continueWatchingOnHome`.
+  MediaHub get _continueWatchingHub => MediaHub(
+    id: 'continue_watching',
+    title: t.discover.continueWatching,
+    type: 'mixed',
+    identifier: '_continue_watching_',
+    size: _onDeck.length + (_hasMoreContinueWatching ? 1 : 0),
+    more: _hasMoreContinueWatching,
+    items: _onDeck,
+  );
 
   /// Raw load failure (unlocalized); the screen wraps it for display.
   String? get errorMessage => _errorMessage;
@@ -464,6 +485,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
         rowOrder: settings.read(SettingsService.homeRowOrder),
         collectionLibraryKinds: {for (final library in _libraries.libraries) library.globalKey: library.kind},
         singleCollectionContents: singleCollectionContents,
+        managedHubHeroOverrides: settings.read(SettingsService.managedHubHeroOverrides),
+        continueWatchingHub: settings.read(SettingsService.continueWatchingOnHome) ? _continueWatchingHub : null,
       );
 
       appLogger.d('DiscoverProvider: ${_onDeck.length} on-deck items, ${filteredHubs.length} hubs');
@@ -1052,6 +1075,8 @@ class DiscoverProvider extends ChangeNotifier with DisposableChangeNotifierMixin
     _libraries.removeListener(_onLibrariesChanged);
     _homeLayoutListenable?.removeListener(_onHomeLayoutChanged);
     _homeRowOrderListenable?.removeListener(_onHomeLayoutChanged);
+    _continueWatchingOnHomeListenable?.removeListener(_onHomeLayoutChanged);
+    _managedHubHeroOverridesListenable?.removeListener(_onHomeLayoutChanged);
     _watchStateSubscription?.cancel();
     _watchStateSubscription = null;
     _deletionSubscription?.cancel();

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -10,25 +10,18 @@ import 'package:provider/provider.dart';
 import '../focus/focusable_action_bar.dart';
 import '../focus/hub_vertical_navigation.dart';
 import '../focus/locked_hub_controller.dart';
-import '../focus/input_mode_tracker.dart';
-import '../focus/key_event_utils.dart';
 
 import '../media/media_item.dart';
-import '../media/media_item_types.dart';
 import '../media/media_server_client.dart';
 import '../media/media_hub.dart';
 import '../utils/media_image_helper.dart';
-import '../utils/content_utils.dart';
-import '../widgets/cycling_media_backdrop.dart';
-import '../widgets/optimized_media_image.dart' show ClearLogoImage, blurArtwork;
 import '../widgets/toolbar_scrim.dart';
 import '../widgets/system_clock.dart';
 import '../providers/discover_provider.dart';
 import '../providers/multi_server_provider.dart';
-import '../providers/watch_state_store.dart';
 import '../widgets/hub_section.dart';
+import '../widgets/hero_hub_section.dart';
 import '../widgets/app_menu.dart';
-import '../widgets/clickable_cursor.dart';
 import '../widgets/loading_indicator_box.dart';
 import '../widgets/profile_switching_overlay.dart';
 import 'profile/profile_switch_screen.dart';
@@ -39,7 +32,6 @@ import '../profiles/profile_activation.dart';
 import '../profiles/profile_avatar.dart';
 import '../services/settings_service.dart';
 import '../widgets/settings_builder.dart';
-import '../widgets/fitting_title_text.dart';
 import '../widgets/tv_browse_rail.dart';
 import '../widgets/tv_spotlight_scaffold.dart';
 import '../mixins/refreshable.dart';
@@ -47,13 +39,9 @@ import '../mixins/tab_visibility_aware.dart';
 import '../i18n/strings.g.dart';
 import '../utils/app_logger.dart';
 import '../utils/dialogs.dart';
-import '../utils/formatters.dart';
 import '../utils/hub_icons.dart';
-import '../utils/media_navigation_helper.dart';
 import '../utils/provider_extensions.dart';
 import '../utils/snackbar_helper.dart';
-import '../utils/video_player_navigation.dart';
-import '../utils/layout_constants.dart';
 import '../utils/platform_detector.dart';
 import '../theme/mono_tokens.dart';
 import 'libraries/content_state_builder.dart';
@@ -106,7 +94,6 @@ class _DiscoverScreenState extends State<DiscoverScreen>
   bool _initialLoadComplete = false;
   bool _pendingTvBrowseRailFocus = false;
 
-  GlobalKey<HubSectionState>? _continueWatchingHubKey;
   final Map<String, GlobalKey<HubSectionState>> _hubKeysByIdentity = {};
   List<GlobalKey<HubSectionState>> _orderedHubKeys = const [];
   final _tvBrowseRailKey = GlobalKey<TvBrowseRailState>();
@@ -149,51 +136,38 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     }
     _hubKeysByIdentity.removeWhere((identity, _) => !liveIdentities.contains(identity));
     _orderedHubKeys = ordered;
-    _continueWatchingHubKey ??= GlobalKey<HubSectionState>();
   }
 
-  List<GlobalKey<HubSectionState>> get _allHubKeys {
-    final keys = <GlobalKey<HubSectionState>>[];
-    if (_continueWatchingHubKey != null && _onDeck.isNotEmpty) {
-      keys.add(_continueWatchingHubKey!);
-    }
-    keys.addAll(_orderedHubKeys);
-    return keys;
-  }
+  // Continue Watching is a normal, removable/reorderable Organizer row now
+  // (see home_layout_settings_screen.dart) folded into `_hubs` at its real
+  // position by buildConfiguredHomeSections, rather than a screen-level
+  // fixture — so `_orderedHubKeys` already covers it and needs no special
+  // prepending here. This getter still gates the legacy top hero banner
+  // below, which remains Continue-Watching-only until per-row hero
+  // rendering replaces it.
+  bool get _continueWatchingEnabled => context.settingsRead(SettingsService.continueWatchingOnHome);
 
-  bool get _isHeroSectionVisible => _onDeck.isNotEmpty && context.settingsRead(SettingsService.showHeroSection);
+  List<GlobalKey<HubSectionState>> get _allHubKeys => _orderedHubKeys;
+
+  bool get _isHeroSectionVisible =>
+      _onDeck.isNotEmpty && _continueWatchingEnabled && context.settingsRead(SettingsService.showHeroSection);
 
   // Memoized on provider list identity (the provider always replaces _onDeck/
   // _hubs with fresh instances on change, never mutates in place) so unrelated
   // rebuilds hand TvBrowseRail the same hubs list and its didUpdateWidget
-  // fast path — and the cached rail widget below — kick in.
+  // fast path — and the cached rail widget below — kick in. Continue
+  // Watching arrives already folded into `_hubs` (see DiscoverProvider), so
+  // this no longer needs to prepend it separately.
   List<MediaHub>? _tvBrowseHubsCache;
-  (List<MediaItem>, List<MediaHub>, bool, String)? _tvBrowseHubsCacheKey;
+  List<MediaHub>? _tvBrowseHubsCacheKey;
 
   List<MediaHub> get _tvBrowseHubs {
-    final key = (_onDeck, _hubs, _hasMoreContinueWatching, t.discover.continueWatching);
-    if (_tvBrowseHubsCache != null && key == _tvBrowseHubsCacheKey) return _tvBrowseHubsCache!;
-    final hubs = <MediaHub>[];
-    if (_onDeck.isNotEmpty) {
-      hubs.add(_continueWatchingHub);
-    }
-    hubs.addAll(_hubs.where((hub) => hub.items.isNotEmpty));
+    if (_tvBrowseHubsCache != null && _hubs == _tvBrowseHubsCacheKey) return _tvBrowseHubsCache!;
+    final hubs = _hubs.where((hub) => hub.items.isNotEmpty).toList();
     _tvBrowseHubsCache = hubs;
-    _tvBrowseHubsCacheKey = key;
+    _tvBrowseHubsCacheKey = _hubs;
     return hubs;
   }
-
-  /// The synthesized Continue Watching row, rendered ahead of the backend hubs
-  /// on both the mobile list and the TV rail.
-  MediaHub get _continueWatchingHub => MediaHub(
-    id: 'continue_watching',
-    title: t.discover.continueWatching,
-    type: 'mixed',
-    identifier: '_continue_watching_',
-    size: _onDeck.length + (_hasMoreContinueWatching ? 1 : 0),
-    more: _hasMoreContinueWatching,
-    items: _onDeck,
-  );
 
   void _setSpotlightItem(MediaItem item) => _spotlight.select(item);
 
@@ -390,37 +364,6 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     }
   }
 
-  /// Handle key events for the hero section.
-  KeyEventResult _handleHeroKeyEvent(FocusNode node, KeyEvent event) {
-    final backResult = handleBackKeyAction(event, _navigateToSidebar);
-    if (backResult != KeyEventResult.ignored) return backResult;
-
-    return dpadKeyHandler(
-      onDown: () {
-        final keys = _allHubKeys;
-        if (keys.isNotEmpty) keys.first.currentState?.requestFocusFromMemory();
-      },
-      onUp: _focusTopActions,
-      onLeft: () {
-        if (_currentHeroIndex > 0) {
-          _heroController.previousPage(duration: tokens(context).slow, curve: Curves.easeInOut);
-        } else {
-          _navigateToSidebar();
-        }
-      },
-      onRight: () {
-        if (_currentHeroIndex < _onDeck.length - 1) {
-          _heroController.nextPage(duration: tokens(context).slow, curve: Curves.easeInOut);
-        }
-      },
-      onSelect: () {
-        if (_onDeck.isNotEmpty && _currentHeroIndex < _onDeck.length) {
-          navigateToMediaItem(context, _onDeck[_currentHeroIndex], playDirectly: true);
-        }
-      },
-    )(node, event);
-  }
-
   @override
   void dispose() {
     _discover.removeListener(_onDiscoverChanged);
@@ -505,26 +448,6 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     _indicatorTimer?.cancel();
   }
 
-  void _resetAutoScrollTimer() {
-    _autoScrollTimer?.cancel();
-    _startAutoScroll();
-  }
-
-  void _pauseAutoScroll() {
-    setState(() {
-      _isAutoScrollPaused = true;
-    });
-    _autoScrollTimer?.cancel();
-    _stopIndicatorProgress();
-  }
-
-  void _resumeAutoScroll() {
-    setState(() {
-      _isAutoScrollPaused = false;
-    });
-    _startAutoScroll();
-  }
-
   @override
   void onTabHidden() {
     _isTabVisible = false;
@@ -548,41 +471,6 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       return;
     }
     _focusTopBoundary();
-  }
-
-  // Helper method to calculate visible dot range (max 5 dots)
-  ({int start, int end}) _getVisibleDotRange() {
-    final totalDots = _onDeck.length;
-    if (totalDots <= 5) {
-      return (start: 0, end: totalDots - 1);
-    }
-
-    // Center the active dot when possible
-    final center = _currentHeroIndex;
-    final int start = (center - 2).clamp(0, totalDots - 5);
-    final int end = start + 4; // 5 dots total (0-4 inclusive)
-
-    return (start: start, end: end);
-  }
-
-  // Helper method to determine dot size based on position
-  double _getDotSize(int dotIndex, int start, int end) {
-    final totalDots = _onDeck.length;
-
-    // If we have 5 or fewer dots, all are full size (8px)
-    if (totalDots <= 5) {
-      return 8.0;
-    }
-
-    // First and last visible dots are smaller if there are more items beyond them
-    final isFirstVisible = dotIndex == start && start > 0;
-    final isLastVisible = dotIndex == end && end < totalDots - 1;
-
-    if (isFirstVisible || isLastVisible) {
-      return 5.0; // Smaller edge dots
-    }
-
-    return 8.0; // Normal size
   }
 
   // Public method to refresh content (for normal navigation)
@@ -888,6 +776,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       prefs: const [
         SettingsService.showServerNameOnHubs,
         SettingsService.showHeroSection,
+        SettingsService.continueWatchingOnHome,
         SettingsService.hideSpoilers,
         SettingsService.libraryDensity,
         SettingsService.episodePosterMode,
@@ -898,7 +787,6 @@ class _DiscoverScreenState extends State<DiscoverScreen>
 
   Widget _buildContent(BuildContext context) {
     final svc = SettingsService.instance;
-    final showHeroSection = svc.read(SettingsService.showHeroSection);
 
     if (PlatformDetector.isTV()) {
       return _buildTvContent(context);
@@ -909,7 +797,6 @@ class _DiscoverScreenState extends State<DiscoverScreen>
 
     final bottomPadding = MediaQuery.paddingOf(context).bottom;
     final theme = Theme.of(context);
-    final continueWatchingHub = _onDeck.isEmpty ? null : _continueWatchingHub;
     return Material(
       color: theme.scaffoldBackgroundColor,
       child: Stack(
@@ -917,51 +804,45 @@ class _DiscoverScreenState extends State<DiscoverScreen>
           CustomScrollView(
             controller: _scrollController,
             slivers: [
-              // Hero Section (Continue Watching) - at top of screen
-              Builder(
-                builder: (context) {
-                  if (_onDeck.isNotEmpty && showHeroSection) {
-                    return _buildHeroSection();
-                  }
-                  // Add top padding when hero is not shown
-                  return SliverToBoxAdapter(
-                    child: SizedBox(height: kToolbarHeight + MediaQuery.paddingOf(context).top + 16),
-                  );
-                },
+              // Top padding — there is no more fixed screen-level hero slot.
+              // Hero rendering is now per-row (see the loop below): whichever
+              // row(s) have heroStyle on render as a HeroHubSection wherever
+              // home_row_order places them, same as any other row.
+              SliverToBoxAdapter(
+                child: SizedBox(height: kToolbarHeight + MediaQuery.paddingOf(context).top + 16),
               ),
               if (_isLoading) LoadingIndicatorBox.sliver,
               if (_errorMessage != null) SliverErrorState(message: _errorMessage!, onRetry: _discover.load),
               if (!_isLoading && _errorMessage == null) ...[
-                if (continueWatchingHub != null)
-                  SliverToBoxAdapter(
-                    child: HubSection(
-                      key: _continueWatchingHubKey,
-                      hub: continueWatchingHub,
-                      focusMemory: _hubFocusMemory,
-                      icon: hubIconFor(continueWatchingHub),
-                      onRefresh: _discover.updateItem,
-                      onRemoveFromContinueWatching: _discover.refreshContinueWatching,
-                      isInContinueWatching: true,
-                      loadMoreItems: _discover.loadAllContinueWatching,
-                      onVerticalNavigation: (isUp) => _handleVerticalNavigation(0, isUp),
-                      onNavigateUp: _focusTopBoundary,
-                      onNavigateToSidebar: _navigateToSidebar,
-                    ),
-                  ),
-
-                // Recommendation Hubs (Trending, Top in Genre, etc.)
+                // Home rows — Continue Watching, Plex-managed rows, and custom
+                // rows all arrive here pre-ordered by DiscoverProvider (see
+                // buildConfiguredHomeSections), so this loop treats every row
+                // uniformly rather than special-casing Continue Watching's
+                // position or navigation index.
                 for (int i = 0; i < _hubs.length; i++)
                   SliverToBoxAdapter(
-                    child: HubSection(
+                    child: _hubs[i].heroStyle && _hubs[i].items.isNotEmpty
+                        ? HeroHubSection(
+                            key: ValueKey('hero:${_hubIdentity(_hubs[i])}'),
+                            hub: _hubs[i],
+                            onVerticalNavigation: (isUp) => _handleVerticalNavigation(i, isUp),
+                            onNavigateUp: i == 0 ? _focusTopBoundary : null,
+                            onNavigateToSidebar: _navigateToSidebar,
+                          )
+                        : HubSection(
                       key: i < _orderedHubKeys.length ? _orderedHubKeys[i] : null,
                       hub: _hubs[i],
                       focusMemory: _hubFocusMemory,
                       icon: hubIconFor(_hubs[i]),
                       showServerName: showServerNameOnHubs || hubsSpanMultipleServers,
                       onRefresh: _discover.updateItem,
-                      // Hub index is i + 1 if continue watching exists, otherwise i
-                      onVerticalNavigation: (isUp) => _handleVerticalNavigation(_onDeck.isNotEmpty ? i + 1 : i, isUp),
-                      onNavigateUp: (i == 0 && _onDeck.isEmpty) ? _focusTopBoundary : null,
+                      onRemoveFromContinueWatching: _hubs[i].isContinueWatchingHub
+                          ? _discover.refreshContinueWatching
+                          : null,
+                      isInContinueWatching: _hubs[i].isContinueWatchingHub,
+                      loadMoreItems: _hubs[i].isContinueWatchingHub ? _discover.loadAllContinueWatching : null,
+                      onVerticalNavigation: (isUp) => _handleVerticalNavigation(i, isUp),
+                      onNavigateUp: i == 0 ? _focusTopBoundary : null,
                       onNavigateToSidebar: _navigateToSidebar,
                     ),
                   ),
@@ -1103,463 +984,4 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     );
   }
 
-  Widget _buildHeroSection() {
-    final statusBarHeight = MediaQuery.paddingOf(context).top;
-    final useSideNav = PlatformDetector.shouldUseSideNavigation(context);
-    final isTv = PlatformDetector.isTV();
-    final heroHeight = isTv
-        ? MediaQuery.sizeOf(context).height * 0.82
-        : useSideNav
-        ? MediaQuery.sizeOf(context).height * 0.75
-        : 500 + statusBarHeight;
-    return SliverToBoxAdapter(
-      child: Focus(
-        focusNode: _heroFocusNode,
-        onKeyEvent: _handleHeroKeyEvent,
-        child: SizedBox(
-          height: heroHeight,
-          child: Stack(
-            clipBehavior: Clip.none,
-            children: [
-              PageView.builder(
-                controller: _heroController,
-                itemCount: _onDeck.length,
-                onPageChanged: (index) {
-                  if (index >= 0 && index < _onDeck.length) {
-                    _currentHeroIndex = index;
-                    _heroIndex.value = index;
-                    _resetAutoScrollTimer();
-                  }
-                },
-                itemBuilder: (context, index) {
-                  return _buildHeroItem(_onDeck[index], heroHeight);
-                },
-              ),
-              // Page indicators with animated progress and pause/play button.
-              // Hidden on TV only (issue #600: pointer-only control unreachable
-              // via d-pad) — never gated on transient input mode, which back-key
-              // events, BT keyboards, and gamepads can flip on phones/desktop.
-              if (!isTv)
-                Positioned(
-                  bottom: 16,
-                  left: -26,
-                  right: 0,
-                  child: Row(
-                    mainAxisAlignment: .center,
-                    children: [
-                      // Pause/Play button
-                      ClickableCursor(
-                        child: GestureDetector(
-                          onTap: () {
-                            if (_isAutoScrollPaused) {
-                              _resumeAutoScroll();
-                            } else {
-                              _pauseAutoScroll();
-                            }
-                          },
-                          child: AppIcon(
-                            _isAutoScrollPaused ? Symbols.play_arrow_rounded : Symbols.pause_rounded,
-                            fill: 1,
-                            color: Theme.of(context).colorScheme.onSurface,
-                            size: 18,
-                            semanticLabel: _isAutoScrollPaused
-                                ? t.accessibility.autoScrollPlay
-                                : t.accessibility.autoScrollPause,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: 8),
-                      ValueListenableBuilder<int>(
-                        valueListenable: _heroIndex,
-                        builder: (context, _, _) {
-                          final range = _getVisibleDotRange();
-                          return Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: List.generate(range.end - range.start + 1, (i) {
-                              final index = range.start + i;
-                              final isActive = _currentHeroIndex == index;
-                              final dotSize = _getDotSize(index, range.start, range.end);
-
-                              return isActive
-                                  ? ValueListenableBuilder<double>(
-                                      valueListenable: _indicatorProgress,
-                                      builder: (context, progress, child) {
-                                        final maxWidth = dotSize * 3;
-                                        final fillWidth = dotSize + ((maxWidth - dotSize) * progress);
-                                        final onSurface = Theme.of(context).colorScheme.onSurface;
-                                        return Container(
-                                          margin: const EdgeInsets.symmetric(horizontal: 4),
-                                          width: maxWidth,
-                                          height: dotSize,
-                                          decoration: BoxDecoration(
-                                            color: onSurface.withValues(alpha: 0.4),
-                                            borderRadius: BorderRadius.circular(dotSize / 2),
-                                          ),
-                                          child: Align(
-                                            alignment: .centerLeft,
-                                            child: Container(
-                                              width: fillWidth,
-                                              height: dotSize,
-                                              decoration: BoxDecoration(
-                                                color: onSurface,
-                                                borderRadius: BorderRadius.circular(dotSize / 2),
-                                              ),
-                                            ),
-                                          ),
-                                        );
-                                      },
-                                    )
-                                  : AnimatedContainer(
-                                      duration: tokens(context).slow,
-                                      curve: Curves.easeInOut,
-                                      margin: const EdgeInsets.symmetric(horizontal: 4),
-                                      width: dotSize,
-                                      height: dotSize,
-                                      decoration: BoxDecoration(
-                                        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
-                                        borderRadius: BorderRadius.circular(dotSize / 2),
-                                      ),
-                                    );
-                            }),
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildHeroItem(MediaItem heroItem, double heroHeight) {
-    final heroClient = _getMediaClientForItem(heroItem);
-    final isEpisode = heroItem.isEpisode;
-    final showName = heroItem.grandparentTitle ?? heroItem.displayTitle;
-    final screenWidth = MediaQuery.sizeOf(context).width;
-    final heroAspectRatio = screenWidth / heroHeight;
-    final heroArtPaths = heroItem.heroArtCandidates(containerAspectRatio: heroAspectRatio);
-    final isLargeScreen = ScreenBreakpoints.isWideTabletOrLarger(screenWidth);
-    final isTv = PlatformDetector.isTV();
-    final alignLeft = isTv || isLargeScreen;
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final heroLogoWidth = isTv ? TvLayoutConstants.heroLogoWidth : 400.0;
-    final heroLogoHeight = isTv ? TvLayoutConstants.heroLogoHeight : 120.0;
-    final heroTitleStyle = theme.textTheme.displaySmall?.copyWith(
-      color: colorScheme.onSurface,
-      fontWeight: .bold,
-      fontSize: isTv ? 52 : null,
-      shadows: [Shadow(color: colorScheme.surface.withValues(alpha: 0.8), blurRadius: 8)],
-    );
-
-    final contentTypeLabel = heroItem.isMovie ? t.discover.movie : t.discover.tvShow;
-
-    final hideSpoilers = SettingsService.instance.read(SettingsService.hideSpoilers);
-    final shouldHideSpoiler = hideSpoilers && heroItem.shouldHideSpoiler;
-
-    final heroLabel = isEpisode ? "${heroItem.grandparentTitle}, ${heroItem.title}" : heroItem.title;
-
-    return Semantics(
-      label: heroLabel,
-      button: true,
-      hint: t.accessibility.tapToPlay,
-      child: ClickableCursor(
-        child: GestureDetector(
-          onTap: () {
-            appLogger.d('Activating hero item: ${heroItem.title}');
-            navigateToMediaItem(context, heroItem, playDirectly: true);
-          },
-          child: Stack(
-            fit: StackFit.expand,
-            clipBehavior: Clip.none,
-            children: [
-              // Background Image with fade/zoom animation and parallax
-              if (heroArtPaths.isNotEmpty)
-                ClipRect(
-                  child: AnimatedBuilder(
-                    animation: _scrollController,
-                    builder: (context, child) {
-                      final scrollOffset = _scrollController.hasClients ? _scrollController.offset : 0.0;
-                      return Transform.translate(offset: Offset(0, scrollOffset * 0.3), child: child);
-                    },
-                    child: TweenAnimationBuilder<double>(
-                      tween: Tween(begin: 0.0, end: 1.0),
-                      duration: const Duration(milliseconds: 800),
-                      curve: Curves.easeOut,
-                      builder: (context, value, child) {
-                        return Transform.scale(
-                          scale: 1.0 + (0.1 * (1 - value)),
-                          child: Opacity(opacity: value, child: child),
-                        );
-                      },
-                      child: Builder(
-                        builder: (context) {
-                          // heroClient resolves to the actual server's client
-                          // (Plex or Jellyfin) so each backend's transcoder
-                          // builds sized URLs.
-                          return blurArtwork(
-                            CyclingMediaBackdrop(
-                              mediaKey: heroItem.globalKey,
-                              imagePaths: heroItem.heroRotationPaths(containerAspectRatio: heroAspectRatio),
-                              fallbackImagePaths: heroArtPaths,
-                              client: heroClient,
-                              active: _isTabVisible,
-                              width: screenWidth,
-                              height: heroHeight,
-                              fallbackColor: Theme.of(context).colorScheme.surfaceContainerHighest,
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                  ),
-                )
-              else
-                ColoredBox(color: colorScheme.surfaceContainerHighest),
-
-              // Gradient Overlay - blends into scaffold background
-              Positioned(
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: -4, // Extend past stack bounds to ensure coverage
-                child: IgnorePointer(
-                  child: Builder(
-                    builder: (context) {
-                      final bgColor = Theme.of(context).scaffoldBackgroundColor;
-                      return Container(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            // Reach full bg before the bottom edge so the hero
-                            // blends seamlessly into the content below and the
-                            // page dots sit on a solid band.
-                            colors: [Colors.transparent, bgColor.withValues(alpha: 0.9), bgColor, bgColor],
-                            stops: isTv ? const [0.25, 0.78, 0.94, 1.0] : const [0.5, 0.85, 0.94, 1.0],
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-
-              // Content with responsive alignment
-              Positioned(
-                bottom: isTv
-                    ? 88
-                    : isLargeScreen
-                    ? 80
-                    : 50,
-                left: 0,
-                right: isTv
-                    ? screenWidth * 0.36
-                    : isLargeScreen
-                    ? 200
-                    : 0,
-                child: Padding(
-                  padding: .symmetric(
-                    horizontal: isTv
-                        ? TvLayoutConstants.horizontalInset
-                        : isLargeScreen
-                        ? 40
-                        : 24,
-                  ),
-                  child: Align(
-                    alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        maxWidth: isTv ? TvLayoutConstants.heroContentMaxWidth : double.infinity,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: alignLeft ? CrossAxisAlignment.start : CrossAxisAlignment.center,
-                        mainAxisSize: .min,
-                        children: [
-                          // Show logo, falling back to the name/title
-                          ClearLogoImage(
-                            client: heroClient,
-                            logoPath: heroItem.clearLogoPath,
-                            width: heroLogoWidth,
-                            height: heroLogoHeight,
-                            alignment: alignLeft ? Alignment.bottomLeft : Alignment.bottomCenter,
-                            fallbackBuilder: (context) => FittingTitleText(
-                              showName,
-                              style: heroTitleStyle,
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                              alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
-                            ),
-                          ),
-
-                          // Metadata as dot-separated text with content type
-                          if (heroItem.year != null || heroItem.contentRating != null || heroItem.rating != null) ...[
-                            const SizedBox(height: 16),
-                            Text(
-                              [
-                                contentTypeLabel,
-                                if (heroItem.rating != null) '★ ${formatRating(heroItem.rating!)}',
-                                if (heroItem.contentRating != null) formatContentRating(heroItem.contentRating!),
-                                if (heroItem.year != null) heroItem.year.toString(),
-                              ].join(' • '),
-                              style: TextStyle(
-                                color: colorScheme.onSurface,
-                                fontSize: isTv ? 18 : 14,
-                                fontWeight: .w600,
-                              ),
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                            ),
-                          ],
-
-                          if (!alignLeft) ...[const SizedBox(height: 20), _buildSmartPlayButton(heroItem)],
-
-                          if (heroItem.summary != null && !shouldHideSpoiler) ...[
-                            const SizedBox(height: 12),
-                            RichText(
-                              maxLines: isTv ? 3 : 2,
-                              overflow: .ellipsis,
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                              text: TextSpan(
-                                style: TextStyle(
-                                  color: colorScheme.onSurface.withValues(alpha: 0.7),
-                                  fontSize: isTv ? 18 : 14,
-                                  height: isTv ? 1.45 : 1.4,
-                                ),
-                                children: [
-                                  if (isEpisode && heroItem.parentIndex != null && heroItem.index != null)
-                                    TextSpan(
-                                      text: 'S${heroItem.parentIndex}, E${heroItem.index}: ',
-                                      style: TextStyle(fontWeight: .bold, color: colorScheme.onSurface),
-                                    ),
-                                  TextSpan(
-                                    text: heroItem.summary?.isNotEmpty == true
-                                        ? heroItem.summary!
-                                        : t.messages.noDescriptionAvailable,
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ] else if (shouldHideSpoiler &&
-                              isEpisode &&
-                              heroItem.parentIndex != null &&
-                              heroItem.index != null) ...[
-                            const SizedBox(height: 12),
-                            Text(
-                              'S${heroItem.parentIndex}, E${heroItem.index}: ${heroItem.title}',
-                              maxLines: 2,
-                              overflow: .ellipsis,
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                              style: TextStyle(
-                                color: colorScheme.onSurface.withValues(alpha: 0.7),
-                                fontSize: isTv ? 18 : 14,
-                                height: isTv ? 1.45 : 1.4,
-                              ),
-                            ),
-                          ],
-
-                          if (alignLeft) ...[SizedBox(height: isTv ? 28 : 20), _buildSmartPlayButton(heroItem)],
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildSmartPlayButton(MediaItem rawHeroItem) {
-    return Builder(
-      builder: (context) {
-        // The on-deck snapshot refetches shortly after a watch event; the store
-        // patch bridges the gap so "minutes left" never lags.
-        final heroItem = context.withFreshWatchState(rawHeroItem);
-        final hasProgress = heroItem.hasActiveProgress;
-        final isTv = PlatformDetector.isTV();
-
-        final minutesLeft = hasProgress ? ((heroItem.durationMs! - heroItem.viewOffsetMs!) / 60_000).round() : 0;
-
-        final progress = hasProgress ? heroItem.viewOffsetMs! / heroItem.durationMs! : 0.0;
-
-        return ListenableBuilder(
-          listenable: _heroFocusNode,
-          builder: (context, _) {
-            final showFocus = isTv && _heroFocusNode.hasFocus && InputModeTracker.isKeyboardMode(context);
-            final colorScheme = Theme.of(context).colorScheme;
-            final backgroundColor = showFocus ? colorScheme.primary : Colors.white;
-            final foregroundColor = showFocus ? colorScheme.onPrimary : Colors.black;
-            return InkWell(
-              onTap: () {
-                appLogger.d('Playing: ${heroItem.title}');
-                navigateToVideoPlayer(context, metadata: heroItem);
-              },
-              borderRadius: BorderRadius.all(Radius.circular(isTv ? 32 : 24)),
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 150),
-                curve: Curves.easeOutCubic,
-                padding: .symmetric(horizontal: isTv ? 34 : 24, vertical: isTv ? 16 : 12),
-                decoration: BoxDecoration(
-                  color: backgroundColor,
-                  borderRadius: BorderRadius.all(Radius.circular(isTv ? 32 : 24)),
-                  boxShadow: showFocus
-                      ? [BoxShadow(color: colorScheme.primary.withValues(alpha: 0.35), blurRadius: 28, spreadRadius: 4)]
-                      : null,
-                ),
-                child: Row(
-                  mainAxisSize: .min,
-                  children: [
-                    AppIcon(Symbols.play_arrow_rounded, fill: 1, size: isTv ? 28 : 20, color: foregroundColor),
-                    SizedBox(width: isTv ? 12 : 8),
-                    if (hasProgress) ...[
-                      // Progress bar
-                      Container(
-                        width: isTv ? 56 : 40,
-                        height: isTv ? 8 : 6,
-                        decoration: BoxDecoration(
-                          color: foregroundColor.withValues(alpha: 0.25),
-                          borderRadius: BorderRadius.all(Radius.circular(isTv ? 4 : 3)),
-                        ),
-                        child: FractionallySizedBox(
-                          alignment: .centerLeft,
-                          widthFactor: progress,
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: foregroundColor,
-                              borderRadius: BorderRadius.all(Radius.circular(isTv ? 3 : 2)),
-                            ),
-                          ),
-                        ),
-                      ),
-                      SizedBox(width: isTv ? 12 : 8),
-                      Text(
-                        t.discover.minutesLeft(minutes: minutesLeft),
-                        style: TextStyle(
-                          color: foregroundColor,
-                          fontSize: isTv ? 18 : 14,
-                          fontWeight: isTv ? FontWeight.w700 : FontWeight.w600,
-                        ),
-                      ),
-                    ] else
-                      Text(
-                        t.common.play,
-                        style: TextStyle(
-                          color: foregroundColor,
-                          fontSize: isTv ? 18 : 14,
-                          fontWeight: isTv ? FontWeight.w700 : FontWeight.w600,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-            );
-          },
-        );
-      },
-    );
-  }
 }

--- a/lib/screens/discover_screen.dart
+++ b/lib/screens/discover_screen.dart
@@ -21,6 +21,7 @@ import '../providers/discover_provider.dart';
 import '../providers/multi_server_provider.dart';
 import '../widgets/hub_section.dart';
 import '../widgets/hero_hub_section.dart';
+import '../widgets/hover_preview/hover_preview_player_controller.dart';
 import '../widgets/app_menu.dart';
 import '../widgets/loading_indicator_box.dart';
 import '../widgets/profile_switching_overlay.dart';
@@ -77,6 +78,16 @@ class _DiscoverScreenState extends State<DiscoverScreen>
   bool get _isLoading => _discover.isLoading;
   bool get _areHubsLoading => _discover.areHubsLoading;
   String? get _errorMessage => _discover.errorMessage == null ? null : t.errors.unableToLoad(context: t.discover.title);
+
+  /// App-wide singleton (registered in main.dart, not created here) —
+  /// Windows' native video plugin only backs one process-wide video core,
+  /// so every hero row's trailer, on any screen, has to share this one
+  /// controller/Player; a screen-owned instance would fight another
+  /// screen's over that same native core the moment both are alive at once
+  /// (the "black screen on the library's Recommended tab" bug reported
+  /// 2026-09-10 — LibraryRecommendedTab had its own separate instance).
+  /// Also what the global mute icon in the app bar controls.
+  late final HoverPreviewPlayerController _hoverPreviewController;
 
   bool _switchingProfile = false;
   final PageController _heroController = PageController();
@@ -281,6 +292,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     _heroFocusNode = FocusNode(debugLabel: 'hero_section');
     _heroFocusNode.addListener(_onHeroFocusChanged);
     _discover = context.read<DiscoverProvider>();
+    _hoverPreviewController = context.read<HoverPreviewPlayerController>();
     _seenLoadGeneration = _discover.loadGeneration;
     _discover.addListener(_onDiscoverChanged);
     _updateHubKeys();
@@ -377,6 +389,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     _scrollController.dispose();
     _heroFocusNode.removeListener(_onHeroFocusChanged);
     _heroFocusNode.dispose();
+    // Not disposed here — app-wide singleton, see its field doc comment.
     super.dispose();
   }
 
@@ -454,6 +467,12 @@ class _DiscoverScreenState extends State<DiscoverScreen>
     _pendingTvBrowseRailFocus = false;
     _autoScrollTimer?.cancel();
     _stopIndicatorProgress();
+    // Discover stays mounted in the background when another tab (e.g.
+    // Settings) is shown over it — individual HeroHubSections only stop
+    // their own trailer on scroll/losing center, neither of which fires
+    // just from switching tabs, so a trailer kept playing indefinitely in
+    // the background otherwise (reported 2026-09-10).
+    unawaited(_hoverPreviewController.stop());
   }
 
   @override
@@ -759,6 +778,43 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                       onPressed: () => _serverActivitiesButtonKey.currentState?.togglePanel(),
                       child: ServerActivitiesButton(key: _serverActivitiesButtonKey),
                     ),
+                  // Global mute for whatever hero trailer is currently
+                  // playing (any of them — only one can play at a time,
+                  // Windows' native video plugin only backs one process-wide
+                  // video core). One persistent, fixed spot rather than
+                  // attached to whichever hero card happens to be playing,
+                  // per spec. Present at all times; dimmed/inert when
+                  // nothing's actually playing rather than disappearing —
+                  // `actions` is typed List<FocusableAction>, so this can't
+                  // conditionally resolve to a different widget type anyway.
+                  FocusableAction(
+                    // FocusableActionBar only wires mouse-click handling for
+                    // the DEFAULT IconButton it builds itself (no custom
+                    // `child`/`builder`) — supplying `builder` here bypasses
+                    // that IconButton entirely, so `onPressed` below only
+                    // ever fired via keyboard/d-pad Select, never a real
+                    // mouse click (the actual bug reported 2026-09-10: "the
+                    // microphone can't be toggled ... click ... doesn't turn
+                    // on"). Fixed by giving the builder's own IconButton the
+                    // same onPressed directly, so both input paths work.
+                    onPressed: () {
+                      if (_hoverPreviewController.player == null) return;
+                      unawaited(_hoverPreviewController.toggleMuted());
+                    },
+                    builder: (context, _) => ListenableBuilder(
+                      listenable: _hoverPreviewController,
+                      builder: (context, _) {
+                        final isPlaying = _hoverPreviewController.player != null;
+                        return IconButton(
+                          onPressed: isPlaying ? () => unawaited(_hoverPreviewController.toggleMuted()) : null,
+                          icon: AppIcon(
+                            _hoverPreviewController.isMuted ? Symbols.volume_off_rounded : Symbols.volume_up_rounded,
+                            fill: 1,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
                   // User menu — profiles + sign out
                   _buildUserMenuAction(context),
                 ],
@@ -808,9 +864,7 @@ class _DiscoverScreenState extends State<DiscoverScreen>
               // Hero rendering is now per-row (see the loop below): whichever
               // row(s) have heroStyle on render as a HeroHubSection wherever
               // home_row_order places them, same as any other row.
-              SliverToBoxAdapter(
-                child: SizedBox(height: kToolbarHeight + MediaQuery.paddingOf(context).top + 16),
-              ),
+              SliverToBoxAdapter(child: SizedBox(height: kToolbarHeight + MediaQuery.paddingOf(context).top + 16)),
               if (_isLoading) LoadingIndicatorBox.sliver,
               if (_errorMessage != null) SliverErrorState(message: _errorMessage!, onRetry: _discover.load),
               if (!_isLoading && _errorMessage == null) ...[
@@ -825,26 +879,27 @@ class _DiscoverScreenState extends State<DiscoverScreen>
                         ? HeroHubSection(
                             key: ValueKey('hero:${_hubIdentity(_hubs[i])}'),
                             hub: _hubs[i],
+                            playerController: _hoverPreviewController,
                             onVerticalNavigation: (isUp) => _handleVerticalNavigation(i, isUp),
                             onNavigateUp: i == 0 ? _focusTopBoundary : null,
                             onNavigateToSidebar: _navigateToSidebar,
                           )
                         : HubSection(
-                      key: i < _orderedHubKeys.length ? _orderedHubKeys[i] : null,
-                      hub: _hubs[i],
-                      focusMemory: _hubFocusMemory,
-                      icon: hubIconFor(_hubs[i]),
-                      showServerName: showServerNameOnHubs || hubsSpanMultipleServers,
-                      onRefresh: _discover.updateItem,
-                      onRemoveFromContinueWatching: _hubs[i].isContinueWatchingHub
-                          ? _discover.refreshContinueWatching
-                          : null,
-                      isInContinueWatching: _hubs[i].isContinueWatchingHub,
-                      loadMoreItems: _hubs[i].isContinueWatchingHub ? _discover.loadAllContinueWatching : null,
-                      onVerticalNavigation: (isUp) => _handleVerticalNavigation(i, isUp),
-                      onNavigateUp: i == 0 ? _focusTopBoundary : null,
-                      onNavigateToSidebar: _navigateToSidebar,
-                    ),
+                            key: i < _orderedHubKeys.length ? _orderedHubKeys[i] : null,
+                            hub: _hubs[i],
+                            focusMemory: _hubFocusMemory,
+                            icon: hubIconFor(_hubs[i]),
+                            showServerName: showServerNameOnHubs || hubsSpanMultipleServers,
+                            onRefresh: _discover.updateItem,
+                            onRemoveFromContinueWatching: _hubs[i].isContinueWatchingHub
+                                ? _discover.refreshContinueWatching
+                                : null,
+                            isInContinueWatching: _hubs[i].isContinueWatchingHub,
+                            loadMoreItems: _hubs[i].isContinueWatchingHub ? _discover.loadAllContinueWatching : null,
+                            onVerticalNavigation: (isUp) => _handleVerticalNavigation(i, isUp),
+                            onNavigateUp: i == 0 ? _focusTopBoundary : null,
+                            onNavigateToSidebar: _navigateToSidebar,
+                          ),
                   ),
 
                 // Show loading skeleton for hubs while they're loading
@@ -983,5 +1038,4 @@ class _DiscoverScreenState extends State<DiscoverScreen>
       ),
     );
   }
-
 }

--- a/lib/screens/libraries/libraries_screen.dart
+++ b/lib/screens/libraries/libraries_screen.dart
@@ -22,6 +22,7 @@ import '../../utils/content_utils.dart';
 import '../../widgets/app_menu.dart';
 import '../../widgets/desktop_app_bar.dart';
 import '../../widgets/focusable_tab_chip.dart';
+import '../../widgets/hover_preview/hover_preview_player_controller.dart';
 import '../../widgets/library_management_sheet.dart';
 import '../../services/storage_service.dart';
 import '../../mixins/refreshable.dart';
@@ -83,6 +84,14 @@ class _LibrariesScreenState extends State<LibrariesScreen>
 
   final _actionBarKey = GlobalKey<FocusableActionBarState>();
 
+  /// App-wide singleton (registered in main.dart) — same shared
+  /// controller/mute state DiscoverScreen's own app bar mute button
+  /// controls, since a library's own Recommended tab hero rows play
+  /// through it too (see library_recommended_tab.dart). Per user request
+  /// 2026-09-10: the mute control needs to be reachable here too, not just
+  /// from Home.
+  late final HoverPreviewPlayerController _hoverPreviewController;
+
   final ScrollController _outerScrollController = ScrollController();
 
   /// Reveal the floating header by jumping the outer NestedScrollView back
@@ -117,6 +126,7 @@ class _LibrariesScreenState extends State<LibrariesScreen>
   void initState() {
     super.initState();
     initTabNavigation();
+    _hoverPreviewController = context.read<HoverPreviewPlayerController>();
 
     // Initialize with libraries from the provider
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -718,6 +728,35 @@ class _LibrariesScreenState extends State<LibrariesScreen>
           tooltip: t.libraries.manageLibraries,
           onPressed: _showLibraryManagementSheet,
         ),
+      // Mutes/unmutes whatever hero trailer is currently playing on this
+      // library's own Recommended tab — same shared controller Home's app
+      // bar mute button already controls (library_recommended_tab.dart's
+      // hero rows play through it too). Present at all times, dimmed/inert
+      // when nothing's playing, per user request 2026-09-10.
+      FocusableAction(
+        // FocusableActionBar only wires mouse-click handling for the
+        // DEFAULT IconButton it builds itself — supplying `builder` here
+        // bypasses that, so `onPressed` below only fires via keyboard/d-pad
+        // Select unless the builder's own IconButton also wires it
+        // directly (same fix as DiscoverScreen's identical mute button).
+        onPressed: () {
+          if (_hoverPreviewController.player == null) return;
+          unawaited(_hoverPreviewController.toggleMuted());
+        },
+        builder: (context, _) => ListenableBuilder(
+          listenable: _hoverPreviewController,
+          builder: (context, _) {
+            final isPlaying = _hoverPreviewController.player != null;
+            return IconButton(
+              onPressed: isPlaying ? () => unawaited(_hoverPreviewController.toggleMuted()) : null,
+              icon: AppIcon(
+                _hoverPreviewController.isMuted ? Symbols.volume_off_rounded : Symbols.volume_up_rounded,
+                fill: 1,
+              ),
+            );
+          },
+        ),
+      ),
       if (showBrowseOptionsAction)
         FocusableAction(
           icon: Symbols.tune_rounded,

--- a/lib/screens/libraries/tabs/library_recommended_tab.dart
+++ b/lib/screens/libraries/tabs/library_recommended_tab.dart
@@ -3,6 +3,7 @@ import '../../../media/ids.dart';
 
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
 
 import '../../../focus/hub_vertical_navigation.dart';
 import '../../../focus/locked_hub_controller.dart';
@@ -15,11 +16,14 @@ import '../../../mixins/item_updatable.dart';
 import '../../../mixins/watch_state_aware.dart';
 import '../../../services/settings_service.dart';
 import '../../../utils/deletion_notifier.dart';
+import '../../../utils/home_section_builder.dart' show libraryContinueWatchingHeroOverrideKey, withResolvedHeroOverride;
 import '../../../utils/hub_icons.dart';
 import '../../../utils/media_event_keys.dart';
 import '../../../utils/platform_detector.dart';
 import '../../../utils/provider_extensions.dart';
 import '../../../utils/watch_state_notifier.dart';
+import '../../../widgets/hero_hub_section.dart';
+import '../../../widgets/hover_preview/hover_preview_player_controller.dart';
 import '../../../widgets/hub_section.dart';
 import '../../../widgets/settings_builder.dart';
 import '../../../widgets/tv_browse_rail.dart';
@@ -54,7 +58,25 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
   final TvSpotlightController _spotlight = TvSpotlightController();
   HubFocusMemory _hubFocusMemory = HubFocusMemory();
 
+  /// App-wide singleton (registered in main.dart, read here — not created
+  /// or disposed by this screen). Windows' native video plugin only backs
+  /// one process-wide video core, so this tab's hero rows have to share the
+  /// exact same controller/Player DiscoverScreen uses, not a separate
+  /// instance: this tab and Home can both be alive at once (a completely
+  /// separate route kept mounted in the background), and two independent
+  /// instances fighting over that one native core is exactly what produced
+  /// a black, silently-failing video surface here (reported 2026-09-10 —
+  /// this field used to construct its own `HoverPreviewPlayerController()`,
+  /// which was the bug, not the fix it looked like at the time).
+  late final HoverPreviewPlayerController _hoverPreviewController;
+
   void _setSpotlightItem(MediaItem item) => _spotlight.select(item);
+
+  @override
+  void initState() {
+    super.initState();
+    _hoverPreviewController = context.read<HoverPreviewPlayerController>();
+  }
 
   @override
   void didUpdateWidget(LibraryRecommendedTab oldWidget) {
@@ -62,11 +84,17 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
     if (oldWidget.library.globalKey != widget.library.globalKey) {
       _hubFocusMemory = HubFocusMemory();
     }
+    // Mirrors DiscoverScreen's onTabHidden fix — a trailer must not keep
+    // playing once this tab is no longer the one on screen.
+    if (!widget.isActive && oldWidget.isActive) {
+      unawaited(_hoverPreviewController.stop());
+    }
   }
 
   @override
   void dispose() {
     _spotlight.dispose();
+    // Not disposed here — app-wide singleton, see its field doc comment.
     super.dispose();
   }
 
@@ -200,6 +228,16 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
             ),
           );
 
+    // This library's own Continue Watching isn't a PlexManagedHub — Plex
+    // has no promote/demote concept for it — so unlike every other row
+    // here it can't be hidden through updateManagedHubVisibility; it's a
+    // Plezy-local toggle instead (Home layout settings → the library's own
+    // "Continue Watching" tile), read directly here.
+    final libraryCwHidden = SettingsService.instance
+        .read(SettingsService.libraryContinueWatchingHidden)
+        .contains(widget.library.globalKey);
+    if (libraryCwHidden) hubs.removeWhere(_isContinueWatchingHub);
+
     // Move Continue Watching hub to the front if present
     final cwIndex = hubs.indexWhere(_isContinueWatchingHub);
     if (cwIndex > 0) {
@@ -207,7 +245,24 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
       hubs.insert(0, cwHub);
     }
 
-    return hubs;
+    // Same Hero/Trailer overrides the Home screen applies to this exact
+    // hub (buildConfiguredHomeSections in home_section_builder.dart) — a
+    // row's Hero/Trailer setting is meant to follow it wherever it's
+    // shown, not just on Home. Continue Watching bypasses this generic
+    // identifier-matched lookup, same reason Home's own Continue Watching
+    // does (see continueWatchingHeroOverrideKey's doc comment) — it's keyed
+    // separately instead, per library.
+    final overrides = SettingsService.instance.read(SettingsService.managedHubHeroOverrides);
+    final cwOverride = overrides[libraryContinueWatchingHeroOverrideKey(widget.library.globalKey)];
+    return [
+      for (final hub in hubs)
+        _isContinueWatchingHub(hub)
+            ? hub.copyWith(
+                heroStyle: cwOverride?.heroStyle ?? false,
+                heroTrailerPreview: cwOverride?.heroTrailerPreview ?? false,
+              )
+            : withResolvedHeroOverride(hub, overrides),
+    ];
   }
 
   /// Ensure we have enough GlobalKeys for all hubs
@@ -287,6 +342,22 @@ class _LibraryRecommendedTabState extends BaseLibraryTabState<MediaHub, LibraryR
               final hub = items[index];
               final isContinueWatching = _isContinueWatchingHub(hub);
               final usesContinueWatchingAction = _usesContinueWatchingAction(hub);
+
+              // Same branch DiscoverScreen uses for Home — a plain ValueKey,
+              // not a GlobalKey<HubSectionState>, since HeroHubSection has
+              // its own state type and doesn't participate in this screen's
+              // focus-memory system (matches Home's own hero rows, which
+              // don't either).
+              if (hub.heroStyle && hub.items.isNotEmpty) {
+                return HeroHubSection(
+                  key: ValueKey('hero:${hub.identifier ?? hub.id}'),
+                  hub: hub,
+                  playerController: _hoverPreviewController,
+                  onVerticalNavigation: (isUp) => _handleVerticalNavigation(index, isUp),
+                  onNavigateUp: index == 0 ? widget.onBack : null,
+                  onNavigateToSidebar: _navigateToSidebar,
+                );
+              }
 
               return HubSection(
                 key: _hubKeys[index],

--- a/lib/screens/settings/appearance_settings_screen.dart
+++ b/lib/screens/settings/appearance_settings_screen.dart
@@ -17,6 +17,7 @@ import '../../widgets/setting_tile.dart';
 import '../../widgets/settings_page.dart';
 import '../../widgets/settings_builder.dart';
 import '../../widgets/settings_section.dart';
+import 'home_layout_settings_screen.dart';
 import 'settings_utils.dart';
 
 class AppearanceSettingsScreen extends StatelessWidget {
@@ -103,6 +104,12 @@ class AppearanceSettingsScreen extends StatelessWidget {
               ),
             _continueWatchingActionSelector(),
             _episodeActionSelector(),
+            SettingNavigationTile(
+              icon: Symbols.view_quilt_rounded,
+              title: 'Home layout',
+              subtitle: 'Choose rows, libraries, and collection categories',
+              destinationBuilder: (_) => const HomeLayoutSettingsScreen(),
+            ),
             SettingSwitchTile(
               pref: SettingsService.useGlobalHubs,
               icon: Symbols.home_rounded,

--- a/lib/screens/settings/home_layout_settings_screen.dart
+++ b/lib/screens/settings/home_layout_settings_screen.dart
@@ -1,0 +1,538 @@
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/home_section_config.dart';
+import '../../media/media_item.dart';
+import '../../media/media_kind.dart';
+import '../../media/media_backend.dart';
+import '../../media/ids.dart';
+import '../../media/media_library.dart';
+import '../../providers/libraries_provider.dart';
+import '../../providers/multi_server_provider.dart';
+import '../../services/settings_service.dart';
+import '../../models/plex/plex_managed_hub.dart';
+import '../../widgets/settings_page.dart';
+import '../../widgets/settings_section.dart';
+
+class HomeLayoutSettingsScreen extends StatefulWidget {
+  const HomeLayoutSettingsScreen({super.key});
+
+  @override
+  State<HomeLayoutSettingsScreen> createState() => _HomeLayoutSettingsScreenState();
+}
+
+class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
+  List<HomeSectionConfig> _sections = [];
+  bool _loaded = false;
+  List<MediaItem> _collections = const [];
+  Map<String, List<PlexManagedHub>> _managedRows = {};
+  List<String> _rowOrder = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final settings = await SettingsService.getInstance();
+    final sections = List.of(settings.read(SettingsService.homeSections));
+    final rowOrder = List.of(settings.read(SettingsService.homeRowOrder));
+    List<MediaItem> collections = const [];
+    try {
+      collections =
+          (await context.read<MultiServerProvider>().aggregationService.getCollectionsFromAllServers()).collections;
+    } catch (_) {
+      // The editor remains usable when a server is temporarily offline.
+    }
+    final managedRows = <String, List<PlexManagedHub>>{};
+
+    final libraryProvider = context.read<LibrariesProvider>();
+    if (!libraryProvider.hasLibraries) await libraryProvider.loadLibraries();
+    final plexLibraries = context
+        .read<LibrariesProvider>()
+        .libraries
+        .where((library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null)
+        .toList();
+    await Future.wait(
+      plexLibraries.map((library) async {
+        try {
+          final client = context.read<MultiServerProvider>().getPlexClientForServer(ServerId(library.serverId!));
+          if (client != null) managedRows[library.globalKey] = await client.fetchManagedHubs(library.id);
+        } catch (_) {}
+      }),
+    );
+    if (!mounted) return;
+    setState(() {
+      _sections = sections;
+      _collections = collections;
+      _managedRows = managedRows;
+      _rowOrder = _normalizeRowOrder(rowOrder, plexLibraries, sections, managedRows);
+      _loaded = true;
+    });
+  }
+
+  Future<void> _save(List<HomeSectionConfig> sections) async {
+    final settings = await SettingsService.getInstance();
+    await settings.write(SettingsService.homeSections, sections);
+    final libraries = context
+        .read<LibrariesProvider>()
+        .libraries
+        .where((library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null)
+        .toList();
+    final order = _normalizeRowOrder(settings.read(SettingsService.homeRowOrder), libraries, sections, _managedRows);
+    await settings.write(SettingsService.homeRowOrder, order);
+    if (mounted)
+      setState(() {
+        _sections = sections;
+        _rowOrder = order;
+      });
+  }
+
+  Future<void> _editSection(HomeSectionConfig current) async {
+    final libraries = context.read<LibrariesProvider>().libraries.where((l) => !l.hidden).toList();
+    final result = await showDialog<HomeSectionConfig>(
+      context: context,
+      builder: (_) => _HomeSectionDialog(libraries: libraries, collections: _collections, initial: current),
+    );
+    if (result != null) {
+      final updated = _sections.map((s) => s.id == current.id ? result : s).toList();
+      await _save(updated);
+    }
+  }
+
+  Future<void> _moveSection(int index, int delta) async {
+    final next = index + delta;
+    if (next < 0 || next >= _sections.length) return;
+    final reordered = List<HomeSectionConfig>.of(_sections);
+    final item = reordered.removeAt(index);
+    reordered.insert(next, item);
+    await _save(reordered);
+  }
+
+  Future<void> _addSection() async {
+    final libraries = context.read<LibrariesProvider>().libraries.where((l) => !l.hidden).toList();
+    final result = await showDialog<HomeSectionConfig>(
+      context: context,
+      builder: (_) => _HomeSectionDialog(libraries: libraries, collections: _collections),
+    );
+    if (result != null) await _save([..._sections, result]);
+  }
+
+  String _libraryToken(MediaLibrary library) => 'library:${library.serverId}:${library.id}';
+
+  String _hubToken(MediaLibrary library, PlexManagedHub hub) =>
+      'plex:${library.serverId}:${library.id}:${hub.identifier}';
+
+  List<String> _normalizeRowOrder(
+    List<String> saved,
+    List<MediaLibrary> libraries,
+    List<HomeSectionConfig> sections,
+    Map<String, List<PlexManagedHub>> managedRows,
+  ) {
+    final available = <String>[
+      for (final library in libraries)
+        for (final hub in managedRows[library.globalKey] ?? const <PlexManagedHub>[])
+          if (hub.promotedToOwnHome) _hubToken(library, hub),
+      for (final section in sections)
+        if (section.enabled && section.showOnHome) 'custom:${section.id}',
+    ];
+    return [...saved.where(available.contains), ...available.where((entry) => !saved.contains(entry))];
+  }
+
+  Future<void> _moveRow(String token, int delta) async {
+    final index = _rowOrder.indexOf(token);
+    final next = index + delta;
+    if (index < 0 || next < 0 || next >= _rowOrder.length) return;
+    final order = List<String>.of(_rowOrder);
+    final item = order.removeAt(index);
+    order.insert(next, item);
+    final settings = await SettingsService.getInstance();
+    await settings.write(SettingsService.homeRowOrder, order);
+    if (mounted) setState(() => _rowOrder = order);
+  }
+
+  List<MapEntry<String, String>> _organizerRows() {
+    final libraries = context.read<LibrariesProvider>().libraries.where(
+      (library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null,
+    );
+    final labels = <String, String>{};
+    for (final library in libraries) {
+      for (final hub in _managedRows[library.globalKey] ?? const <PlexManagedHub>[]) {
+        if (hub.promotedToOwnHome) labels[_hubToken(library, hub)] = '${library.title}: ${hub.title}';
+      }
+    }
+    for (final section in _sections) {
+      if (section.enabled && section.showOnHome) labels['custom:${section.id}'] = 'Custom: ${section.title}';
+    }
+    return [
+      for (final token in _rowOrder)
+        if (labels[token] != null) MapEntry(token, labels[token]!),
+    ];
+  }
+
+  List<Widget> _plexManagerGroups() {
+    final libraries = context.read<LibrariesProvider>().libraries.where(
+      (library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null,
+    );
+    return [
+      SettingsGroup(
+        title: 'Plex Home manager',
+        children: [
+          ExpansionTile(
+            initiallyExpanded: false,
+            leading: const Icon(Symbols.sync_rounded),
+            title: const Text('Manage Plex rows in Plezy'),
+            subtitle: const Text('Open to organize the Home-selected rows'),
+            children: [
+              for (var index = 0; index < _organizerRows().length; index++)
+                ListTile(
+                  dense: true,
+                  leading: const Icon(Symbols.drag_indicator_rounded),
+                  title: Text(_organizerRows()[index].value),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Symbols.arrow_upward_rounded),
+                        onPressed: index == 0 ? null : () => _moveRow(_organizerRows()[index].key, -1),
+                      ),
+                      IconButton(
+                        icon: const Icon(Symbols.arrow_downward_rounded),
+                        onPressed: index == _organizerRows().length - 1
+                            ? null
+                            : () => _moveRow(_organizerRows()[index].key, 1),
+                      ),
+                    ],
+                  ),
+                ),
+              if (_organizerRows().isEmpty) const ListTile(title: Text('Select Home rows below first.')),
+            ],
+          ),
+          for (final library in libraries) _managedLibraryTile(library),
+        ],
+      ),
+    ];
+  }
+
+  Future<void> _setManagedVisibility(
+    MediaLibrary library,
+    PlexManagedHub hub, {
+    bool? recommended,
+    bool? home,
+    bool? friendsHome,
+  }) async {
+    final client = context.read<MultiServerProvider>().getPlexClientForServer(ServerId(library.serverId!));
+    if (client == null) return;
+    await client.updateManagedHubVisibility(
+      library.id,
+      hub.identifier,
+      promotedToRecommended: recommended ?? hub.promotedToRecommended,
+      promotedToOwnHome: home ?? hub.promotedToOwnHome,
+      promotedToSharedHome: friendsHome ?? hub.promotedToSharedHome,
+    );
+    await _load();
+  }
+
+  Future<void> _moveManaged(MediaLibrary library, int index, int delta) async {
+    final rows = _managedRows[library.globalKey] ?? const <PlexManagedHub>[];
+    final next = index + delta;
+    if (next < 0 || next >= rows.length) return;
+    final client = context.read<MultiServerProvider>().getPlexClientForServer(ServerId(library.serverId!));
+    if (client == null) return;
+    await client.moveManagedHub(
+      library.id,
+      rows[index].identifier,
+      after: next == 0 ? null : rows[next - 1].identifier,
+    );
+    await _load();
+  }
+
+  Widget _managedLibraryTile(MediaLibrary library) {
+    final rows = _managedRows[library.globalKey] ?? const <PlexManagedHub>[];
+    return ExpansionTile(
+      initiallyExpanded: false,
+      leading: Icon(library.kind == MediaKind.show ? Symbols.tv_rounded : Symbols.movie_rounded),
+      title: Text(library.title),
+      subtitle: Text('${rows.length} Plex-managed rows'),
+      children: [
+        for (var index = 0; index < rows.length; index++)
+          ListTile(
+            dense: true,
+            title: Text(rows[index].title),
+            subtitle: rows[index].deletable ? const Text('Custom Plex row') : null,
+            trailing: Wrap(
+              spacing: 2,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                Tooltip(
+                  message: 'Show in Library Recommended',
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Checkbox(
+                        value: rows[index].promotedToRecommended,
+                        onChanged: (v) => _setManagedVisibility(library, rows[index], recommended: v),
+                      ),
+                      const Text('Library'),
+                    ],
+                  ),
+                ),
+                Tooltip(
+                  message: 'Show on Home screen',
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Checkbox(
+                        value: rows[index].promotedToOwnHome,
+                        onChanged: (v) => _setManagedVisibility(library, rows[index], home: v),
+                      ),
+                      const Text('Home'),
+                    ],
+                  ),
+                ),
+                if (rows[index].deletable)
+                  IconButton(
+                    icon: const Icon(Symbols.delete_outline_rounded),
+                    tooltip: 'Remove Hub',
+                    onPressed: () async {
+                      final client = context.read<MultiServerProvider>().getPlexClientForServer(
+                        ServerId(library.serverId!),
+                      );
+                      if (client != null) {
+                        await client.removeManagedHub(library.id, rows[index].identifier);
+                        await _load();
+                      }
+                    },
+                  ),
+              ],
+            ),
+          ),
+        if (rows.isEmpty) const ListTile(title: Text('No Plex-managed rows returned for this library.')),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsPage(
+      title: const Text('Home layout'),
+      children: [
+        if (_loaded) ..._plexManagerGroups(),
+        SettingsGroup(
+          title: 'Custom rows',
+          children: [
+            if (!_loaded) const ListTile(title: Text('Loading home layout…')),
+            if (_loaded && _sections.isEmpty)
+              const ListTile(title: Text('No custom rows yet'), subtitle: Text('Use Add Home row to create one.')),
+            ListTile(
+              leading: const Icon(Symbols.add_rounded),
+              title: const Text('Add Home row'),
+              subtitle: const Text('Choose a category; the new row is added to Organizer automatically'),
+              onTap: _addSection,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+String _label(HomeSectionKind kind) => switch (kind) {
+  HomeSectionKind.recentlyAdded => 'Recently Added',
+  HomeSectionKind.recentlyReleased => 'Recently Released',
+  HomeSectionKind.movieCollections => 'Movie Collections',
+  HomeSectionKind.showCollections => 'Show Collections',
+};
+
+class _HomeSectionDialog extends StatefulWidget {
+  const _HomeSectionDialog({required this.libraries, required this.collections, this.initial});
+  final List<MediaLibrary> libraries;
+  final List<MediaItem> collections;
+  final HomeSectionConfig? initial;
+  @override
+  State<_HomeSectionDialog> createState() => _HomeSectionDialogState();
+}
+
+class _HomeSectionDialogState extends State<_HomeSectionDialog> {
+  final _title = TextEditingController();
+  HomeSectionKind _kind = HomeSectionKind.recentlyAdded;
+  final _selected = <String>{};
+  final _selectedCollections = <String>{};
+  bool _allCollections = true;
+  bool _showInLibraryRecommended = true;
+  bool _showOnHome = true;
+
+  @override
+  void dispose() {
+    _title.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initial;
+    if (initial != null) {
+      _title.text = initial.title;
+      _kind = initial.kind;
+      _selected.addAll(initial.libraryKeys);
+      _selectedCollections.addAll(initial.collectionKeys);
+      _allCollections = initial.collectionKeys.isEmpty;
+      _showInLibraryRecommended = initial.showInLibraryRecommended;
+      _showOnHome = initial.showOnHome;
+    }
+  }
+
+  List<MediaItem> _filteredCollections() => widget.collections.where((item) {
+    final isMovie = widget.libraries.any(
+      (library) => library.globalKey == item.libraryGlobalKey && library.kind == MediaKind.movie,
+    );
+    final isShow = widget.libraries.any(
+      (library) => library.globalKey == item.libraryGlobalKey && library.kind == MediaKind.show,
+    );
+    final matchesKind = _kind == HomeSectionKind.movieCollections ? isMovie : isShow;
+    return matchesKind && (_selected.isEmpty || _selected.contains(item.libraryGlobalKey));
+  }).toList();
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+    // Nudged above dead-center: on a shorter window the dialog's natural
+    // content height (title + dropdown + both checklists) can exceed the
+    // available height even after the cap below, and centering split the
+    // overflow evenly above/below — the bottom half (Save/Cancel) was the
+    // one actually getting clipped against the window edge.
+    alignment: const Alignment(0, -0.3),
+    title: Text(widget.initial == null ? 'Add Home row' : 'Edit Home row'),
+    content: SizedBox(
+      width: 560,
+      // A shrink-wrapped ListView sizes to its content with no ceiling, so a
+      // dialog with many libraries/collections checked could grow taller
+      // than the window and get clipped at the bottom instead of scrolling.
+      // Capping the height here and dropping shrinkWrap makes the list
+      // scroll internally once it would otherwise overflow.
+      height: (MediaQuery.sizeOf(context).height - 160).clamp(200, 640),
+      child: ListView(
+        children: [
+          TextField(
+            controller: _title,
+            decoration: const InputDecoration(labelText: 'Row title'),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<HomeSectionKind>(
+            value: _kind,
+            decoration: const InputDecoration(labelText: 'Content'),
+            items: [
+              for (final kind in HomeSectionKind.values) DropdownMenuItem(value: kind, child: Text(_label(kind))),
+            ],
+            onChanged: (value) => setState(() {
+              _kind = value ?? _kind;
+              _selectedCollections.clear();
+              _allCollections = true;
+            }),
+          ),
+          const SizedBox(height: 12),
+          const Text('Show this row in:'),
+          CheckboxListTile(
+            dense: true,
+            title: const Text('Library Recommended'),
+            value: _showInLibraryRecommended,
+            onChanged: (value) => setState(() => _showInLibraryRecommended = value ?? false),
+          ),
+          CheckboxListTile(
+            dense: true,
+            title: const Text('Home'),
+            value: _showOnHome,
+            onChanged: (value) => setState(() => _showOnHome = value ?? false),
+          ),
+          const SizedBox(height: 12),
+          const Text('Libraries (leave all unchecked to include every library)'),
+          Padding(
+            padding: const EdgeInsets.only(top: 2, bottom: 4),
+            child: Text(
+              'Every library checked here is merged into this one row.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+          for (final library in widget.libraries)
+            CheckboxListTile(
+              dense: true,
+              value: _selected.contains(library.globalKey),
+              title: Text(library.title),
+              subtitle: Text(library.serverName ?? ''),
+              onChanged: (value) => setState(
+                () => value == true ? _selected.add(library.globalKey) : _selected.remove(library.globalKey),
+              ),
+            ),
+          if (_kind == HomeSectionKind.movieCollections || _kind == HomeSectionKind.showCollections) ...[
+            const SizedBox(height: 12),
+            Text(
+              _kind == HomeSectionKind.movieCollections
+                  ? 'Movie collections (leave all unchecked for every selected library)'
+                  : 'Show collections (leave all unchecked for every selected library)',
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 2, bottom: 4),
+              child: Text(
+                'If exactly one collection matches, its titles show directly in the '
+                "row. If more than one matches, each collection shows as a single "
+                'poster — tap it to open that collection.',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            CheckboxListTile(
+              dense: true,
+              title: const Text('All collections'),
+              value: _allCollections,
+              onChanged: (value) => setState(() {
+                _allCollections = value ?? true;
+                if (_allCollections) _selectedCollections.clear();
+              }),
+            ),
+            for (final collection in _filteredCollections())
+              CheckboxListTile(
+                dense: true,
+                value: !_allCollections && _selectedCollections.contains(collection.globalKey),
+                title: Text(collection.title ?? 'Untitled collection'),
+                subtitle: Text(collection.libraryTitle ?? ''),
+                onChanged: _allCollections
+                    ? null
+                    : (value) => setState(
+                        () => value == true
+                            ? _selectedCollections.add(collection.globalKey)
+                            : _selectedCollections.remove(collection.globalKey),
+                      ),
+              ),
+          ],
+        ],
+      ),
+    ),
+    actions: [
+      TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+      FilledButton(
+        onPressed: () {
+          final title = _title.text.trim().isEmpty ? _label(_kind) : _title.text.trim();
+          Navigator.pop(
+            context,
+            HomeSectionConfig(
+              id: 'custom_${DateTime.now().microsecondsSinceEpoch}',
+              title: title,
+              kind: _kind,
+              libraryKeys: _selected.toList(),
+              collectionKeys: _selectedCollections.toList(),
+              keepSourceRows: true,
+              showInLibraryRecommended: _showInLibraryRecommended,
+              showOnHome: _showOnHome,
+            ),
+          );
+        },
+        child: const Text('Save'),
+      ),
+    ],
+  );
+}

--- a/lib/screens/settings/home_layout_settings_screen.dart
+++ b/lib/screens/settings/home_layout_settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:provider/provider.dart';
@@ -28,6 +29,7 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
   List<MediaItem> _collections = const [];
   Map<String, List<PlexManagedHub>> _managedRows = {};
   List<String> _rowOrder = [];
+  String? _highlightedRowToken;
 
   @override
   void initState() {
@@ -63,12 +65,21 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
         } catch (_) {}
       }),
     );
+    final normalizedOrder = _normalizeRowOrder(rowOrder, plexLibraries, sections, managedRows);
+    // home_row_order is the only thing that decides what shows on Home
+    // (see buildConfiguredHomeSections), so a newly-promoted Plex hub or a
+    // row created outside the normal Add-row flow has to actually land in
+    // the saved order the moment it's discovered here -- otherwise it stays
+    // invisible on Home until some unrelated reorder happens to write it.
+    if (!listEquals(normalizedOrder, rowOrder)) {
+      await settings.write(SettingsService.homeRowOrder, normalizedOrder);
+    }
     if (!mounted) return;
     setState(() {
       _sections = sections;
       _collections = collections;
       _managedRows = managedRows;
-      _rowOrder = _normalizeRowOrder(rowOrder, plexLibraries, sections, managedRows);
+      _rowOrder = normalizedOrder;
       _loaded = true;
     });
   }
@@ -102,25 +113,41 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     }
   }
 
-  Future<void> _moveSection(int index, int delta) async {
-    final next = index + delta;
-    if (next < 0 || next >= _sections.length) return;
-    final reordered = List<HomeSectionConfig>.of(_sections);
-    final item = reordered.removeAt(index);
-    reordered.insert(next, item);
-    await _save(reordered);
-  }
-
   Future<void> _addSection() async {
     final libraries = context.read<LibrariesProvider>().libraries.where((l) => !l.hidden).toList();
     final result = await showDialog<HomeSectionConfig>(
       context: context,
       builder: (_) => _HomeSectionDialog(libraries: libraries, collections: _collections),
     );
-    if (result != null) await _save([..._sections, result]);
+    if (result == null) return;
+    await _save([..._sections, result]);
+    if (result.showOnHome) await _moveTokenToTop('custom:${result.id}');
   }
 
-  String _libraryToken(MediaLibrary library) => 'library:${library.serverId}:${library.id}';
+  Future<void> _moveTokenToTop(String token) async {
+    if (!_rowOrder.contains(token)) return;
+    final order = List<String>.of(_rowOrder)..remove(token);
+    order.insert(0, token);
+    final settings = await SettingsService.getInstance();
+    await settings.write(SettingsService.homeRowOrder, order);
+    if (mounted) setState(() => _rowOrder = order);
+  }
+
+  Future<void> _deleteSection(HomeSectionConfig section) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Remove Home row?'),
+        content: Text('"${section.title}" will be deleted. This can\'t be undone.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(dialogContext, false), child: const Text('Cancel')),
+          FilledButton(onPressed: () => Navigator.pop(dialogContext, true), child: const Text('Remove')),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    await _save(_sections.where((s) => s.id != section.id).toList());
+  }
 
   String _hubToken(MediaLibrary library, PlexManagedHub hub) =>
       'plex:${library.serverId}:${library.id}:${hub.identifier}';
@@ -148,9 +175,44 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     final order = List<String>.of(_rowOrder);
     final item = order.removeAt(index);
     order.insert(next, item);
+    // Update and highlight immediately rather than after the settings write
+    // completes: waiting made the row jump with no visible cue of which one
+    // moved, since the highlight and the reorder landed in the same frame
+    // only once the (imperceptibly fast, but still async) write returned.
+    setState(() {
+      _rowOrder = order;
+      _highlightedRowToken = token;
+    });
+    Future.delayed(const Duration(milliseconds: 1400), () {
+      if (mounted && _highlightedRowToken == token) setState(() => _highlightedRowToken = null);
+    });
     final settings = await SettingsService.getInstance();
     await settings.write(SettingsService.homeRowOrder, order);
-    if (mounted) setState(() => _rowOrder = order);
+  }
+
+  Future<void> _removeRowFromHome(String token) async {
+    if (token.startsWith('custom:')) {
+      final id = token.substring('custom:'.length);
+      await _save(_sections.map((s) => s.id == id ? s.copyWith(showOnHome: false) : s).toList());
+      return;
+    }
+    if (!token.startsWith('plex:')) return;
+    final parts = token.split(':');
+    if (parts.length < 4) return;
+    final serverId = parts[1];
+    final libraryId = parts[2];
+    final hubIdentifier = parts.sublist(3).join(':');
+    final library = context
+        .read<LibrariesProvider>()
+        .libraries
+        .where((l) => l.serverId == serverId && l.id == libraryId)
+        .firstOrNull;
+    if (library == null) return;
+    final hub = (_managedRows[library.globalKey] ?? const <PlexManagedHub>[])
+        .where((h) => h.identifier == hubIdentifier)
+        .firstOrNull;
+    if (hub == null) return;
+    await _setManagedVisibility(library, hub, home: false);
   }
 
   List<MapEntry<String, String>> _organizerRows() {
@@ -186,25 +248,36 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
             title: const Text('Manage Plex rows in Plezy'),
             subtitle: const Text('Open to organize the Home-selected rows'),
             children: [
-              for (var index = 0; index < _organizerRows().length; index++)
-                ListTile(
-                  dense: true,
-                  leading: const Icon(Symbols.drag_indicator_rounded),
-                  title: Text(_organizerRows()[index].value),
-                  trailing: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      IconButton(
-                        icon: const Icon(Symbols.arrow_upward_rounded),
-                        onPressed: index == 0 ? null : () => _moveRow(_organizerRows()[index].key, -1),
-                      ),
-                      IconButton(
-                        icon: const Icon(Symbols.arrow_downward_rounded),
-                        onPressed: index == _organizerRows().length - 1
-                            ? null
-                            : () => _moveRow(_organizerRows()[index].key, 1),
-                      ),
-                    ],
+              for (final indexed in _organizerRows().indexed)
+                AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  color: indexed.$2.key == _highlightedRowToken
+                      ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.35)
+                      : Colors.transparent,
+                  child: ListTile(
+                    dense: true,
+                    leading: const Icon(Symbols.drag_indicator_rounded),
+                    title: Text(indexed.$2.value),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        IconButton(
+                          icon: const Icon(Symbols.arrow_upward_rounded),
+                          onPressed: indexed.$1 == 0 ? null : () => _moveRow(indexed.$2.key, -1),
+                        ),
+                        IconButton(
+                          icon: const Icon(Symbols.arrow_downward_rounded),
+                          onPressed: indexed.$1 == _organizerRows().length - 1
+                              ? null
+                              : () => _moveRow(indexed.$2.key, 1),
+                        ),
+                        IconButton(
+                          icon: const Icon(Symbols.close_rounded),
+                          tooltip: 'Remove from Home',
+                          onPressed: () => _removeRowFromHome(indexed.$2.key),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
               if (_organizerRows().isEmpty) const ListTile(title: Text('Select Home rows below first.')),
@@ -231,20 +304,6 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
       promotedToRecommended: recommended ?? hub.promotedToRecommended,
       promotedToOwnHome: home ?? hub.promotedToOwnHome,
       promotedToSharedHome: friendsHome ?? hub.promotedToSharedHome,
-    );
-    await _load();
-  }
-
-  Future<void> _moveManaged(MediaLibrary library, int index, int delta) async {
-    final rows = _managedRows[library.globalKey] ?? const <PlexManagedHub>[];
-    final next = index + delta;
-    if (next < 0 || next >= rows.length) return;
-    final client = context.read<MultiServerProvider>().getPlexClientForServer(ServerId(library.serverId!));
-    if (client == null) return;
-    await client.moveManagedHub(
-      library.id,
-      rows[index].identifier,
-      after: next == 0 ? null : rows[next - 1].identifier,
     );
     await _load();
   }
@@ -326,6 +385,18 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
             if (!_loaded) const ListTile(title: Text('Loading home layout…')),
             if (_loaded && _sections.isEmpty)
               const ListTile(title: Text('No custom rows yet'), subtitle: Text('Use Add Home row to create one.')),
+            for (final section in _sections)
+              ListTile(
+                leading: const Icon(Symbols.tune_rounded),
+                title: Text(section.title),
+                subtitle: Text(_label(section.kind)),
+                onTap: () => _editSection(section),
+                trailing: IconButton(
+                  icon: const Icon(Symbols.delete_outline_rounded),
+                  tooltip: 'Remove row',
+                  onPressed: () => _deleteSection(section),
+                ),
+              ),
             ListTile(
               leading: const Icon(Symbols.add_rounded),
               title: const Text('Add Home row'),
@@ -520,12 +591,15 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
           Navigator.pop(
             context,
             HomeSectionConfig(
-              id: 'custom_${DateTime.now().microsecondsSinceEpoch}',
+              // Reuse the original id on an edit: it's also the row's identity
+              // in home_row_order (as 'custom:<id>'), so minting a fresh one
+              // here would orphan the saved position and the row would land
+              // at the back of the Organizer instead of staying put.
+              id: widget.initial?.id ?? 'custom_${DateTime.now().microsecondsSinceEpoch}',
               title: title,
               kind: _kind,
               libraryKeys: _selected.toList(),
               collectionKeys: _selectedCollections.toList(),
-              keepSourceRows: true,
               showInLibraryRecommended: _showInLibraryRecommended,
               showOnHome: _showOnHome,
             ),

--- a/lib/screens/settings/home_layout_settings_screen.dart
+++ b/lib/screens/settings/home_layout_settings_screen.dart
@@ -13,6 +13,7 @@ import '../../providers/libraries_provider.dart';
 import '../../providers/multi_server_provider.dart';
 import '../../services/settings_service.dart';
 import '../../models/plex/plex_managed_hub.dart';
+import '../../utils/home_section_builder.dart' show continueWatchingHeroOverrideKey, continueWatchingRowToken;
 import '../../widgets/settings_page.dart';
 import '../../widgets/settings_section.dart';
 
@@ -30,16 +31,39 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
   Map<String, List<PlexManagedHub>> _managedRows = {};
   Map<String, ManagedHubHeroOverride> _heroOverrides = {};
   List<String> _rowOrder = [];
+  bool _continueWatchingOnHome = true;
+
+  Future<void> _setContinueWatchingOnHome(bool value) async {
+    final settings = await SettingsService.getInstance();
+    await settings.write(SettingsService.continueWatchingOnHome, value);
+    final libraries = context
+        .read<LibrariesProvider>()
+        .libraries
+        .where((library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null)
+        .toList();
+    final order = _normalizeRowOrder(_rowOrder, libraries, _sections, _managedRows, continueWatchingOnHome: value);
+    await settings.write(SettingsService.homeRowOrder, order);
+    if (mounted) {
+      setState(() {
+        _continueWatchingOnHome = value;
+        _rowOrder = order;
+      });
+    }
+  }
 
   String _heroOverrideKey(MediaLibrary library, PlexManagedHub hub) => '${library.globalKey}::${hub.identifier}';
 
   ManagedHubHeroOverride _heroOverrideFor(MediaLibrary library, PlexManagedHub hub) =>
-      _heroOverrides[_heroOverrideKey(library, hub)] ?? const ManagedHubHeroOverride();
+      _heroOverrideForKey(_heroOverrideKey(library, hub));
 
-  Future<void> _setHeroOverride(MediaLibrary library, PlexManagedHub hub, ManagedHubHeroOverride override) async {
+  Future<void> _setHeroOverride(MediaLibrary library, PlexManagedHub hub, ManagedHubHeroOverride override) =>
+      _setHeroOverrideForKey(_heroOverrideKey(library, hub), override);
+
+  ManagedHubHeroOverride _heroOverrideForKey(String key) => _heroOverrides[key] ?? const ManagedHubHeroOverride();
+
+  Future<void> _setHeroOverrideForKey(String key, ManagedHubHeroOverride override) async {
     final settings = await SettingsService.getInstance();
     final updated = Map<String, ManagedHubHeroOverride>.of(_heroOverrides);
-    final key = _heroOverrideKey(library, hub);
     // Trailer preview can never survive hero style being off — enforced
     // here too, not just by the UI graying the checkbox out, so a stale
     // true left over from before hero was disabled can't linger unseen.
@@ -54,6 +78,7 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     await settings.write(SettingsService.managedHubHeroOverrides, updated);
     setState(() => _heroOverrides = updated);
   }
+
   String? _highlightedRowToken;
 
   @override
@@ -90,7 +115,13 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
         } catch (_) {}
       }),
     );
-    final normalizedOrder = _normalizeRowOrder(rowOrder, plexLibraries, sections, managedRows);
+    final normalizedOrder = _normalizeRowOrder(
+      rowOrder,
+      plexLibraries,
+      sections,
+      managedRows,
+      continueWatchingOnHome: settings.read(SettingsService.continueWatchingOnHome),
+    );
     // home_row_order is the only thing that decides what shows on Home
     // (see buildConfiguredHomeSections), so a newly-promoted Plex hub or a
     // row created outside the normal Add-row flow has to actually land in
@@ -106,6 +137,7 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
       _managedRows = managedRows;
       _heroOverrides = settings.read(SettingsService.managedHubHeroOverrides);
       _rowOrder = normalizedOrder;
+      _continueWatchingOnHome = settings.read(SettingsService.continueWatchingOnHome);
       _loaded = true;
     });
   }
@@ -118,7 +150,13 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
         .libraries
         .where((library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null)
         .toList();
-    final order = _normalizeRowOrder(settings.read(SettingsService.homeRowOrder), libraries, sections, _managedRows);
+    final order = _normalizeRowOrder(
+      settings.read(SettingsService.homeRowOrder),
+      libraries,
+      sections,
+      _managedRows,
+      continueWatchingOnHome: _continueWatchingOnHome,
+    );
     await settings.write(SettingsService.homeRowOrder, order);
     if (mounted)
       setState(() {
@@ -182,9 +220,14 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     List<String> saved,
     List<MediaLibrary> libraries,
     List<HomeSectionConfig> sections,
-    Map<String, List<PlexManagedHub>> managedRows,
-  ) {
+    Map<String, List<PlexManagedHub>> managedRows, {
+    required bool continueWatchingOnHome,
+  }) {
     final available = <String>[
+      // Continue Watching defaults to the front of the list (matching its
+      // old fixed-first position) so an untouched install's saved order
+      // stays effectively unchanged the first time this runs after upgrade.
+      if (continueWatchingOnHome) continueWatchingRowToken,
       for (final library in libraries)
         for (final hub in managedRows[library.globalKey] ?? const <PlexManagedHub>[])
           if (hub.promotedToOwnHome) _hubToken(library, hub),
@@ -216,15 +259,13 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     await settings.write(SettingsService.homeRowOrder, order);
   }
 
-  Future<void> _removeRowFromHome(String token) async {
-    if (token.startsWith('custom:')) {
-      final id = token.substring('custom:'.length);
-      await _save(_sections.map((s) => s.id == id ? s.copyWith(showOnHome: false) : s).toList());
-      return;
-    }
-    if (!token.startsWith('plex:')) return;
+  /// Parses a `plex:<serverId>:<libraryId>:<hubIdentifier>` token back into
+  /// the real (library, hub) pair it names, or null if either no longer
+  /// exists (a library was removed, a Plex row was deleted upstream, etc).
+  (MediaLibrary, PlexManagedHub)? _resolvePlexRowRef(String token) {
+    if (!token.startsWith('plex:')) return null;
     final parts = token.split(':');
-    if (parts.length < 4) return;
+    if (parts.length < 4) return null;
     final serverId = parts[1];
     final libraryId = parts[2];
     final hubIdentifier = parts.sublist(3).join(':');
@@ -233,31 +274,119 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
         .libraries
         .where((l) => l.serverId == serverId && l.id == libraryId)
         .firstOrNull;
-    if (library == null) return;
+    if (library == null) return null;
     final hub = (_managedRows[library.globalKey] ?? const <PlexManagedHub>[])
         .where((h) => h.identifier == hubIdentifier)
         .firstOrNull;
-    if (hub == null) return;
-    await _setManagedVisibility(library, hub, home: false);
+    if (hub == null) return null;
+    return (library, hub);
   }
 
-  List<MapEntry<String, String>> _organizerRows() {
-    final libraries = context.read<LibrariesProvider>().libraries.where(
-      (library) => !library.hidden && library.backend == MediaBackend.plex && library.serverId != null,
-    );
-    final labels = <String, String>{};
-    for (final library in libraries) {
-      for (final hub in _managedRows[library.globalKey] ?? const <PlexManagedHub>[]) {
-        if (hub.promotedToOwnHome) labels[_hubToken(library, hub)] = '${library.title}: ${hub.title}';
+  Future<void> _removeRowFromHome(String token) async {
+    if (token.startsWith('custom:')) {
+      final id = token.substring('custom:'.length);
+      await _save(_sections.map((s) => s.id == id ? s.copyWith(showOnHome: false) : s).toList());
+      return;
+    }
+    if (token == continueWatchingRowToken) {
+      await _setContinueWatchingOnHome(false);
+      return;
+    }
+    final ref = _resolvePlexRowRef(token);
+    if (ref == null) return;
+    await _setManagedVisibility(ref.$1, ref.$2, home: false);
+  }
+
+  /// Row data for the actual Organizer list (drag handle + up/down/X) — the
+  /// single place that reflects what's really on Home and in what order, so
+  /// Hero/Trailer belong here rather than only inside each library's own
+  /// raw hub list below (which includes hubs that aren't even on Home).
+  List<_OrganizerRow> _organizerRows() {
+    final rows = <_OrganizerRow>[];
+    for (final token in _rowOrder) {
+      if (token.startsWith('custom:')) {
+        final id = token.substring('custom:'.length);
+        final section = _sections.where((s) => s.id == id).firstOrNull;
+        if (section == null || !section.enabled || !section.showOnHome) continue;
+        rows.add(
+          _OrganizerRow(
+            token: token,
+            label: 'Custom: ${section.title}',
+            supportsHero: section.supportsHeroStyle,
+            heroStyle: section.heroStyle,
+            heroTrailerPreview: section.heroTrailerPreview,
+          ),
+        );
+        continue;
       }
+      if (token == continueWatchingRowToken) {
+        if (!_continueWatchingOnHome) continue;
+        final override = _heroOverrideForKey(continueWatchingHeroOverrideKey);
+        rows.add(
+          _OrganizerRow(
+            token: token,
+            label: 'Continue Watching',
+            supportsHero: true,
+            heroStyle: override.heroStyle,
+            heroTrailerPreview: override.heroTrailerPreview,
+          ),
+        );
+        continue;
+      }
+      final ref = _resolvePlexRowRef(token);
+      if (ref == null) continue;
+      final (library, hub) = ref;
+      final override = _heroOverrideFor(library, hub);
+      rows.add(
+        _OrganizerRow(
+          token: token,
+          label: '${library.title}: ${hub.title}',
+          supportsHero: true,
+          heroStyle: override.heroStyle,
+          heroTrailerPreview: override.heroTrailerPreview,
+        ),
+      );
     }
-    for (final section in _sections) {
-      if (section.enabled && section.showOnHome) labels['custom:${section.id}'] = 'Custom: ${section.title}';
+    return rows;
+  }
+
+  Future<void> _setOrganizerRowHero(String token, {bool? heroStyle, bool? heroTrailerPreview}) async {
+    if (token.startsWith('custom:')) {
+      final id = token.substring('custom:'.length);
+      final section = _sections.where((s) => s.id == id).firstOrNull;
+      if (section == null) return;
+      var updated = section.copyWith(
+        heroStyle: heroStyle ?? section.heroStyle,
+        heroTrailerPreview: heroTrailerPreview ?? section.heroTrailerPreview,
+      );
+      // Trailer can never survive hero being turned off — same rule the
+      // managed-hub override and the Add/Edit dialog both enforce.
+      if (!updated.heroStyle && updated.heroTrailerPreview) updated = updated.copyWith(heroTrailerPreview: false);
+      await _save(_sections.map((s) => s.id == id ? updated : s).toList());
+      return;
     }
-    return [
-      for (final token in _rowOrder)
-        if (labels[token] != null) MapEntry(token, labels[token]!),
-    ];
+    if (token == continueWatchingRowToken) {
+      final override = _heroOverrideForKey(continueWatchingHeroOverrideKey);
+      await _setHeroOverrideForKey(
+        continueWatchingHeroOverrideKey,
+        override.copyWith(
+          heroStyle: heroStyle ?? override.heroStyle,
+          heroTrailerPreview: heroTrailerPreview ?? override.heroTrailerPreview,
+        ),
+      );
+      return;
+    }
+    final ref = _resolvePlexRowRef(token);
+    if (ref == null) return;
+    final override = _heroOverrideFor(ref.$1, ref.$2);
+    await _setHeroOverride(
+      ref.$1,
+      ref.$2,
+      override.copyWith(
+        heroStyle: heroStyle ?? override.heroStyle,
+        heroTrailerPreview: heroTrailerPreview ?? override.heroTrailerPreview,
+      ),
+    );
   }
 
   List<Widget> _plexManagerGroups() {
@@ -274,33 +403,69 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
             title: const Text('Manage Plex rows in Plezy'),
             subtitle: const Text('Open to organize the Home-selected rows'),
             children: [
+              if (!_continueWatchingOnHome) _continueWatchingTile(),
               for (final indexed in _organizerRows().indexed)
                 AnimatedContainer(
                   duration: const Duration(milliseconds: 200),
-                  color: indexed.$2.key == _highlightedRowToken
+                  color: indexed.$2.token == _highlightedRowToken
                       ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.35)
                       : Colors.transparent,
                   child: ListTile(
                     dense: true,
                     leading: const Icon(Symbols.drag_indicator_rounded),
-                    title: Text(indexed.$2.value),
-                    trailing: Row(
-                      mainAxisSize: MainAxisSize.min,
+                    title: Text(indexed.$2.label),
+                    trailing: Wrap(
+                      spacing: 2,
+                      crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
+                        Tooltip(
+                          message: indexed.$2.supportsHero
+                              ? 'Render as a hero card'
+                              : 'Only available when this row resolves to a single collection\'s actual titles',
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Checkbox(
+                                value: indexed.$2.supportsHero && indexed.$2.heroStyle,
+                                onChanged: !indexed.$2.supportsHero
+                                    ? null
+                                    : (v) => _setOrganizerRowHero(indexed.$2.token, heroStyle: v ?? false),
+                              ),
+                              const Text('Hero'),
+                            ],
+                          ),
+                        ),
+                        Tooltip(
+                          message: indexed.$2.heroStyle
+                              ? 'Play a trailer/scene clip in the hero card'
+                              : 'Enable Hero first — trailer preview needs a hero card to play in',
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Checkbox(
+                                value: indexed.$2.heroStyle && indexed.$2.heroTrailerPreview,
+                                onChanged: !indexed.$2.heroStyle
+                                    ? null
+                                    : (v) => _setOrganizerRowHero(indexed.$2.token, heroTrailerPreview: v ?? false),
+                              ),
+                              const Text('Trailer'),
+                            ],
+                          ),
+                        ),
                         IconButton(
                           icon: const Icon(Symbols.arrow_upward_rounded),
-                          onPressed: indexed.$1 == 0 ? null : () => _moveRow(indexed.$2.key, -1),
+                          onPressed: indexed.$1 == 0 ? null : () => _moveRow(indexed.$2.token, -1),
                         ),
                         IconButton(
                           icon: const Icon(Symbols.arrow_downward_rounded),
                           onPressed: indexed.$1 == _organizerRows().length - 1
                               ? null
-                              : () => _moveRow(indexed.$2.key, 1),
+                              : () => _moveRow(indexed.$2.token, 1),
                         ),
                         IconButton(
                           icon: const Icon(Symbols.close_rounded),
                           tooltip: 'Remove from Home',
-                          onPressed: () => _removeRowFromHome(indexed.$2.key),
+                          onPressed: () => _removeRowFromHome(indexed.$2.token),
                         ),
                       ],
                     ),
@@ -387,11 +552,8 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
                         children: [
                           Checkbox(
                             value: override.heroStyle,
-                            onChanged: (v) => _setHeroOverride(
-                              library,
-                              rows[index],
-                              override.copyWith(heroStyle: v ?? false),
-                            ),
+                            onChanged: (v) =>
+                                _setHeroOverride(library, rows[index], override.copyWith(heroStyle: v ?? false)),
                           ),
                           const Text('Hero'),
                         ],
@@ -447,6 +609,35 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     );
   }
 
+  /// Continue Watching used to be a fixed fixture always pinned ahead of
+  /// every other Home row, with no way to remove or reorder it. This is now
+  /// ONLY the add-back switch for when it's off (mirroring the "Add Home
+  /// row" / per-library "Home" checkbox mechanisms every other row type
+  /// already has) — once it's on, `_organizerRows()` already includes it as
+  /// a normal token with its own Hero/Trailer checkboxes and reordering, so
+  /// this tile is hidden entirely rather than showing a second, lesser copy
+  /// of the same row (the actual bug reported 2026-09-09: this tile used to
+  /// render unconditionally, creating a Hero/Trailer-less duplicate above
+  /// the real entry, which could be scrolled to way down at wherever
+  /// `home_row_order` had placed it).
+  Widget _continueWatchingTile() {
+    return ListTile(
+      dense: true,
+      title: const Text('Continue Watching'),
+      subtitle: const Text('The resume-progress row shown on Home'),
+      trailing: Tooltip(
+        message: 'Show on Home screen',
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Checkbox(value: _continueWatchingOnHome, onChanged: (v) => _setContinueWatchingOnHome(v ?? false)),
+            const Text('Home'),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return SettingsPage(
@@ -482,6 +673,23 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
       ],
     );
   }
+}
+
+/// One row's display data for the real Organizer list (drag handle +
+/// up/down/X) — see [_HomeLayoutSettingsScreenState._organizerRows].
+class _OrganizerRow {
+  const _OrganizerRow({
+    required this.token,
+    required this.label,
+    required this.supportsHero,
+    required this.heroStyle,
+    required this.heroTrailerPreview,
+  });
+  final String token;
+  final String label;
+  final bool supportsHero;
+  final bool heroStyle;
+  final bool heroTrailerPreview;
 }
 
 String _label(HomeSectionKind kind) => switch (kind) {
@@ -637,9 +845,9 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
             padding: const EdgeInsets.only(top: 2, bottom: 4),
             child: Text(
               'Every library checked here is merged into this one row.',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
           ),
           for (final library in widget.libraries)
@@ -665,9 +873,9 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
                 'If exactly one collection matches, its titles show directly in the '
                 "row. If more than one matches, each collection shows as a single "
                 'poster — tap it to open that collection.',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
-                ),
+                style: Theme.of(
+                  context,
+                ).textTheme.bodySmall?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
               ),
             ),
             CheckboxListTile(

--- a/lib/screens/settings/home_layout_settings_screen.dart
+++ b/lib/screens/settings/home_layout_settings_screen.dart
@@ -28,7 +28,32 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
   bool _loaded = false;
   List<MediaItem> _collections = const [];
   Map<String, List<PlexManagedHub>> _managedRows = {};
+  Map<String, ManagedHubHeroOverride> _heroOverrides = {};
   List<String> _rowOrder = [];
+
+  String _heroOverrideKey(MediaLibrary library, PlexManagedHub hub) => '${library.globalKey}::${hub.identifier}';
+
+  ManagedHubHeroOverride _heroOverrideFor(MediaLibrary library, PlexManagedHub hub) =>
+      _heroOverrides[_heroOverrideKey(library, hub)] ?? const ManagedHubHeroOverride();
+
+  Future<void> _setHeroOverride(MediaLibrary library, PlexManagedHub hub, ManagedHubHeroOverride override) async {
+    final settings = await SettingsService.getInstance();
+    final updated = Map<String, ManagedHubHeroOverride>.of(_heroOverrides);
+    final key = _heroOverrideKey(library, hub);
+    // Trailer preview can never survive hero style being off — enforced
+    // here too, not just by the UI graying the checkbox out, so a stale
+    // true left over from before hero was disabled can't linger unseen.
+    if (!override.heroStyle && override.heroTrailerPreview) {
+      override = override.copyWith(heroTrailerPreview: false);
+    }
+    if (!override.heroStyle && !override.heroTrailerPreview) {
+      updated.remove(key);
+    } else {
+      updated[key] = override;
+    }
+    await settings.write(SettingsService.managedHubHeroOverrides, updated);
+    setState(() => _heroOverrides = updated);
+  }
   String? _highlightedRowToken;
 
   @override
@@ -79,6 +104,7 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
       _sections = sections;
       _collections = collections;
       _managedRows = managedRows;
+      _heroOverrides = settings.read(SettingsService.managedHubHeroOverrides);
       _rowOrder = normalizedOrder;
       _loaded = true;
     });
@@ -351,6 +377,54 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
                     ],
                   ),
                 ),
+                Builder(
+                  builder: (context) {
+                    final override = _heroOverrideFor(library, rows[index]);
+                    return Tooltip(
+                      message: 'Render as a hero card',
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Checkbox(
+                            value: override.heroStyle,
+                            onChanged: (v) => _setHeroOverride(
+                              library,
+                              rows[index],
+                              override.copyWith(heroStyle: v ?? false),
+                            ),
+                          ),
+                          const Text('Hero'),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+                Builder(
+                  builder: (context) {
+                    final override = _heroOverrideFor(library, rows[index]);
+                    return Tooltip(
+                      message: override.heroStyle
+                          ? 'Play a trailer/scene clip in the hero card'
+                          : 'Enable Hero first — trailer preview needs a hero card to play in',
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Checkbox(
+                            value: override.heroStyle && override.heroTrailerPreview,
+                            onChanged: !override.heroStyle
+                                ? null
+                                : (v) => _setHeroOverride(
+                                    library,
+                                    rows[index],
+                                    override.copyWith(heroTrailerPreview: v ?? false),
+                                  ),
+                          ),
+                          const Text('Trailer'),
+                        ],
+                      ),
+                    );
+                  },
+                ),
                 if (rows[index].deletable)
                   IconButton(
                     icon: const Icon(Symbols.delete_outline_rounded),
@@ -434,6 +508,15 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
   bool _allCollections = true;
   bool _showInLibraryRecommended = true;
   bool _showOnHome = true;
+  bool _heroStyle = false;
+  bool _heroTrailerPreview = false;
+
+  /// Mirrors [HomeSectionConfig.supportsHeroStyle] against the dialog's
+  /// live, not-yet-saved selection — a collection row only qualifies once
+  /// it resolves to exactly one collection's actual contents.
+  bool get _supportsHeroStyle =>
+      (_kind != HomeSectionKind.movieCollections && _kind != HomeSectionKind.showCollections) ||
+      (!_allCollections && _selectedCollections.length == 1);
 
   @override
   void dispose() {
@@ -453,6 +536,8 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
       _allCollections = initial.collectionKeys.isEmpty;
       _showInLibraryRecommended = initial.showInLibraryRecommended;
       _showOnHome = initial.showOnHome;
+      _heroStyle = initial.heroStyle;
+      _heroTrailerPreview = initial.heroTrailerPreview;
     }
   }
 
@@ -516,6 +601,35 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
             title: const Text('Home'),
             value: _showOnHome,
             onChanged: (value) => setState(() => _showOnHome = value ?? false),
+          ),
+          const SizedBox(height: 12),
+          const Text('Hero card'),
+          CheckboxListTile(
+            dense: true,
+            title: const Text('Render as a hero card'),
+            subtitle: Text(
+              _supportsHeroStyle
+                  ? 'Shows as one full-width rotating card instead of a poster shelf.'
+                  : 'Only available when this row resolves to a single collection\'s '
+                        'actual titles — with more than one collection selected there is '
+                        'no single title to rotate through.',
+            ),
+            value: _supportsHeroStyle && _heroStyle,
+            onChanged: !_supportsHeroStyle
+                ? null
+                : (value) => setState(() {
+                    _heroStyle = value ?? false;
+                    if (!_heroStyle) _heroTrailerPreview = false;
+                  }),
+          ),
+          CheckboxListTile(
+            dense: true,
+            title: const Text('Play trailer preview'),
+            subtitle: const Text('Plays a trailer or scene clip in the hero card instead of static art.'),
+            value: _supportsHeroStyle && _heroStyle && _heroTrailerPreview,
+            onChanged: (!_supportsHeroStyle || !_heroStyle)
+                ? null
+                : (value) => setState(() => _heroTrailerPreview = value ?? false),
           ),
           const SizedBox(height: 12),
           const Text('Libraries (leave all unchecked to include every library)'),
@@ -602,6 +716,11 @@ class _HomeSectionDialogState extends State<_HomeSectionDialog> {
               collectionKeys: _selectedCollections.toList(),
               showInLibraryRecommended: _showInLibraryRecommended,
               showOnHome: _showOnHome,
+              // Re-checked here, not just at the checkbox: the collection
+              // selection can change after hero/trailer were toggled on,
+              // and a stale true must never survive into the saved config.
+              heroStyle: _supportsHeroStyle && _heroStyle,
+              heroTrailerPreview: _supportsHeroStyle && _heroStyle && _heroTrailerPreview,
             ),
           );
         },

--- a/lib/screens/settings/home_layout_settings_screen.dart
+++ b/lib/screens/settings/home_layout_settings_screen.dart
@@ -13,7 +13,9 @@ import '../../providers/libraries_provider.dart';
 import '../../providers/multi_server_provider.dart';
 import '../../services/settings_service.dart';
 import '../../models/plex/plex_managed_hub.dart';
-import '../../utils/home_section_builder.dart' show continueWatchingHeroOverrideKey, continueWatchingRowToken;
+import '../../utils/home_section_builder.dart'
+    show continueWatchingHeroOverrideKey, continueWatchingRowToken, libraryContinueWatchingHeroOverrideKey;
+import '../../widgets/setting_tile.dart';
 import '../../widgets/settings_page.dart';
 import '../../widgets/settings_section.dart';
 
@@ -33,6 +35,19 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
   List<String> _rowOrder = [];
   bool _continueWatchingOnHome = true;
 
+  /// Reordering starts unlocked every time this screen opens, per user
+  /// request 2026-09-10 (revised same day — the first cut of this defaulted
+  /// locked, inverted from what was actually wanted). A lock icon toggles
+  /// this per list: open padlock = unlocked (can drag), closed padlock =
+  /// locked (a whole-row click does nothing, so Hero/Trailer/Library
+  /// checkboxes can be tapped without risking an accidental drag). `true`
+  /// here is the Organizer list; per-library lists get their own entry in
+  /// [_libraryReorderUnlocked] instead, since each library's own row list
+  /// is independent — both default to unlocked (`?? true` at each read
+  /// site) the same way this field's own literal default does.
+  bool _organizerReorderUnlocked = true;
+  final Map<String, bool> _libraryReorderUnlocked = {};
+
   Future<void> _setContinueWatchingOnHome(bool value) async {
     final settings = await SettingsService.getInstance();
     await settings.write(SettingsService.continueWatchingOnHome, value);
@@ -49,6 +64,24 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
         _rowOrder = order;
       });
     }
+  }
+
+  /// Per-library counterpart to [_setContinueWatchingOnHome] — Plex's own
+  /// Continue Watching hub for a library isn't a [PlexManagedHub] the way
+  /// every other row on that library's Recommended tab is (nothing to
+  /// promote/demote via `updateManagedHubVisibility`), so this is a
+  /// Plezy-local toggle instead, read directly by [LibraryRecommendedTab]
+  /// when it decides what to show.
+  Future<void> _setLibraryContinueWatchingVisible(MediaLibrary library, bool visible) async {
+    final settings = await SettingsService.getInstance();
+    final hidden = Set<String>.of(settings.read(SettingsService.libraryContinueWatchingHidden));
+    if (visible) {
+      hidden.remove(library.globalKey);
+    } else {
+      hidden.add(library.globalKey);
+    }
+    await settings.write(SettingsService.libraryContinueWatchingHidden, hidden);
+    if (mounted) setState(() {});
   }
 
   String _heroOverrideKey(MediaLibrary library, PlexManagedHub hub) => '${library.globalKey}::${hub.identifier}';
@@ -237,23 +270,58 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     return [...saved.where(available.contains), ...available.where((entry) => !saved.contains(entry))];
   }
 
-  Future<void> _moveRow(String token, int delta) async {
-    final index = _rowOrder.indexOf(token);
-    final next = index + delta;
-    if (index < 0 || next < 0 || next >= _rowOrder.length) return;
-    final order = List<String>.of(_rowOrder);
-    final item = order.removeAt(index);
-    order.insert(next, item);
+  /// Wraps [child] so the entire tile — not just a small handle icon — is a
+  /// drag target, but only once reordering is unlocked; locked, [child]
+  /// renders plain with no drag capability at all, so nothing in it can
+  /// start a reorder no matter where it's clicked.
+  Widget _maybeDraggable({required bool unlocked, required int index, required Widget child}) =>
+      unlocked ? ReorderableDragStartListener(index: index, child: child) : child;
+
+  /// A tappable padlock — open means unlocked (rows can be dragged by
+  /// clicking anywhere on them), closed means locked (a whole-row click
+  /// does nothing, so the Hero/Trailer/Library checkboxes underneath can be
+  /// tapped without risking an accidental drag). Starts open every time
+  /// this screen loads — not persisted.
+  Widget _reorderLockTile({required bool unlocked, required ValueChanged<bool> onChanged}) {
+    return ListTile(
+      dense: true,
+      leading: Icon(unlocked ? Symbols.lock_open_rounded : Symbols.lock_rounded),
+      title: Text(unlocked ? 'Reordering unlocked' : 'Reordering locked'),
+      subtitle: Text(unlocked ? 'Rows can be dragged — tap the lock to prevent that' : 'Tap the lock to drag rows'),
+      onTap: () => onChanged(!unlocked),
+    );
+  }
+
+  /// [oldIndex]/[newIndex] are positions within the currently-*visible*
+  /// organizer list (`_organizerRows()`), not [_rowOrder] itself — that list
+  /// can also hold tokens for rows that aren't currently shown (a disabled
+  /// custom row, Continue Watching while off), which [_organizerRows]
+  /// silently skips. Moving the dragged token to sit directly before
+  /// whichever visible token now follows it (rather than just splicing by
+  /// raw index into [_rowOrder]) keeps those hidden tokens at their existing
+  /// relative position instead of bunching them at the end.
+  Future<void> _reorderOrganizerRow(int oldIndex, int newIndex) async {
+    final rows = _organizerRows();
+    if (newIndex > oldIndex) newIndex -= 1; // ReorderableListView's own convention
+    final movedToken = rows[oldIndex].token;
+    final order = List<String>.of(_rowOrder)..remove(movedToken);
+    final visibleAfterRemoval = [
+      for (final row in rows)
+        if (row.token != movedToken) row.token,
+    ];
+    final insertBeforeToken = newIndex < visibleAfterRemoval.length ? visibleAfterRemoval[newIndex] : null;
+    final insertAt = insertBeforeToken == null ? order.length : order.indexOf(insertBeforeToken);
+    order.insert(insertAt < 0 ? order.length : insertAt, movedToken);
     // Update and highlight immediately rather than after the settings write
     // completes: waiting made the row jump with no visible cue of which one
     // moved, since the highlight and the reorder landed in the same frame
     // only once the (imperceptibly fast, but still async) write returned.
     setState(() {
       _rowOrder = order;
-      _highlightedRowToken = token;
+      _highlightedRowToken = movedToken;
     });
     Future.delayed(const Duration(milliseconds: 1400), () {
-      if (mounted && _highlightedRowToken == token) setState(() => _highlightedRowToken = null);
+      if (mounted && _highlightedRowToken == movedToken) setState(() => _highlightedRowToken = null);
     });
     final settings = await SettingsService.getInstance();
     await settings.write(SettingsService.homeRowOrder, order);
@@ -404,73 +472,104 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
             subtitle: const Text('Open to organize the Home-selected rows'),
             children: [
               if (!_continueWatchingOnHome) _continueWatchingTile(),
-              for (final indexed in _organizerRows().indexed)
-                AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  color: indexed.$2.token == _highlightedRowToken
-                      ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.35)
-                      : Colors.transparent,
-                  child: ListTile(
-                    dense: true,
-                    leading: const Icon(Symbols.drag_indicator_rounded),
-                    title: Text(indexed.$2.label),
-                    trailing: Wrap(
-                      spacing: 2,
-                      crossAxisAlignment: WrapCrossAlignment.center,
-                      children: [
-                        Tooltip(
-                          message: indexed.$2.supportsHero
-                              ? 'Render as a hero card'
-                              : 'Only available when this row resolves to a single collection\'s actual titles',
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Checkbox(
-                                value: indexed.$2.supportsHero && indexed.$2.heroStyle,
-                                onChanged: !indexed.$2.supportsHero
-                                    ? null
-                                    : (v) => _setOrganizerRowHero(indexed.$2.token, heroStyle: v ?? false),
-                              ),
-                              const Text('Hero'),
-                            ],
-                          ),
-                        ),
-                        Tooltip(
-                          message: indexed.$2.heroStyle
-                              ? 'Play a trailer/scene clip in the hero card'
-                              : 'Enable Hero first — trailer preview needs a hero card to play in',
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Checkbox(
-                                value: indexed.$2.heroStyle && indexed.$2.heroTrailerPreview,
-                                onChanged: !indexed.$2.heroStyle
-                                    ? null
-                                    : (v) => _setOrganizerRowHero(indexed.$2.token, heroTrailerPreview: v ?? false),
-                              ),
-                              const Text('Trailer'),
-                            ],
-                          ),
-                        ),
-                        IconButton(
-                          icon: const Icon(Symbols.arrow_upward_rounded),
-                          onPressed: indexed.$1 == 0 ? null : () => _moveRow(indexed.$2.token, -1),
-                        ),
-                        IconButton(
-                          icon: const Icon(Symbols.arrow_downward_rounded),
-                          onPressed: indexed.$1 == _organizerRows().length - 1
-                              ? null
-                              : () => _moveRow(indexed.$2.token, 1),
-                        ),
-                        IconButton(
-                          icon: const Icon(Symbols.close_rounded),
-                          tooltip: 'Remove from Home',
-                          onPressed: () => _removeRowFromHome(indexed.$2.token),
-                        ),
-                      ],
-                    ),
-                  ),
+              if (_organizerRows().isNotEmpty) ...[
+                _reorderLockTile(
+                  unlocked: _organizerReorderUnlocked,
+                  onChanged: (v) => setState(() => _organizerReorderUnlocked = v),
                 ),
+                ReorderableListView(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  buildDefaultDragHandles: false,
+                  onReorder: _reorderOrganizerRow,
+                  children: [
+                    for (final indexed in _organizerRows().indexed)
+                      AnimatedContainer(
+                        key: ValueKey(indexed.$2.token),
+                        duration: const Duration(milliseconds: 200),
+                        color: indexed.$2.token == _highlightedRowToken
+                            ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.35)
+                            : Colors.transparent,
+                        child: _maybeDraggable(
+                          unlocked: _organizerReorderUnlocked,
+                          index: indexed.$1,
+                          child: ListTile(
+                            dense: true,
+                            leading: const Icon(Symbols.drag_indicator_rounded),
+                            title: Text(indexed.$2.label),
+                            trailing: Wrap(
+                              spacing: 2,
+                              crossAxisAlignment: WrapCrossAlignment.center,
+                              children: [
+                                Tooltip(
+                                  message: indexed.$2.supportsHero
+                                      ? 'Render as a hero card'
+                                      : 'Only available when this row resolves to a single collection\'s actual titles',
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Checkbox(
+                                        value: indexed.$2.supportsHero && indexed.$2.heroStyle,
+                                        onChanged: !indexed.$2.supportsHero
+                                            ? null
+                                            : (v) => _setOrganizerRowHero(indexed.$2.token, heroStyle: v ?? false),
+                                      ),
+                                      const Text('Hero'),
+                                    ],
+                                  ),
+                                ),
+                                Tooltip(
+                                  message: indexed.$2.heroStyle
+                                      ? 'Play a trailer/scene clip in the hero card'
+                                      : 'Enable Hero first — trailer preview needs a hero card to play in',
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Checkbox(
+                                        value: indexed.$2.heroStyle && indexed.$2.heroTrailerPreview,
+                                        onChanged: !indexed.$2.heroStyle
+                                            ? null
+                                            : (v) => _setOrganizerRowHero(
+                                                indexed.$2.token,
+                                                heroTrailerPreview: v ?? false,
+                                              ),
+                                      ),
+                                      const Text('Trailer'),
+                                    ],
+                                  ),
+                                ),
+                                // Continue Watching has no library/custom-row
+                                // list to re-add it from once removed — every
+                                // other row type here does (its own library's
+                                // expansion tile, or Custom rows), which is
+                                // what makes an X safe for them. A checkbox
+                                // keeps this one genuinely reversible in place
+                                // instead.
+                                if (indexed.$2.token == continueWatchingRowToken)
+                                  Tooltip(
+                                    message: 'Show on Home screen',
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Checkbox(value: true, onChanged: (v) => _setContinueWatchingOnHome(v ?? false)),
+                                        const Text('Home'),
+                                      ],
+                                    ),
+                                  )
+                                else
+                                  IconButton(
+                                    icon: const Icon(Symbols.close_rounded),
+                                    tooltip: 'Remove from Home',
+                                    onPressed: () => _removeRowFromHome(indexed.$2.token),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
               if (_organizerRows().isEmpty) const ListTile(title: Text('Select Home rows below first.')),
             ],
           ),
@@ -499,111 +598,261 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
     await _load();
   }
 
-  Widget _managedLibraryTile(MediaLibrary library) {
+  /// Applies this library's saved drag-to-reorder order (if any) to its
+  /// fetched managed rows. A saved identifier not present among the
+  /// currently-fetched rows is simply dropped (that hub no longer exists or
+  /// was removed); any fetched row not yet in the saved order is appended
+  /// at the end (a newly-discovered hub) — same "saved order wins, unknowns
+  /// go last" shape [_normalizeRowOrder] already uses for Home's own order.
+  List<PlexManagedHub> _orderedManagedRows(MediaLibrary library) {
     final rows = _managedRows[library.globalKey] ?? const <PlexManagedHub>[];
+    final savedOrder = SettingsService.instance.read(SettingsService.libraryManagedRowOrder)[library.globalKey];
+    if (savedOrder == null || savedOrder.isEmpty) return rows;
+    final remaining = List<PlexManagedHub>.of(rows);
+    final ordered = <PlexManagedHub>[];
+    for (final identifier in savedOrder) {
+      final match = remaining.where((row) => row.identifier == identifier).firstOrNull;
+      if (match != null) {
+        ordered.add(match);
+        remaining.remove(match);
+      }
+    }
+    return [...ordered, ...remaining];
+  }
+
+  Future<void> _reorderLibraryRow(
+    MediaLibrary library,
+    List<PlexManagedHub> orderedRows,
+    int oldIndex,
+    int newIndex,
+  ) async {
+    final reordered = List<PlexManagedHub>.of(orderedRows);
+    if (newIndex > oldIndex) newIndex -= 1; // ReorderableListView's own convention
+    final moved = reordered.removeAt(oldIndex);
+    reordered.insert(newIndex, moved);
+    final settings = await SettingsService.getInstance();
+    final allOrders = Map<String, List<String>>.of(settings.read(SettingsService.libraryManagedRowOrder));
+    allOrders[library.globalKey] = [for (final row in reordered) row.identifier];
+    await settings.write(SettingsService.libraryManagedRowOrder, allOrders);
+    if (mounted) setState(() {});
+  }
+
+  Widget _managedLibraryTile(MediaLibrary library) {
+    final rows = _orderedManagedRows(library);
+    final continueWatchingVisible = !SettingsService.instance
+        .read(SettingsService.libraryContinueWatchingHidden)
+        .contains(library.globalKey);
+    final continueWatchingOverride = _heroOverrideForKey(libraryContinueWatchingHeroOverrideKey(library.globalKey));
     return ExpansionTile(
       initiallyExpanded: false,
       leading: Icon(library.kind == MediaKind.show ? Symbols.tv_rounded : Symbols.movie_rounded),
       title: Text(library.title),
       subtitle: Text('${rows.length} Plex-managed rows'),
       children: [
-        for (var index = 0; index < rows.length; index++)
-          ListTile(
-            dense: true,
-            title: Text(rows[index].title),
-            subtitle: rows[index].deletable ? const Text('Custom Plex row') : null,
-            trailing: Wrap(
-              spacing: 2,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              children: [
-                Tooltip(
-                  message: 'Show in Library Recommended',
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Checkbox(
-                        value: rows[index].promotedToRecommended,
-                        onChanged: (v) => _setManagedVisibility(library, rows[index], recommended: v),
-                      ),
-                      const Text('Library'),
-                    ],
-                  ),
+        // Continue Watching isn't a PlexManagedHub — Plex itself has no
+        // promote/demote concept for it — so it can't come from `rows`
+        // like every other tile here. Shown first, matching how Home's own
+        // Organizer always pins Continue Watching to the front too.
+        ListTile(
+          dense: true,
+          title: const Text('Continue Watching'),
+          subtitle: const Text("This library's own resume-progress row"),
+          trailing: Wrap(
+            spacing: 2,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Tooltip(
+                message: 'Show in Library Recommended',
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Checkbox(
+                      value: continueWatchingVisible,
+                      onChanged: (v) => _setLibraryContinueWatchingVisible(library, v ?? false),
+                    ),
+                    const Text('Library'),
+                  ],
                 ),
-                Tooltip(
-                  message: 'Show on Home screen',
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Checkbox(
-                        value: rows[index].promotedToOwnHome,
-                        onChanged: (v) => _setManagedVisibility(library, rows[index], home: v),
-                      ),
-                      const Text('Home'),
-                    ],
-                  ),
+              ),
+              Tooltip(
+                message: continueWatchingVisible
+                    ? 'Render as a hero card'
+                    : 'Check Library first — Hero needs somewhere to show',
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Checkbox(
+                      value: continueWatchingVisible && continueWatchingOverride.heroStyle,
+                      onChanged: !continueWatchingVisible
+                          ? null
+                          : (v) => _setHeroOverrideForKey(
+                              libraryContinueWatchingHeroOverrideKey(library.globalKey),
+                              continueWatchingOverride.copyWith(heroStyle: v ?? false),
+                            ),
+                    ),
+                    const Text('Hero'),
+                  ],
                 ),
-                Builder(
-                  builder: (context) {
-                    final override = _heroOverrideFor(library, rows[index]);
-                    return Tooltip(
-                      message: 'Render as a hero card',
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Checkbox(
-                            value: override.heroStyle,
-                            onChanged: (v) =>
-                                _setHeroOverride(library, rows[index], override.copyWith(heroStyle: v ?? false)),
-                          ),
-                          const Text('Hero'),
-                        ],
-                      ),
-                    );
-                  },
+              ),
+              Tooltip(
+                message: continueWatchingVisible && continueWatchingOverride.heroStyle
+                    ? 'Play a trailer/scene clip in the hero card'
+                    : 'Enable Hero first — trailer preview needs a hero card to play in',
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Checkbox(
+                      value:
+                          continueWatchingVisible &&
+                          continueWatchingOverride.heroStyle &&
+                          continueWatchingOverride.heroTrailerPreview,
+                      onChanged: !continueWatchingVisible || !continueWatchingOverride.heroStyle
+                          ? null
+                          : (v) => _setHeroOverrideForKey(
+                              libraryContinueWatchingHeroOverrideKey(library.globalKey),
+                              continueWatchingOverride.copyWith(heroTrailerPreview: v ?? false),
+                            ),
+                    ),
+                    const Text('Trailer'),
+                  ],
                 ),
-                Builder(
-                  builder: (context) {
-                    final override = _heroOverrideFor(library, rows[index]);
-                    return Tooltip(
-                      message: override.heroStyle
-                          ? 'Play a trailer/scene clip in the hero card'
-                          : 'Enable Hero first — trailer preview needs a hero card to play in',
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Checkbox(
-                            value: override.heroStyle && override.heroTrailerPreview,
-                            onChanged: !override.heroStyle
-                                ? null
-                                : (v) => _setHeroOverride(
-                                    library,
-                                    rows[index],
-                                    override.copyWith(heroTrailerPreview: v ?? false),
-                                  ),
-                          ),
-                          const Text('Trailer'),
-                        ],
-                      ),
-                    );
-                  },
-                ),
-                if (rows[index].deletable)
-                  IconButton(
-                    icon: const Icon(Symbols.delete_outline_rounded),
-                    tooltip: 'Remove Hub',
-                    onPressed: () async {
-                      final client = context.read<MultiServerProvider>().getPlexClientForServer(
-                        ServerId(library.serverId!),
-                      );
-                      if (client != null) {
-                        await client.removeManagedHub(library.id, rows[index].identifier);
-                        await _load();
-                      }
-                    },
-                  ),
-              ],
-            ),
+              ),
+            ],
           ),
+        ),
+        if (rows.isNotEmpty) ...[
+          _reorderLockTile(
+            unlocked: _libraryReorderUnlocked[library.globalKey] ?? true,
+            onChanged: (v) => setState(() => _libraryReorderUnlocked[library.globalKey] = v),
+          ),
+          ReorderableListView(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            buildDefaultDragHandles: false,
+            onReorder: (oldIndex, newIndex) => _reorderLibraryRow(library, rows, oldIndex, newIndex),
+            children: [
+              for (var index = 0; index < rows.length; index++)
+                KeyedSubtree(
+                  key: ValueKey(rows[index].identifier),
+                  child: _maybeDraggable(
+                    unlocked: _libraryReorderUnlocked[library.globalKey] ?? true,
+                    index: index,
+                    child: ListTile(
+                      dense: true,
+                      leading: const Icon(Symbols.drag_indicator_rounded),
+                      title: Text(rows[index].title),
+                      subtitle: rows[index].deletable ? const Text('Custom Plex row') : null,
+                      trailing: Wrap(
+                        spacing: 2,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          Tooltip(
+                            message: 'Show in Library Recommended',
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Checkbox(
+                                  value: rows[index].promotedToRecommended,
+                                  onChanged: (v) => _setManagedVisibility(library, rows[index], recommended: v),
+                                ),
+                                const Text('Library'),
+                              ],
+                            ),
+                          ),
+                          Tooltip(
+                            message: 'Show on Home screen',
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Checkbox(
+                                  value: rows[index].promotedToOwnHome,
+                                  onChanged: (v) => _setManagedVisibility(library, rows[index], home: v),
+                                ),
+                                const Text('Home'),
+                              ],
+                            ),
+                          ),
+                          Builder(
+                            builder: (context) {
+                              final override = _heroOverrideFor(library, rows[index]);
+                              // Hero only actually renders anywhere this hub is
+                              // visible — with neither Library nor Home checked,
+                              // there's no surface left for it to apply to, so it
+                              // can't be turned on until at least one is.
+                              final canHero = rows[index].promotedToRecommended || rows[index].promotedToOwnHome;
+                              return Tooltip(
+                                message: canHero
+                                    ? 'Render as a hero card'
+                                    : 'Check Library or Home first — Hero needs somewhere to show',
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Checkbox(
+                                      value: canHero && override.heroStyle,
+                                      onChanged: !canHero
+                                          ? null
+                                          : (v) => _setHeroOverride(
+                                              library,
+                                              rows[index],
+                                              override.copyWith(heroStyle: v ?? false),
+                                            ),
+                                    ),
+                                    const Text('Hero'),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                          Builder(
+                            builder: (context) {
+                              final override = _heroOverrideFor(library, rows[index]);
+                              final canHero = rows[index].promotedToRecommended || rows[index].promotedToOwnHome;
+                              final canTrailer = canHero && override.heroStyle;
+                              return Tooltip(
+                                message: canTrailer
+                                    ? 'Play a trailer/scene clip in the hero card'
+                                    : 'Enable Hero first — trailer preview needs a hero card to play in',
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Checkbox(
+                                      value: canTrailer && override.heroTrailerPreview,
+                                      onChanged: !canTrailer
+                                          ? null
+                                          : (v) => _setHeroOverride(
+                                              library,
+                                              rows[index],
+                                              override.copyWith(heroTrailerPreview: v ?? false),
+                                            ),
+                                    ),
+                                    const Text('Trailer'),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
+                          if (rows[index].deletable)
+                            IconButton(
+                              icon: const Icon(Symbols.delete_outline_rounded),
+                              tooltip: 'Remove Hub',
+                              onPressed: () async {
+                                final client = context.read<MultiServerProvider>().getPlexClientForServer(
+                                  ServerId(library.serverId!),
+                                );
+                                if (client != null) {
+                                  await client.removeManagedHub(library.id, rows[index].identifier);
+                                  await _load();
+                                }
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
         if (rows.isEmpty) const ListTile(title: Text('No Plex-managed rows returned for this library.')),
       ],
     );
@@ -644,6 +893,29 @@ class _HomeLayoutSettingsScreenState extends State<HomeLayoutSettingsScreen> {
       title: const Text('Home layout'),
       children: [
         if (_loaded) ..._plexManagerGroups(),
+        SettingsGroup(
+          title: 'Hero cards',
+          children: [
+            SettingSegmentedTile<HeroCardTapAction>(
+              pref: SettingsService.heroCardTapAction,
+              icon: Symbols.touch_app_rounded,
+              title: 'Tapping a hero card',
+              segments: const [
+                ButtonSegment(value: HeroCardTapAction.play, label: Text('Play')),
+                ButtonSegment(value: HeroCardTapAction.details, label: Text('Open details')),
+              ],
+            ),
+            SettingSegmentedTile<HeroCardTapAction>(
+              pref: SettingsService.heroCardTrailerTapAction,
+              icon: Symbols.smart_display_rounded,
+              title: 'Tapping trailer',
+              segments: const [
+                ButtonSegment(value: HeroCardTapAction.play, label: Text('Play')),
+                ButtonSegment(value: HeroCardTapAction.details, label: Text('Open details')),
+              ],
+            ),
+          ],
+        ),
         SettingsGroup(
           title: 'Custom rows',
           children: [

--- a/lib/services/data_aggregation_service.dart
+++ b/lib/services/data_aggregation_service.dart
@@ -596,6 +596,15 @@ class DataAggregationService {
                   includePlaybackHubs: includePlaybackHubs,
                   libraries: serverLibraries ?? const [],
                   kinds: {MediaKind.artist, ...additionalLibraryHubKinds},
+                  // additionalLibraryHubKinds exists only to feed a configured
+                  // merge row (#1652) its recently-added/-released source hub,
+                  // not to surface every hub type Plex has for that library on
+                  // Home — a per-library fetch also returns collection hubs,
+                  // genre hubs, etc. Restricting it to just those two kinds
+                  // keeps everything else from leaking onto Home uncontrolled
+                  // by any setting. Music (artist) keeps its existing
+                  // unrestricted behavior — it isn't part of this ask.
+                  restrictToRecentHubKinds: additionalLibraryHubKinds,
                 );
           Object? globalError;
           StackTrace? globalStackTrace;
@@ -686,6 +695,12 @@ class DataAggregationService {
     required bool includePlaybackHubs,
     List<MediaLibrary>? libraries,
     Set<MediaKind> kinds = const {MediaKind.movie, MediaKind.show, MediaKind.clip, MediaKind.artist},
+    // Libraries of these kinds keep only recently-added/-released-looking
+    // hubs from their per-library response, dropping everything else Plex
+    // also returns there (collection hubs, genre hubs, top rated, ...).
+    // Empty by default: only the #1652 merge-support caller opts in, since
+    // every other caller of this method genuinely wants every hub type.
+    Set<MediaKind> restrictToRecentHubKinds = const {},
   }) async {
     final libs = libraries ?? await client.fetchLibraries();
     final visible = libs.where((l) {
@@ -724,7 +739,9 @@ class DataAggregationService {
             libraryKind: library.kind,
             diagnostics: diagnostics,
           );
-          results[index] = hubs;
+          results[index] = restrictToRecentHubKinds.contains(library.kind)
+              ? hubs.where(_looksLikeRecentAddedOrReleasedHub).toList()
+              : hubs;
           if (hubs.isNotEmpty || (!diagnostics.failed && !diagnostics.cancelled)) succeeded = true;
         } catch (e, st) {
           if (_isCancellation(e)) {
@@ -743,6 +760,25 @@ class DataAggregationService {
     await Future.wait([for (var i = 0; i < concurrency && i < visible.length; i++) worker()]);
 
     return (hubs: [for (final list in results) ...list], succeeded: succeeded, failed: failed, cancelled: cancelled);
+  }
+
+  /// Mirrors home_section_builder.dart's own recently-added/-released match
+  /// so a restricted per-library fetch keeps exactly what that builder would
+  /// have matched anyway — this just avoids handing it (or an un-configured
+  /// caller) hub types it was never going to use.
+  bool _looksLikeRecentAddedOrReleasedHub(MediaHub hub) {
+    final values = [hub.id, hub.identifier, hub.title].whereType<String>().map(
+      (v) => v.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), ''),
+    );
+    return values.any(
+      (v) =>
+          v.contains('recentlyadded') ||
+          v == 'latest' ||
+          v.contains('latestin') ||
+          v.contains('recentlyreleased') ||
+          v.contains('newlyreleased') ||
+          v.contains('recentlyavailable'),
+    );
   }
 
   /// Filter hidden-library items and drop empty hubs.

--- a/lib/services/data_aggregation_service.dart
+++ b/lib/services/data_aggregation_service.dart
@@ -54,6 +54,12 @@ typedef LibraryAggregationResult = ({
 /// the full post-hidden-filter, pre-rank pool behind it, so a caller can
 /// re-rank a subset (e.g. one media kind) without a kind ranked out of
 /// `items` disappearing from its own filter.
+typedef CollectionAggregationResult = ({
+  List<MediaItem> collections,
+  Set<String> succeededServerIds,
+  Set<String> cancelledServerIds,
+  Set<String> failedServerIds,
+});
 typedef SearchAggregationResult = ({
   List<MediaItem> items,
   List<MediaItem> candidates,
@@ -119,6 +125,49 @@ class DataAggregationService {
   final MultiServerManager _serverManager;
 
   DataAggregationService(this._serverManager);
+
+  /// Fetch real collection entities from visible movie and show libraries.
+  Future<CollectionAggregationResult> getCollectionsFromAllServers({
+    Set<String>? hiddenLibraryKeys,
+    Set<String>? serverIds,
+  }) async {
+    final clients = _clientsFor(serverIds);
+    final libraries = await getMediaLibrariesFromAllServers(serverIds: serverIds);
+    final byServer = <String, List<MediaLibrary>>{};
+    for (final library in libraries.libraries) {
+      if (library.hidden || hiddenLibraryKeys?.contains(library.globalKey) == true) continue;
+      if (library.kind != MediaKind.movie && library.kind != MediaKind.show) continue;
+      final sid = library.serverId;
+      if (sid != null) byServer.putIfAbsent(sid, () => []).add(library);
+    }
+    final fetched = await _fanOut<MediaItem>(
+      clients,
+      failureMessage: (serverId) => 'Failed to fetch collections from server $serverId',
+      fetch: (serverId, client) async {
+        final result = <MediaItem>[];
+        for (final library in byServer[serverId] ?? const <MediaLibrary>[]) {
+          final items = await client.fetchCollections(library.id);
+          result.addAll(
+            items.map(
+              (item) => item.copyWith(
+                libraryId: library.id,
+                libraryTitle: library.title,
+                serverId: serverId,
+                serverName: library.serverName,
+              ),
+            ),
+          );
+        }
+        return result;
+      },
+    );
+    return (
+      collections: fetched.items,
+      succeededServerIds: fetched.succeededServerIds.intersection(libraries.succeededServerIds),
+      cancelledServerIds: {...fetched.cancelledServerIds, ...libraries.cancelledServerIds},
+      failedServerIds: {...fetched.failedServerIds, ...libraries.failedServerIds},
+    );
+  }
 
   /// Online clients, optionally restricted to [serverIds] — delta refreshes
   /// fan out to newly-online servers only.
@@ -479,6 +528,14 @@ class DataAggregationService {
     bool useGlobalHubs = true,
     bool includePlaybackHubs = true,
     Set<String>? serverIds,
+    // Extra library kinds to append per-library hubs for, alongside the
+    // existing artist/music append below (#1652). Plex's global/promoted
+    // hub endpoint does not guarantee a recently-added/recently-released hub
+    // for every visible library — only "promoted" ones — so a caller with an
+    // enabled custom Home section spanning movie/show libraries the global
+    // endpoint happens to skip must ask for those explicitly, the same way
+    // music libraries already do.
+    Set<MediaKind> additionalLibraryHubKinds = const {},
   }) async {
     final clients = _clientsFor(serverIds);
     if (clients.isEmpty) {
@@ -538,7 +595,7 @@ class DataAggregationService {
                   hiddenLibraryKeys: hiddenLibraryKeys,
                   includePlaybackHubs: includePlaybackHubs,
                   libraries: serverLibraries ?? const [],
-                  kinds: const {MediaKind.artist},
+                  kinds: {MediaKind.artist, ...additionalLibraryHubKinds},
                 );
           Object? globalError;
           StackTrace? globalStackTrace;

--- a/lib/services/hover_trailer_service.dart
+++ b/lib/services/hover_trailer_service.dart
@@ -1,0 +1,156 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+
+import '../media/media_item.dart';
+import '../media/media_kind.dart';
+import '../media/media_server_client.dart';
+
+/// What a hover-preview card should show once the debounce fires, in
+/// descending order of quality.
+sealed class HoverPreviewSource {
+  const HoverPreviewSource();
+}
+
+/// A trailer clip exists — play it from the start.
+class TrailerPreviewSource extends HoverPreviewSource {
+  const TrailerPreviewSource(this.streamUrl);
+  final String streamUrl;
+}
+
+/// No trailer, but the owned movie/show file itself can be played — seek
+/// past the likely opening logos/credits and play a short clip from there.
+class SceneClipPreviewSource extends HoverPreviewSource {
+  const SceneClipPreviewSource(this.streamUrl, this.startOffset);
+  final String streamUrl;
+  final Duration startOffset;
+}
+
+/// Neither worked (or the item has no resolvable duration) — the card
+/// expands to show metadata over static art, no video.
+class NoPreviewSource extends HoverPreviewSource {
+  const NoPreviewSource();
+}
+
+/// Resolves what a hover-preview card should play for a given item.
+///
+/// Priority: (1) a Plex-scraped trailer, (2) a clip from the owned media
+/// file itself (the user owns this content — playing a clip of it is not
+/// the same question as pulling a clip from somewhere else), (3) no video,
+/// metadata-only. Never throws — a failed lookup at any stage just falls
+/// through to the next one; a hover preview has nothing worth surfacing
+/// an error for.
+class HoverPreviewSourceResolver {
+  /// Plex's `extraType` values distinguish trailers from other extras
+  /// (deleted scenes, featurettes, behind-the-scenes) — 1 is trailer,
+  /// confirmed against a real library item via the Plex API directly.
+  // Plex numeric extraType 1 == subtype 'trailer'; this branch's PlexMediaItem
+  // consolidated onto the String subtype field (see media_item.dart), so
+  // match on that instead of the old numeric extraType this was ported from.
+  static const _trailerSubtype = 'trailer';
+
+  /// Skip this fraction of runtime before starting a scene-clip fallback,
+  /// clearing most studio logos/opening credits without needing per-title
+  /// chapter data.
+  static const _sceneStartFraction = 0.12;
+
+  Future<HoverPreviewSource> resolve(MediaServerClient client, MediaItem item, {bool preferResumePosition = false}) async {
+    // TEMP DIAGNOSTIC (remove once the per-hub blank-video bug is found):
+    // the same title reportedly resolves in one hub's row and not another —
+    // logging id/kind/duration here to see what actually differs between a
+    // working and a failing call for the same movie.
+    debugPrint('[hover-preview] resolve id=${item.id} kind=${item.kind} title=${item.displayTitle} durationMs=${item.durationMs} serverId=${item.serverId}');
+
+    final playableItem = await _resolvePlayableItem(client, item);
+
+    // Continue Watching cards want to pick up where the user left off, not
+    // a trailer or the usual 12%-in scene clip — checked first and, when it
+    // resolves, skips the rest of this method entirely.
+    if (preferResumePosition && playableItem.hasActiveProgress) {
+      final resumeClip = await _resolveResumeClip(client, playableItem);
+      if (resumeClip != null) {
+        debugPrint('[hover-preview] resumeClip OK id=${item.id} url=${resumeClip.streamUrl}');
+        return resumeClip;
+      }
+    }
+
+    final trailerUrl = await _resolveTrailerUrl(client, playableItem);
+    if (trailerUrl != null) {
+      debugPrint('[hover-preview] trailer OK id=${item.id} url=$trailerUrl');
+      return TrailerPreviewSource(trailerUrl);
+    }
+
+    final sceneClip = await _resolveSceneClip(client, playableItem);
+    if (sceneClip != null) {
+      debugPrint('[hover-preview] sceneClip OK id=${item.id} url=${sceneClip.streamUrl}');
+      return sceneClip;
+    }
+
+    debugPrint('[hover-preview] NO PREVIEW id=${item.id} title=${item.displayTitle}');
+    return const NoPreviewSource();
+  }
+
+  /// A show's own card represents the whole series, not a single playable
+  /// file — resolving extras or a scene clip against its own id either
+  /// returns nothing or fails outright, since there's no video Part on a
+  /// show itself. Substitutes the actual on-deck episode (Plex's own
+  /// lookup, which already knows to pick up where the user left off, or the
+  /// first episode for a never-started show) so the rest of this resolver
+  /// has something genuinely playable to work with. Movies pass through
+  /// unchanged — they're already the playable item.
+  Future<MediaItem> _resolvePlayableItem(MediaServerClient client, MediaItem item) async {
+    if (item.kind != MediaKind.show) return item;
+    try {
+      final result = await client.fetchItemWithOnDeck(item.id);
+      return result.onDeckEpisode ?? item;
+    } catch (_) {
+      return item;
+    }
+  }
+
+  Future<SceneClipPreviewSource?> _resolveResumeClip(MediaServerClient client, MediaItem item) async {
+    final offsetMs = item.viewOffsetMs;
+    if (offsetMs == null || offsetMs <= 0) return null;
+    try {
+      final url = await client.resolveExternalPlaybackUrl(item);
+      if (url == null) return null;
+      return SceneClipPreviewSource(url, Duration(milliseconds: offsetMs));
+    } catch (e) {
+      debugPrint('[hover-preview] resumeClip FAILED id=${item.id}: $e');
+      return null;
+    }
+  }
+
+  Future<String?> _resolveTrailerUrl(MediaServerClient client, MediaItem item) async {
+    try {
+      final extras = await client.fetchExtras(item.id);
+      final trailer = extras.firstWhereOrNull(
+        (extra) => extra is PlexMediaItem && extra.subtype == _trailerSubtype,
+      );
+      if (trailer == null) return null;
+      return await client.resolveExternalPlaybackUrl(trailer);
+    } catch (e) {
+      debugPrint('[hover-preview] trailer FAILED id=${item.id}: $e');
+      return null;
+    }
+  }
+
+  Future<SceneClipPreviewSource?> _resolveSceneClip(MediaServerClient client, MediaItem item) async {
+    final durationMs = item.durationMs;
+    if (durationMs == null || durationMs <= 0) {
+      debugPrint('[hover-preview] sceneClip SKIPPED (no durationMs) id=${item.id} durationMs=$durationMs');
+      return null;
+    }
+    try {
+      final url = await client.resolveExternalPlaybackUrl(item);
+      if (url == null) {
+        debugPrint('[hover-preview] sceneClip FAILED (null url) id=${item.id}');
+        return null;
+      }
+      final offsetMs = (durationMs * _sceneStartFraction).round();
+      return SceneClipPreviewSource(url, Duration(milliseconds: offsetMs));
+    } catch (e) {
+      debugPrint('[hover-preview] sceneClip FAILED (exception) id=${item.id}: $e');
+      return null;
+    }
+  }
+}

--- a/lib/services/plex_client.dart
+++ b/lib/services/plex_client.dart
@@ -48,6 +48,7 @@ import '../media/media_file_info.dart';
 import '../media/media_filter.dart';
 import '../media/media_source_info.dart';
 import '../models/plex/plex_subtitle_search_result.dart';
+import '../models/plex/plex_managed_hub.dart';
 import '../models/plex/plex_match_result.dart';
 import '../utils/codec_utils.dart';
 import '../utils/content_utils.dart';
@@ -614,6 +615,59 @@ class PlexClient
     final response = await _http.post(path, queryParameters: queryParameters, allowEndpointFailover: true);
     throwIfHttpError(response);
     return response;
+  }
+
+  /// Read the rows and visibility flags shown by Plex's Home manager.
+  Future<List<PlexManagedHub>> fetchManagedHubs(String sectionId) async {
+    final response = await _getWithFailover('/hubs/sections/$sectionId/manage');
+    final container = _getMediaContainer(response);
+    final rawHubs = container?['Hub'];
+    final hubs = rawHubs is List
+        ? rawHubs
+        : rawHubs is Map
+        ? [rawHubs]
+        : const [];
+    return hubs
+        .whereType<Map>()
+        .map((hub) => PlexManagedHub.fromJson(Map<String, dynamic>.from(hub)))
+        .where((hub) => hub.identifier.isNotEmpty)
+        .toList();
+  }
+
+  Future<void> updateManagedHubVisibility(
+    String sectionId,
+    String identifier, {
+    required bool promotedToRecommended,
+    required bool promotedToOwnHome,
+    required bool promotedToSharedHome,
+  }) async {
+    final response = await _http.put(
+      '/hubs/sections/$sectionId/manage/${Uri.encodeComponent(identifier)}',
+      queryParameters: {
+        'promotedToRecommended': promotedToRecommended ? 1 : 0,
+        'promotedToOwnHome': promotedToOwnHome ? 1 : 0,
+        'promotedToSharedHome': promotedToSharedHome ? 1 : 0,
+      },
+    );
+    throwIfHttpError(response);
+  }
+
+  Future<void> moveManagedHub(String sectionId, String identifier, {String? after}) async {
+    final response = await _http.put(
+      '/hubs/sections/$sectionId/manage/${Uri.encodeComponent(identifier)}/move',
+      queryParameters: {'after': after ?? ''},
+    );
+    throwIfHttpError(response);
+  }
+
+  Future<void> removeManagedHub(String sectionId, String identifier) async {
+    final response = await _http.delete('/hubs/sections/$sectionId/manage/${Uri.encodeComponent(identifier)}');
+    throwIfHttpError(response);
+  }
+
+  Future<void> resetManagedHubs(String sectionId) async {
+    final response = await _http.delete('/hubs/sections/$sectionId/manage');
+    throwIfHttpError(response);
   }
 
   /// Fetch /media/providers and parse libraries + EPG providers from the response.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -32,6 +32,7 @@ export 'base_shared_preferences_service.dart'
         JsonPref;
 import '../models/audio_quality_preset.dart';
 import '../models/transcode_quality_preset.dart';
+import '../models/home_section_config.dart';
 import '../navigation/navigation_tabs.dart';
 import '../utils/platform_detector.dart';
 import 'trackers/tracker_constants.dart';
@@ -709,6 +710,24 @@ class SettingsService extends BaseSharedPreferencesService {
   );
   static const mpvConfigText = _MpvConfigTextPref();
 
+  /// Configurable Home rows that merge selected libraries into one row
+  /// instead of one row per library (#1652).
+  static final homeSections = JsonPref<List<HomeSectionConfig>>(
+    'home_sections',
+    defaultValue: const [],
+    encode: (v) => json.encode(v.map((section) => section.toJson()).toList()),
+    decode: (raw) => (raw as List).map((e) => HomeSectionConfig.fromJson(Map<String, dynamic>.from(e as Map))).toList(),
+  );
+
+  /// Saved display order for Home rows (both configured sections and
+  /// Plex-promoted managed hubs) — see `home_layout_settings_screen.dart`.
+  static final homeRowOrder = JsonPref<List<String>>(
+    'home_row_order',
+    defaultValue: const [],
+    encode: (v) => json.encode(v),
+    decode: (raw) => (raw as List).whereType<String>().toList(),
+  );
+
   static final keyboardHotkeys = JsonPref<Map<String, HotKey?>>(
     'keyboard_hotkeys',
     defaultValue: <String, HotKey?>{..._defaultKeyboardHotkeys()},
@@ -1160,6 +1179,7 @@ class SettingsService extends BaseSharedPreferencesService {
     episodePosterMode,
     continueWatchingAction,
     episodeAction,
+    homeSections,
     keyboardHotkeys,
     // Library filters, one pair per tracker service.
     for (final s in TrackerService.values) ...[trackerFilterModePref(s), trackerFilterIdsPref(s)],

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -33,6 +33,7 @@ export 'base_shared_preferences_service.dart'
 import '../models/audio_quality_preset.dart';
 import '../models/transcode_quality_preset.dart';
 import '../models/home_section_config.dart';
+import '../models/plex/plex_managed_hub.dart';
 import '../navigation/navigation_tabs.dart';
 import '../utils/platform_detector.dart';
 import 'trackers/tracker_constants.dart';
@@ -717,6 +718,20 @@ class SettingsService extends BaseSharedPreferencesService {
     defaultValue: const [],
     encode: (v) => json.encode(v.map((section) => section.toJson()).toList()),
     decode: (raw) => (raw as List).map((e) => HomeSectionConfig.fromJson(Map<String, dynamic>.from(e as Map))).toList(),
+  );
+
+  /// Hero-card/trailer-preview preference for native Plex-managed hubs
+  /// (e.g. Continue Watching, a promoted Recently Added), keyed by
+  /// `'${library.globalKey}::${hub.identifier}'`. Plex has no such concept
+  /// itself — see [ManagedHubHeroOverride] — so this is Plezy-local only,
+  /// the counterpart to [HomeSectionConfig.heroStyle] for custom rows.
+  static final managedHubHeroOverrides = JsonPref<Map<String, ManagedHubHeroOverride>>(
+    'managed_hub_hero_overrides',
+    defaultValue: const {},
+    encode: (v) => json.encode(v.map((key, value) => MapEntry(key, value.toJson()))),
+    decode: (raw) => (raw as Map).map(
+      (key, value) => MapEntry(key as String, ManagedHubHeroOverride.fromJson(Map<String, dynamic>.from(value as Map))),
+    ),
   );
 
   /// Saved display order for Home rows (both configured sections and

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -83,6 +83,13 @@ enum ContinueWatchingAction { play, details }
 
 enum EpisodeAction { play, details }
 
+/// What tapping a hero row's card (backdrop/video area, not the Play
+/// button itself, which always plays) does — user-configurable per
+/// user request 2026-09-10: some people want a poster tap to behave like a
+/// remote control (play immediately), others want it to behave like
+/// browsing (open details first, decide from there).
+enum HeroCardTapAction { play, details }
+
 /// How Specials (season 0) are placed in the episode watch order — the
 /// sequence auto-advance, offline next/prev, and "download next N" walk.
 enum SpecialsOrdering {
@@ -713,6 +720,30 @@ class SettingsService extends BaseSharedPreferencesService {
     values: EpisodeAction.values,
     defaultValue: EpisodeAction.play,
   );
+  static const heroCardTapAction = EnumPref<HeroCardTapAction>(
+    'hero_card_tap_action',
+    values: HeroCardTapAction.values,
+    // Defaults to details, not play: tapping a hero card's static poster
+    // should land on the metadata page — cast, description, etc. — unless
+    // the user has explicitly opted into "Play" in Home layout settings.
+    // Only applies while the card is showing its poster; see
+    // [heroCardTrailerTapAction] for the same choice while a trailer is
+    // actively playing on it — the two are independently configurable per
+    // user request 2026-09-10. The Play button in the overlay always plays
+    // directly regardless of either setting.
+    defaultValue: HeroCardTapAction.details,
+  );
+
+  /// Same choice as [heroCardTapAction], but for tapping a hero card while
+  /// its trailer is actively playing on it, rather than its static poster —
+  /// split into its own setting so the two states can be configured
+  /// independently (e.g. "poster tap plays, but tapping mid-trailer opens
+  /// details instead").
+  static const heroCardTrailerTapAction = EnumPref<HeroCardTapAction>(
+    'hero_card_trailer_tap_action',
+    values: HeroCardTapAction.values,
+    defaultValue: HeroCardTapAction.details,
+  );
   static const mpvConfigText = _MpvConfigTextPref();
 
   /// Configurable Home rows that merge selected libraries into one row
@@ -736,6 +767,37 @@ class SettingsService extends BaseSharedPreferencesService {
     decode: (raw) => (raw as Map).map(
       (key, value) => MapEntry(key as String, ManagedHubHeroOverride.fromJson(Map<String, dynamic>.from(value as Map))),
     ),
+  );
+
+  /// Libraries (by `library.globalKey`) whose own Continue Watching row is
+  /// hidden from that library's Recommended tab. That hub isn't a
+  /// [PlexManagedHub] Plex lets you promote/demote itself, unlike every
+  /// other row on a library's Recommended tab — this is the toggle for it,
+  /// the per-library counterpart to [continueWatchingOnHome]. Absent from
+  /// this set means shown, matching the behavior before this setting
+  /// existed (every fetched hub, Continue Watching included, always
+  /// rendered unconditionally).
+  static final libraryContinueWatchingHidden = JsonPref<Set<String>>(
+    'library_continue_watching_hidden',
+    defaultValue: const {},
+    encode: (v) => json.encode(v.toList()),
+    decode: (raw) => (raw as List).whereType<String>().toSet(),
+  );
+
+  /// Per-library custom row order for a library's own Recommended tab —
+  /// keyed by `library.globalKey`, each value an ordered list of that
+  /// library's managed-hub identifiers (see `hubIdentifierMatches` in
+  /// home_section_builder.dart for why a saved identifier here isn't
+  /// compared for exact equality against a fetched hub's own). The
+  /// per-library counterpart to [homeRowOrder]. A library absent from this
+  /// map, or an identifier not present in its saved list, falls back to
+  /// whatever order the server itself returned.
+  static final libraryManagedRowOrder = JsonPref<Map<String, List<String>>>(
+    'library_managed_row_order',
+    defaultValue: const {},
+    encode: (v) => json.encode(v),
+    decode: (raw) =>
+        (raw as Map).map((key, value) => MapEntry(key as String, (value as List).whereType<String>().toList())),
   );
 
   /// Saved display order for Home rows (both configured sections and
@@ -1199,6 +1261,7 @@ class SettingsService extends BaseSharedPreferencesService {
     episodePosterMode,
     continueWatchingAction,
     episodeAction,
+    heroCardTapAction,
     homeSections,
     keyboardHotkeys,
     // Library filters, one pair per tracker service.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -442,6 +442,10 @@ class SettingsService extends BaseSharedPreferencesService {
   static const seekTimeLarge = IntPref('seek_time_large', defaultValue: 30);
   static const rewindOnResume = IntPref('rewind_on_resume');
   static const showHeroSection = BoolPref('show_hero_section', defaultValue: true);
+  // Lets Continue Watching be added/removed from Home like any other
+  // Organizer row (see home_layout_settings_screen.dart), instead of it
+  // always being a fixed, unremovable fixture ahead of every other row.
+  static const continueWatchingOnHome = BoolPref('continue_watching_on_home', defaultValue: true);
   static const tvFullCardLayout = BoolPref('tv_full_card_layout', defaultValue: false);
   static const focusGlow = BoolPref('focus_glow', defaultValue: true);
   static const useGlobalHubs = BoolPref('use_global_hubs', defaultValue: true);
@@ -1115,6 +1119,7 @@ class SettingsService extends BaseSharedPreferencesService {
     seekTimeSmall,
     seekTimeLarge,
     showHeroSection,
+    continueWatchingOnHome,
     sleepTimerDuration,
     audioSyncOffset,
     subtitleSyncOffset,

--- a/lib/utils/home_section_builder.dart
+++ b/lib/utils/home_section_builder.dart
@@ -123,10 +123,9 @@ List<MediaItem> _recentItems(HomeSectionConfig section, List<MediaHub> matchedHu
   return items;
 }
 
-int Function(MediaItem, MediaItem) _recencyComparator(HomeSectionKind kind) =>
-    kind == HomeSectionKind.recentlyReleased
-        ? (a, b) => (b.originallyAvailableAt ?? '').compareTo(a.originallyAvailableAt ?? '')
-        : (a, b) => (b.addedAt ?? 0).compareTo(a.addedAt ?? 0);
+int Function(MediaItem, MediaItem) _recencyComparator(HomeSectionKind kind) => kind == HomeSectionKind.recentlyReleased
+    ? (a, b) => (b.originallyAvailableAt ?? '').compareTo(a.originallyAvailableAt ?? '')
+    : (a, b) => (b.addedAt ?? 0).compareTo(a.addedAt ?? 0);
 
 String? _hubLibraryGlobalKey(MediaHub hub) {
   final serverId = hub.serverId;

--- a/lib/utils/home_section_builder.dart
+++ b/lib/utils/home_section_builder.dart
@@ -12,19 +12,25 @@ List<MediaHub> buildConfiguredHomeSections({
   required List<HomeSectionConfig> sections,
   Map<String, MediaKind> collectionLibraryKinds = const {},
   List<String> rowOrder = const [],
+  Map<String, List<MediaItem>> singleCollectionContents = const {},
 }) {
   final output = <MediaHub>[];
   for (final section in sections.where((s) => s.enabled && s.showOnHome)) {
-    final items = section.isCollectionRow
-        ? _collectionItems(section, collections, collectionLibraryKinds)
-        : _recentItems(section, sourceHubs.where((hub) => _matches(section.kind, hub)).toList());
+    // A row scoped to exactly one collection is more useful as that
+    // collection's actual contents than as a single folder tile.
+    final singleCollection = section.collectionKeys.length == 1 ? singleCollectionContents[section.id] : null;
+    final items =
+        singleCollection ??
+        (section.isCollectionRow
+            ? _collectionItems(section, collections, collectionLibraryKinds)
+            : _recentItems(section, sourceHubs.where((hub) => _matches(section.kind, hub)).toList()));
     if (items.isEmpty) continue;
     output.add(
       MediaHub(
         id: section.id,
         identifier: 'configured.${section.kind.id}',
         title: section.title,
-        type: section.isCollectionRow ? 'collection' : 'mixed',
+        type: singleCollection != null ? 'mixed' : (section.isCollectionRow ? 'collection' : 'mixed'),
         items: _dedupe(items),
         size: items.length,
       ),

--- a/lib/utils/home_section_builder.dart
+++ b/lib/utils/home_section_builder.dart
@@ -17,7 +17,7 @@ List<MediaHub> buildConfiguredHomeSections({
   for (final section in sections.where((s) => s.enabled && s.showOnHome)) {
     final items = section.isCollectionRow
         ? _collectionItems(section, collections, collectionLibraryKinds)
-        : _recentItems(section, sourceHubs);
+        : _recentItems(section, sourceHubs.where((hub) => _matches(section.kind, hub)).toList());
     if (items.isEmpty) continue;
     output.add(
       MediaHub(
@@ -30,21 +30,65 @@ List<MediaHub> buildConfiguredHomeSections({
       ),
     );
   }
-  final combined = output.isEmpty || sections.every((s) => s.keepSourceRows) ? [...output, ...sourceHubs] : output;
+  final combined = [...output, ...sourceHubs];
   if (rowOrder.isEmpty) return combined;
-  final positions = {for (var i = 0; i < rowOrder.length; i++) rowOrder[i]: i};
-  String tokenFor(MediaHub hub) {
-    final custom = sections.where((section) => section.id == hub.id).firstOrNull;
-    if (custom != null) return 'custom:${custom.id}';
-    if (hub.libraryId != null) return 'plex:${hub.serverId ?? ''}:${hub.libraryId}:${hub.identifier ?? hub.id}';
-    return '';
+
+  // home_row_order (the Organizer, what Settings actually shows and lets the
+  // user edit) is the single source of truth for which rows appear on Home
+  // and in what order, once it's non-empty -- not a secondary sort layered
+  // over a separately decided content list, and not a sort-with-fallback
+  // that silently re-adds anything the user removed. A merged row and the
+  // specific raw hub it draws from can both have their own token here; if
+  // the user doesn't want the raw one showing too, they remove its row
+  // directly in the Organizer, and that removal has to actually stick. A hub
+  // with no library id can never get a token at all (nothing to remove it
+  // by), so it always shows, same as before this feature existed.
+  //
+  // A saved Plex token's identifier can't be compared for exact equality
+  // against a fetched hub's identifier: the Organizer's token comes from
+  // Plex's hub-*management* endpoint (fetchManagedHubs), while the hub shown
+  // on Home comes from its hub-*content* endpoints -- Plex itself returns a
+  // different identifier string for the same conceptual hub across those two
+  // APIs (e.g. "movie.recentlyreleased" vs. "movie.recentlyreleased.7",
+  // confirmed live). The content identifier always extends the managed one
+  // as a dot-separated suffix, so matching is done per (server, library) by
+  // identifier-prefix rather than by exact string.
+  final custom = <String, MediaHub>{};
+  final byLibrary = <String, List<MediaHub>>{};
+  final untrackable = <MediaHub>[];
+  for (final hub in combined) {
+    final customSection = sections.where((section) => section.id == hub.id).firstOrNull;
+    if (customSection != null) {
+      custom['custom:${customSection.id}'] = hub;
+      continue;
+    }
+    final libraryId = _hubLibraryId(hub);
+    if (libraryId == null) {
+      untrackable.add(hub);
+      continue;
+    }
+    (byLibrary['${hub.serverId ?? ''}:$libraryId'] ??= []).add(hub);
   }
 
-  final sorted = combined.indexed.toList();
-  sorted.sort(
-    (a, b) => (positions[tokenFor(a.$2)] ?? rowOrder.length).compareTo(positions[tokenFor(b.$2)] ?? rowOrder.length),
-  );
-  return sorted.map((entry) => entry.$2).toList();
+  MediaHub? resolvePlexToken(String token) {
+    final parts = token.split(':');
+    if (parts.length < 4 || parts[0] != 'plex') return null;
+    final wantedIdentifier = parts.sublist(3).join(':');
+    final candidates = byLibrary['${parts[1]}:${parts[2]}'] ?? const [];
+    for (final hub in candidates) {
+      final actual = hub.identifier ?? hub.id;
+      if (actual == wantedIdentifier || actual.startsWith('$wantedIdentifier.')) return hub;
+    }
+    return null;
+  }
+
+  final usedHubs = <MediaHub>{};
+  final ordered = <MediaHub>[];
+  for (final token in rowOrder) {
+    final hub = token.startsWith('custom:') ? custom[token] : resolvePlexToken(token);
+    if (hub != null && usedHubs.add(hub)) ordered.add(hub);
+  }
+  return [...ordered, ...untrackable];
 }
 
 List<MediaItem> _collectionItems(HomeSectionConfig section, List<MediaItem> all, Map<String, MediaKind> libraryKinds) =>
@@ -56,20 +100,47 @@ List<MediaItem> _collectionItems(HomeSectionConfig section, List<MediaItem> all,
       return section.libraryKeys.isEmpty || section.libraryKeys.contains(item.libraryGlobalKey);
     }).toList();
 
-List<MediaItem> _recentItems(HomeSectionConfig section, List<MediaHub> hubs) => [
-  for (final hub in hubs)
-    if (_matches(section.kind, hub))
+/// [matchedHubs] are already filtered to this section's kind (see the
+/// caller) so this only applies the section's own library selection.
+List<MediaItem> _recentItems(HomeSectionConfig section, List<MediaHub> matchedHubs) {
+  final items = [
+    for (final hub in matchedHubs)
       for (final item in hub.items)
         if (section.libraryKeys.isEmpty ||
             section.libraryKeys.contains(item.libraryGlobalKey ?? _hubLibraryGlobalKey(hub)))
           item,
-];
+  ];
+  // Items above are grouped one source hub at a time (every movie-library item,
+  // then every show-library item, ...), so a merged row needs its own sort or
+  // it renders as library-sized blocks rather than one interleaved timeline.
+  items.sort(_recencyComparator(section.kind));
+  return items;
+}
+
+int Function(MediaItem, MediaItem) _recencyComparator(HomeSectionKind kind) =>
+    kind == HomeSectionKind.recentlyReleased
+        ? (a, b) => (b.originallyAvailableAt ?? '').compareTo(a.originallyAvailableAt ?? '')
+        : (a, b) => (b.addedAt ?? 0).compareTo(a.addedAt ?? 0);
 
 String? _hubLibraryGlobalKey(MediaHub hub) {
   final serverId = hub.serverId;
-  final libraryId = hub.libraryId;
+  final libraryId = _hubLibraryId(hub);
   if (serverId == null || libraryId == null) return null;
   return buildGlobalKey(ServerId(serverId), libraryId);
+}
+
+/// The Plex client never sets [MediaHub.libraryId] itself (the section id it
+/// computes per hub only gets pushed down onto that hub's own items), so a
+/// hub has to borrow one of its item's library ids instead -- the same
+/// fallback media_hub_ordering.dart's own library sort already relies on.
+String? _hubLibraryId(MediaHub hub) {
+  final direct = hub.libraryId;
+  if (direct != null) return direct;
+  for (final item in hub.items) {
+    final itemLibraryId = item.libraryId;
+    if (itemLibraryId != null) return itemLibraryId;
+  }
+  return null;
 }
 
 bool _matches(HomeSectionKind kind, MediaHub hub) {

--- a/lib/utils/home_section_builder.dart
+++ b/lib/utils/home_section_builder.dart
@@ -1,0 +1,93 @@
+import '../media/media_hub.dart';
+import '../media/media_item.dart';
+import '../media/media_kind.dart';
+import '../models/home_section_config.dart';
+import '../media/ids.dart';
+import '../utils/global_key_utils.dart';
+
+/// Builds user-defined Home rows from normalized hubs and real collection items.
+List<MediaHub> buildConfiguredHomeSections({
+  required List<MediaHub> sourceHubs,
+  required List<MediaItem> collections,
+  required List<HomeSectionConfig> sections,
+  Map<String, MediaKind> collectionLibraryKinds = const {},
+  List<String> rowOrder = const [],
+}) {
+  final output = <MediaHub>[];
+  for (final section in sections.where((s) => s.enabled && s.showOnHome)) {
+    final items = section.isCollectionRow
+        ? _collectionItems(section, collections, collectionLibraryKinds)
+        : _recentItems(section, sourceHubs);
+    if (items.isEmpty) continue;
+    output.add(
+      MediaHub(
+        id: section.id,
+        identifier: 'configured.${section.kind.id}',
+        title: section.title,
+        type: section.isCollectionRow ? 'collection' : 'mixed',
+        items: _dedupe(items),
+        size: items.length,
+      ),
+    );
+  }
+  final combined = output.isEmpty || sections.every((s) => s.keepSourceRows) ? [...output, ...sourceHubs] : output;
+  if (rowOrder.isEmpty) return combined;
+  final positions = {for (var i = 0; i < rowOrder.length; i++) rowOrder[i]: i};
+  String tokenFor(MediaHub hub) {
+    final custom = sections.where((section) => section.id == hub.id).firstOrNull;
+    if (custom != null) return 'custom:${custom.id}';
+    if (hub.libraryId != null) return 'plex:${hub.serverId ?? ''}:${hub.libraryId}:${hub.identifier ?? hub.id}';
+    return '';
+  }
+
+  final sorted = combined.indexed.toList();
+  sorted.sort(
+    (a, b) => (positions[tokenFor(a.$2)] ?? rowOrder.length).compareTo(positions[tokenFor(b.$2)] ?? rowOrder.length),
+  );
+  return sorted.map((entry) => entry.$2).toList();
+}
+
+List<MediaItem> _collectionItems(HomeSectionConfig section, List<MediaItem> all, Map<String, MediaKind> libraryKinds) =>
+    all.where((item) {
+      if (item.kind != MediaKind.collection) return false;
+      final libraryKind = libraryKinds[item.libraryGlobalKey];
+      if (libraryKind != section.kind.collectionKind) return false;
+      if (section.collectionKeys.isNotEmpty && !section.collectionKeys.contains(item.globalKey)) return false;
+      return section.libraryKeys.isEmpty || section.libraryKeys.contains(item.libraryGlobalKey);
+    }).toList();
+
+List<MediaItem> _recentItems(HomeSectionConfig section, List<MediaHub> hubs) => [
+  for (final hub in hubs)
+    if (_matches(section.kind, hub))
+      for (final item in hub.items)
+        if (section.libraryKeys.isEmpty ||
+            section.libraryKeys.contains(item.libraryGlobalKey ?? _hubLibraryGlobalKey(hub)))
+          item,
+];
+
+String? _hubLibraryGlobalKey(MediaHub hub) {
+  final serverId = hub.serverId;
+  final libraryId = hub.libraryId;
+  if (serverId == null || libraryId == null) return null;
+  return buildGlobalKey(ServerId(serverId), libraryId);
+}
+
+bool _matches(HomeSectionKind kind, MediaHub hub) {
+  final values = [hub.id, hub.identifier, hub.title].whereType<String>().map(_compact);
+  return switch (kind) {
+    HomeSectionKind.recentlyAdded => values.any(
+      (v) => v.contains('recentlyadded') || v == 'latest' || v.contains('latestin'),
+    ),
+    HomeSectionKind.recentlyReleased => values.any(
+      (v) => v.contains('recentlyreleased') || v.contains('newlyreleased') || v.contains('recentlyavailable'),
+    ),
+    _ => false,
+  };
+}
+
+String _compact(String value) => value.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '');
+
+List<MediaItem> _dedupe(List<MediaItem> items) {
+  final seen = <String>{};
+  return items.where((item) => seen.add(item.globalKey)).toList(growable: false);
+}

--- a/lib/utils/home_section_builder.dart
+++ b/lib/utils/home_section_builder.dart
@@ -2,8 +2,20 @@ import '../media/media_hub.dart';
 import '../media/media_item.dart';
 import '../media/media_kind.dart';
 import '../models/home_section_config.dart';
+import '../models/plex/plex_managed_hub.dart';
 import '../media/ids.dart';
 import '../utils/global_key_utils.dart';
+
+/// Override-store key Continue Watching's hero/trailer settings are saved
+/// under (see `home_layout_settings_screen.dart`) — it isn't a
+/// [PlexManagedHub] at all, so it can't use the `library::hubIdentifier`
+/// key shape every other managed-hub override uses.
+const continueWatchingHeroOverrideKey = 'builtin::continue_watching';
+
+/// Row-order token for Continue Watching once it's enabled (see
+/// `SettingsService.continueWatchingOnHome`) — parallels `custom:<id>` and
+/// `plex:<server>:<library>:<identifier>` for the other row kinds.
+const continueWatchingRowToken = 'builtin:continueWatching';
 
 /// Builds user-defined Home rows from normalized hubs and real collection items.
 List<MediaHub> buildConfiguredHomeSections({
@@ -13,6 +25,8 @@ List<MediaHub> buildConfiguredHomeSections({
   Map<String, MediaKind> collectionLibraryKinds = const {},
   List<String> rowOrder = const [],
   Map<String, List<MediaItem>> singleCollectionContents = const {},
+  Map<String, ManagedHubHeroOverride> managedHubHeroOverrides = const {},
+  MediaHub? continueWatchingHub,
 }) {
   final output = <MediaHub>[];
   for (final section in sections.where((s) => s.enabled && s.showOnHome)) {
@@ -33,10 +47,23 @@ List<MediaHub> buildConfiguredHomeSections({
         type: singleCollection != null ? 'mixed' : (section.isCollectionRow ? 'collection' : 'mixed'),
         items: _dedupe(items),
         size: items.length,
+        heroStyle: section.heroStyle,
+        heroTrailerPreview: section.heroTrailerPreview,
       ),
     );
   }
-  final combined = [...output, ...sourceHubs];
+  final resolvedSourceHubs = [for (final hub in sourceHubs) _withResolvedHeroOverride(hub, managedHubHeroOverrides)];
+  // Same "no empty rows" rule every other row in this function follows (see
+  // the `if (items.isEmpty) continue;` above) -- an empty Continue Watching
+  // hub would otherwise show as a real row with nothing in it.
+  final continueWatchingOverride = managedHubHeroOverrides[continueWatchingHeroOverrideKey];
+  final resolvedContinueWatchingHub = (continueWatchingHub == null || continueWatchingHub.items.isEmpty)
+      ? null
+      : continueWatchingHub.copyWith(
+          heroStyle: continueWatchingOverride?.heroStyle ?? false,
+          heroTrailerPreview: continueWatchingOverride?.heroTrailerPreview ?? false,
+        );
+  final combined = [?resolvedContinueWatchingHub, ...output, ...resolvedSourceHubs];
   if (rowOrder.isEmpty) return combined;
 
   // home_row_order (the Organizer, what Settings actually shows and lets the
@@ -63,6 +90,10 @@ List<MediaHub> buildConfiguredHomeSections({
   final byLibrary = <String, List<MediaHub>>{};
   final untrackable = <MediaHub>[];
   for (final hub in combined) {
+    if (hub.id == 'continue_watching') {
+      custom[continueWatchingRowToken] = hub;
+      continue;
+    }
     final customSection = sections.where((section) => section.id == hub.id).firstOrNull;
     if (customSection != null) {
       custom['custom:${customSection.id}'] = hub;
@@ -91,7 +122,9 @@ List<MediaHub> buildConfiguredHomeSections({
   final usedHubs = <MediaHub>{};
   final ordered = <MediaHub>[];
   for (final token in rowOrder) {
-    final hub = token.startsWith('custom:') ? custom[token] : resolvePlexToken(token);
+    final hub = (token.startsWith('custom:') || token == continueWatchingRowToken)
+        ? custom[token]
+        : resolvePlexToken(token);
     if (hub != null && usedHubs.add(hub)) ordered.add(hub);
   }
   return [...ordered, ...untrackable];
@@ -132,6 +165,29 @@ String? _hubLibraryGlobalKey(MediaHub hub) {
   final libraryId = _hubLibraryId(hub);
   if (serverId == null || libraryId == null) return null;
   return buildGlobalKey(ServerId(serverId), libraryId);
+}
+
+/// Attaches a native hub's saved Hero/Trailer override, if any. Overrides
+/// are saved keyed by `'<library.globalKey>::<managementApiIdentifier>'`
+/// (see `home_layout_settings_screen.dart`), but a fetched hub only carries
+/// its *content*-API identifier -- the same management-vs-content identifier
+/// mismatch `resolvePlexToken` above already works around, so this applies
+/// the identical (server, library)-scoped prefix match rather than exact
+/// string equality.
+MediaHub _withResolvedHeroOverride(MediaHub hub, Map<String, ManagedHubHeroOverride> overrides) {
+  if (overrides.isEmpty) return hub;
+  final libraryGlobalKey = _hubLibraryGlobalKey(hub);
+  if (libraryGlobalKey == null) return hub;
+  final actual = hub.identifier ?? hub.id;
+  final prefix = '$libraryGlobalKey::';
+  for (final entry in overrides.entries) {
+    if (!entry.key.startsWith(prefix)) continue;
+    final wantedIdentifier = entry.key.substring(prefix.length);
+    if (actual == wantedIdentifier || actual.startsWith('$wantedIdentifier.')) {
+      return hub.copyWith(heroStyle: entry.value.heroStyle, heroTrailerPreview: entry.value.heroTrailerPreview);
+    }
+  }
+  return hub;
 }
 
 /// The Plex client never sets [MediaHub.libraryId] itself (the section id it

--- a/lib/utils/home_section_builder.dart
+++ b/lib/utils/home_section_builder.dart
@@ -12,6 +12,17 @@ import '../utils/global_key_utils.dart';
 /// key shape every other managed-hub override uses.
 const continueWatchingHeroOverrideKey = 'builtin::continue_watching';
 
+/// Same idea as [continueWatchingHeroOverrideKey], but for a specific
+/// library's own section-scoped Continue Watching hub (shown on that
+/// library's Recommended tab, e.g. `LibraryRecommendedTab`) rather than the
+/// app-wide one on Home. Plex gives that hub a dynamic identifier
+/// (`movie.inprogress.<n>`, the trailing number varying per fetch), so this
+/// is keyed the same deliberately-not-identifier-matched way as Home's own
+/// Continue Watching, just scoped per library instead of being a single
+/// global key.
+String libraryContinueWatchingHeroOverrideKey(String libraryGlobalKey) =>
+    'builtin::continue_watching::$libraryGlobalKey';
+
 /// Row-order token for Continue Watching once it's enabled (see
 /// `SettingsService.continueWatchingOnHome`) — parallels `custom:<id>` and
 /// `plex:<server>:<library>:<identifier>` for the other row kinds.
@@ -52,7 +63,7 @@ List<MediaHub> buildConfiguredHomeSections({
       ),
     );
   }
-  final resolvedSourceHubs = [for (final hub in sourceHubs) _withResolvedHeroOverride(hub, managedHubHeroOverrides)];
+  final resolvedSourceHubs = [for (final hub in sourceHubs) withResolvedHeroOverride(hub, managedHubHeroOverrides)];
   // Same "no empty rows" rule every other row in this function follows (see
   // the `if (items.isEmpty) continue;` above) -- an empty Continue Watching
   // hub would otherwise show as a real row with nothing in it.
@@ -174,7 +185,23 @@ String? _hubLibraryGlobalKey(MediaHub hub) {
 /// mismatch `resolvePlexToken` above already works around, so this applies
 /// the identical (server, library)-scoped prefix match rather than exact
 /// string equality.
-MediaHub _withResolvedHeroOverride(MediaHub hub, Map<String, ManagedHubHeroOverride> overrides) {
+///
+/// Public (not `_`-prefixed) so [LibraryRecommendedTab] can apply the same
+/// overrides to a library's own Recommended tab, not just the Home screen —
+/// per the spec, Hero/Trailer settings should follow a row wherever it's
+/// shown, not just its Home appearance.
+/// Whether [hub]'s own *content*-API identifier matches [wantedIdentifier]
+/// — a saved *management*-API identifier (see `home_layout_settings_screen`
+/// / `resolvePlexToken` above for why the two can't be compared for exact
+/// equality). Public so `LibraryRecommendedTab` can sort its fetched hubs
+/// into a library's saved custom row order using the same rule Home's own
+/// row order already relies on.
+bool hubIdentifierMatches(MediaHub hub, String wantedIdentifier) {
+  final actual = hub.identifier ?? hub.id;
+  return actual == wantedIdentifier || actual.startsWith('$wantedIdentifier.');
+}
+
+MediaHub withResolvedHeroOverride(MediaHub hub, Map<String, ManagedHubHeroOverride> overrides) {
   if (overrides.isEmpty) return hub;
   final libraryGlobalKey = _hubLibraryGlobalKey(hub);
   if (libraryGlobalKey == null) return hub;

--- a/lib/utils/media_hub_ordering.dart
+++ b/lib/utils/media_hub_ordering.dart
@@ -13,7 +13,14 @@ bool sortMediaHubsByLibraryOrder(List<MediaHub> hubs, List<MediaLibrary> library
     orderByGlobalKey.putIfAbsent(libraryOrder[i].globalKey, () => i);
   }
 
-  final indexedHubs = [for (var i = 0; i < hubs.length; i++) (index: i, hub: hubs[i])];
+  // Configured rows can contain items from several libraries. Their position
+  // is controlled by home_row_order, so keep them out of the library sorter.
+  final sortableIndexes = [
+    for (var i = 0; i < hubs.length; i++)
+      if (!_isConfiguredHomeRow(hubs[i])) i,
+  ];
+  if (sortableIndexes.length < 2) return false;
+  final indexedHubs = [for (final i in sortableIndexes) (index: i, hub: hubs[i])];
   indexedHubs.sort((a, b) {
     final aIndex = _hubLibraryOrderIndex(a.hub, orderByGlobalKey);
     final bIndex = _hubLibraryOrderIndex(b.hub, orderByGlobalKey);
@@ -27,13 +34,16 @@ bool sortMediaHubsByLibraryOrder(List<MediaHub> hubs, List<MediaLibrary> library
   });
 
   var changed = false;
-  for (var i = 0; i < hubs.length; i++) {
+  for (var i = 0; i < indexedHubs.length; i++) {
+    final targetIndex = sortableIndexes[i];
     final hub = indexedHubs[i].hub;
-    if (!identical(hubs[i], hub)) changed = true;
-    hubs[i] = hub;
+    if (!identical(hubs[targetIndex], hub)) changed = true;
+    hubs[targetIndex] = hub;
   }
   return changed;
 }
+
+bool _isConfiguredHomeRow(MediaHub hub) => hub.identifier?.startsWith('configured.') ?? false;
 
 int? _hubLibraryOrderIndex(MediaHub hub, Map<String, int> orderByGlobalKey) {
   final hubLibraryKey = _globalKey(serverIdOrNull(hub.serverId), hub.libraryId);

--- a/lib/widgets/hero_hub_section.dart
+++ b/lib/widgets/hero_hub_section.dart
@@ -10,20 +10,24 @@ import '../media/media_hub.dart';
 import '../media/media_item.dart';
 import '../media/media_item_types.dart';
 import '../media/media_server_client.dart';
+import '../mpv/video.dart';
 import '../providers/watch_state_store.dart';
-import '../utils/provider_extensions.dart';
+import '../services/hover_trailer_service.dart';
 import '../services/settings_service.dart';
 import '../theme/mono_tokens.dart';
+import '../utils/app_logger.dart';
 import '../utils/content_utils.dart';
 import '../utils/formatters.dart';
 import '../utils/layout_constants.dart';
 import '../utils/media_navigation_helper.dart';
 import '../utils/platform_detector.dart';
+import '../utils/provider_extensions.dart';
 import '../utils/video_player_navigation.dart';
-import '../widgets/clickable_cursor.dart';
-import '../widgets/cycling_media_backdrop.dart';
-import '../widgets/fitting_title_text.dart';
-import '../widgets/optimized_media_image.dart' show ClearLogoImage, blurArtwork;
+import 'clickable_cursor.dart';
+import 'cycling_media_backdrop.dart';
+import 'fitting_title_text.dart';
+import 'hover_preview/hover_preview_player_controller.dart';
+import 'optimized_media_image.dart' show ClearLogoImage, blurArtwork;
 import '../i18n/strings.g.dart';
 
 /// A per-row hero banner: backdrop, title, play button, description, paging
@@ -38,19 +42,36 @@ import '../i18n/strings.g.dart';
 /// to parallax against, so this uses only the fade/zoom-in entrance effect,
 /// independent of scroll position.
 ///
-/// Trailer-preview (dwell-triggered playback) is intentionally not wired up
-/// here yet — hero-row rendering is the must-have per the spec, trailer is
-/// the stretch goal layered on top in a follow-up pass.
+/// Trailer-preview trigger model (revised 2026-09-10 after hands-on testing
+/// showed the original "dwell while auto-rotating" design fighting itself
+/// across every hero row mounted at once): auto-rotation is purely
+/// visibility-based and runs identically whether or not a row has trailers
+/// enabled — see [_isVisible]/[_computeIsVisible]. A trailer only starts
+/// on genuine mouse hover (or, on TV, d-pad focus — not yet wired, see
+/// [_onHoverEnter]) over the specific card, after a 3s dwell, and stops the
+/// instant hover ends. Paging to a new item — by arrow, by auto-rotate, or
+/// by a trailer finishing — always requires a fresh dwell before that new
+/// item's trailer can start, even if the pointer never physically moved
+/// (see the `onPageChanged` handling in [build]).
 class HeroHubSection extends StatefulWidget {
   const HeroHubSection({
     super.key,
     required this.hub,
     required this.onVerticalNavigation,
+    required this.playerController,
     this.onNavigateUp,
     this.onNavigateToSidebar,
   });
 
   final MediaHub hub;
+
+  /// Shared, not owned by this widget — Windows' native video plugin only
+  /// backs one process-wide video core, so only one hero/hover-preview
+  /// trailer can actually be playing anywhere in the app at a time,
+  /// regardless of how many hero rows are configured. Owned by
+  /// DiscoverScreen (also where the global mute icon lives) and passed
+  /// down, matching the same pattern the hover-preview rows already use.
+  final HoverPreviewPlayerController playerController;
 
   /// Same contract as [HubSection.onVerticalNavigation]: return true if this
   /// row handled the up/down request itself (e.g. moving between paged
@@ -67,21 +88,194 @@ class HeroHubSectionState extends State<HeroHubSection> {
   static const _autoScrollDuration = Duration(seconds: 8);
   static const _indicatorUpdateInterval = Duration(milliseconds: 50);
 
+  /// Per the spec: dwell for 3 seconds on a hero item before its trailer
+  /// starts. Deliberately shorter than [_autoScrollDuration] — trailer-off
+  /// hero rows still just auto-advance every 8s, only trailer-on rows use
+  /// this faster dwell instead of advancing.
+  static const _trailerDwellDuration = Duration(seconds: 3);
+
+  /// Confirmed via the native source (windows/runner/mpv/mpv_plugin.cpp +
+  /// flutter_window.cpp): the video's child HWND is parented directly to
+  /// Flutter's own rendering window, so by basic Win32 rules it always
+  /// paints over Flutter's own content within its bounds — no widget, in
+  /// any part of the tree, can ever appear on top of it. Genuine
+  /// non-overlap is therefore the only sound approach: this insets the
+  /// video just enough to leave the arrow buttons and the title/summary
+  /// safe zone (see [_buildOverlayContent]) clear of its rect.
+  static const _videoSideInset = 56.0;
+
   final _pageController = PageController();
   final _focusNode = FocusNode(debugLabel: 'hero_hub_section');
   final _indicatorProgress = ValueNotifier<double>(0.0);
   final _currentIndex = ValueNotifier<int>(0);
+  final _trailerResolver = HoverPreviewSourceResolver();
+
+  /// Key on the title/facts/summary/play-button block so its real rendered
+  /// height can be measured after layout — the video's own bottom inset is
+  /// sized to exactly this (see [_measureContentBlock]) rather than a
+  /// guessed fraction of [heroHeight], so the video gets as much of the
+  /// card as it genuinely can without ever touching the text underneath it.
+  final _contentBlockKey = GlobalKey();
+
+  /// Bottom inset the video needs to clear the content block, from the most
+  /// recent measurement — null until the first item has been laid out once,
+  /// at which point [_videoBottomInset] falls back to a rough fraction of
+  /// [heroHeight] for that first frame only.
+  double? _measuredVideoBottomInset;
+
+  double _videoBottomInset(double heroHeight, bool isTv) => _measuredVideoBottomInset ?? (isTv ? 140.0 : 110.0);
+
+  /// Measures the content block actually painted this frame and, if it
+  /// differs from what the video is currently inset by, schedules a rebuild
+  /// with the corrected inset. [bottomAnchor] is the same offset
+  /// [_buildOverlayContent] anchors the block's own bottom edge to (its
+  /// `Positioned.bottom`), so the video's inset covers the anchor gap too,
+  /// not just the block's own height.
+  void _measureContentBlock(double bottomAnchor) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final renderBox = _contentBlockKey.currentContext?.findRenderObject();
+      if (renderBox is! RenderBox || !renderBox.hasSize) return;
+      final needed = bottomAnchor + renderBox.size.height;
+      if (_measuredVideoBottomInset != null && (needed - _measuredVideoBottomInset!).abs() < 1.0) return;
+      setState(() => _measuredVideoBottomInset = needed);
+    });
+  }
 
   Timer? _autoScrollTimer;
   Timer? _indicatorTimer;
   bool _isAutoScrollPaused = false;
+
+  /// The scrollable this row lives in doesn't lazily unmount off-screen
+  /// slivers (every hub is a plain SliverToBoxAdapter, always built), so
+  /// without a visibility check every hero row on the page — not just the
+  /// one actually on screen — would auto-rotate at once regardless of
+  /// scroll position. Per the spec this is now a pure "any part of the row
+  /// overlaps the viewport" check, not a narrow centered-band — auto-
+  /// rotation should run "if they are visible on the screen at all",
+  /// independent of trailer-enabled status (revised 2026-09-10; the
+  /// earlier centered-band gate existed to solve a different problem — all
+  /// rows fighting over the single shared trailer player — which hover-
+  /// exclusivity now solves on its own).
+  bool _isVisible = false;
+  ScrollPosition? _scrollPosition;
+
+  bool _computeIsVisible() {
+    final renderObject = context.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.attached) return false;
+    final scrollable = Scrollable.maybeOf(context);
+    final viewportRenderObject = scrollable?.context.findRenderObject();
+    if (viewportRenderObject is! RenderBox) return false;
+    final viewportHeight = viewportRenderObject.size.height;
+    final topLeft = renderObject.localToGlobal(Offset.zero, ancestor: viewportRenderObject);
+    final top = topLeft.dy;
+    final bottom = top + renderObject.size.height;
+    return bottom > 0 && top < viewportHeight;
+  }
+
+  void _onScrollChanged() {
+    // The native video plane's on-screen position is only recomputed on a
+    // real Flutter layout pass — plain scrolling moves this row via the
+    // Scrollable's paint transform alone, which the video plugin has no way
+    // to observe, so it keeps rendering at its last-known screen position
+    // while the app scrolls underneath it (looks exactly like "a second
+    // window I can't get rid of", reported 2026-09-10). Stop on ANY scroll
+    // rather than try to keep a native plane glued to a Scrollable's offset.
+    if (_trailerIndex != null) _stopTrailer();
+
+    final visible = _computeIsVisible();
+    if (visible == _isVisible) return;
+    _isVisible = visible;
+    if (!_isVisible) {
+      _autoScrollTimer?.cancel();
+      _indicatorTimer?.cancel();
+      _hoverDwellTimer?.cancel();
+    } else {
+      _startAutoScroll();
+    }
+  }
+
+  /// Index of the item currently showing a trailer in place of its static
+  /// backdrop, or null if none is (this row might not even be the one
+  /// playing — [widget.playerController] is shared across every hero row on
+  /// screen, since only one video can physically play at once).
+  int? _trailerIndex;
+  int _trailerRequestToken = 0;
+
+  /// True while the pointer is genuinely hovering the current card of a
+  /// trailer-enabled row. Drives the dwell timer directly — no more
+  /// starting a trailer just because a row happened to auto-rotate into
+  /// view; per spec it should "just sit on the poster card" until actually
+  /// hovered (or, on TV, focused — not yet wired here).
+  bool _isHovering = false;
+  Timer? _hoverDwellTimer;
+
+  /// Continue Watching hero rows preview the user's actual resume point
+  /// instead of a trailer (per user request 2026-09-10: "don't play the
+  /// trailer, play the first 30 seconds of where you left off... if you
+  /// click play it resumes"). [_trailerResolver.resolve]'s own
+  /// `preferResumePosition` already resolves that clip when this is true —
+  /// this only decides whether to ask for it, not how it's fetched.
+  bool get _isContinueWatching => widget.hub.isContinueWatchingHub;
+
+  /// Caps a Continue Watching row's resume-clip preview at 30s of playback
+  /// — there's no natural end-of-stream to key off since it's the real
+  /// file, not a short trailer, so this manufactures one, then goes back to
+  /// hero art exactly like a trailer that finished on its own.
+  static const _resumeClipPreviewCap = Duration(seconds: 30);
+  Timer? _resumeClipCapTimer;
 
   List<MediaItem> get _items => widget.hub.items;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _startAutoScroll());
+    widget.playerController.addListener(_onPlayerStateChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _isVisible = _computeIsVisible();
+      if (_isVisible) _startAutoScroll();
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final newPosition = Scrollable.maybeOf(context)?.position;
+    if (newPosition != _scrollPosition) {
+      _scrollPosition?.removeListener(_onScrollChanged);
+      _scrollPosition = newPosition;
+      _scrollPosition?.addListener(_onScrollChanged);
+    }
+  }
+
+  /// A failed or naturally-completed trailer only stops rendering it (via
+  /// the ListenableBuilder in _buildHeroItem) — without this, _trailerIndex
+  /// stays set forever, and _startAutoScroll's "already playing, nothing to
+  /// dwell toward" guard would permanently freeze this row instead of
+  /// resuming normal auto-advance. Ignores changes that aren't about a
+  /// trailer THIS row started (_trailerIndex == null means nothing here is
+  /// tracked as playing, regardless of what the shared controller is doing
+  /// for some other row).
+  void _onPlayerStateChanged() {
+    if (_trailerIndex == null) return;
+    if (widget.playerController.playbackCompleted) {
+      // Per spec: a trailer that finishes on its own goes back to the hero
+      // art for the SAME item, not straight on to the next one — the user
+      // is still hovering it, there's just nothing left to play.
+      // _startAutoScroll re-arms the normal visibility-based rotation clock
+      // for this item (it already no-ops while still hovered, same as any
+      // other transition).
+      _resumeClipCapTimer?.cancel();
+      setState(() => _trailerIndex = null);
+      _startAutoScroll();
+    } else if (widget.playerController.playbackFailed) {
+      // A broken stream, unlike a clean finish, has nothing worth sitting
+      // on — advance past it so a bad trailer URL can't freeze the row.
+      _resumeClipCapTimer?.cancel();
+      setState(() => _trailerIndex = null);
+      _advancePage();
+    }
   }
 
   @override
@@ -94,8 +288,17 @@ class HeroHubSectionState extends State<HeroHubSection> {
 
   @override
   void dispose() {
+    // Stop, don't dispose — playerController is shared and owned by
+    // DiscoverScreen, not this row. Only stop it if THIS row was actually
+    // the one playing, so unmounting an unrelated hero row (e.g. reordered
+    // out of view) can't cut off a different row's trailer.
+    if (_trailerIndex != null) unawaited(widget.playerController.stop());
+    widget.playerController.removeListener(_onPlayerStateChanged);
+    _scrollPosition?.removeListener(_onScrollChanged);
     _autoScrollTimer?.cancel();
     _indicatorTimer?.cancel();
+    _hoverDwellTimer?.cancel();
+    _resumeClipCapTimer?.cancel();
     _pageController.dispose();
     _focusNode.dispose();
     _indicatorProgress.dispose();
@@ -107,26 +310,180 @@ class HeroHubSectionState extends State<HeroHubSection> {
 
   void requestFocusFromMemory() => _focusNode.requestFocus();
 
+  bool get _trailerEnabled => widget.hub.heroTrailerPreview;
+
+  /// Plain periodic auto-advance — identical for every row, trailer-enabled
+  /// or not, gated only on visibility (and, for trailer rows, not currently
+  /// hovered/playing). TV dwell-trailer (d-pad focus instead of mouse hover)
+  /// needs its own integration with the TV spotlight/focus system this
+  /// widget doesn't have yet — deliberately out of scope for this pass, so
+  /// TV keeps the pre-existing early-return here.
   void _startAutoScroll() {
     _autoScrollTimer?.cancel();
-    if (PlatformDetector.isTV() || _isAutoScrollPaused || !mounted) return;
+    if (PlatformDetector.isTV() || _isAutoScrollPaused || !mounted || !_isVisible) return;
+    if (_isHovering && _trailerEnabled) return; // the hover dwell timer owns the schedule right now
+    if (_trailerIndex != null) return; // trailer currently playing this slide
 
     _startIndicatorProgress();
     _autoScrollTimer = Timer.periodic(_autoScrollDuration, (timer) {
-      if (_items.isEmpty || !_pageController.hasClients || _isAutoScrollPaused) return;
-      if (_currentIndex.value >= _items.length) _currentIndex.value = 0;
-      final nextPage = (_currentIndex.value + 1) % _items.length;
-      _pageController.animateToPage(nextPage, duration: const Duration(milliseconds: 500), curve: Curves.easeInOut);
-      Future.delayed(const Duration(milliseconds: 500), () {
-        if (mounted && !_isAutoScrollPaused) _startIndicatorProgress();
-      });
+      if (_isAutoScrollPaused) return;
+      _advancePage();
     });
+  }
+
+  /// Pages to the next item. [onPageChanged] (in [build]) does all the
+  /// actual timer/dwell restart work once the index actually changes —
+  /// shared by plain auto-advance and every trailer outcome (played to
+  /// completion, failed, or nothing to play), so a trailer-enabled row
+  /// always eventually keeps moving through its items instead of freezing
+  /// on whichever one it dwelled on first.
+  void _advancePage() {
+    if (_items.isEmpty || !_pageController.hasClients) return;
+    if (_currentIndex.value >= _items.length) _currentIndex.value = 0;
+    final nextPage = (_currentIndex.value + 1) % _items.length;
+    _pageController.animateToPage(nextPage, duration: const Duration(milliseconds: 500), curve: Curves.easeInOut);
+  }
+
+  /// Pointer entered this specific card. Only trailer-enabled rows react —
+  /// plain rows keep auto-rotating through hover untouched. Starts a fresh
+  /// 3s dwell before actually calling [_startTrailer]; per spec nothing
+  /// should play "unless the cursor... is [over it]", so hover is the only
+  /// thing that can ever arm this timer.
+  void _onHoverEnter(int index) {
+    if (PlatformDetector.isTV() || !_trailerEnabled) return;
+    _isHovering = true;
+    _autoScrollTimer?.cancel();
+    _indicatorTimer?.cancel();
+    if (_trailerIndex == index) return; // already playing this exact slide
+    _hoverDwellTimer?.cancel();
+    _hoverDwellTimer = Timer(_trailerDwellDuration, () {
+      if (!mounted || !_isHovering) return;
+      unawaited(_startTrailer());
+    });
+  }
+
+  /// Pointer left the card. Stops any trailer instantly (per spec: "move
+  /// it, it stops instantly... otherwise it should just sit on the poster
+  /// card") and resumes normal auto-rotation on the current item rather
+  /// than skipping ahead.
+  void _onHoverExit() {
+    if (PlatformDetector.isTV() || !_trailerEnabled) return;
+    _isHovering = false;
+    _hoverDwellTimer?.cancel();
+    if (_trailerIndex != null) _stopTrailer();
+    _startAutoScroll();
+  }
+
+  /// `PlayerNative.open()` calls `setVisible(true)` on the shared native
+  /// child HWND right at its own start (player_native.dart), before media
+  /// even loads — showing that window at whatever rect it was last
+  /// positioned to. The just-mounted [Video] widget's own on-screen rect
+  /// only reaches native from a `postFrameCallback` registered during ITS
+  /// first layout pass, which only happens on Flutter's next frame after
+  /// the `setState` that mounts it. Without waiting here, the shared HWND
+  /// pops up at the previous card's position (or the native default
+  /// 0,0,100x100 on the very first play ever) before ever being told where
+  /// this card actually is — confirmed by reading both call sites directly,
+  /// not guessed; this is the "secondary popup not covering the card" bug
+  /// reported 2026-09-10. One frame is enough: Dart resumes an `await`
+  /// continuation as a microtask, so the rect-push callback (registered and
+  /// invoked synchronously within the same postFrameCallback pass this
+  /// waiter's own callback fires in) has already dispatched its channel
+  /// message by the time control returns to this function.
+  Future<void> _waitForNextFrame() {
+    final completer = Completer<void>();
+    WidgetsBinding.instance.addPostFrameCallback((_) => completer.complete());
+    return completer.future;
+  }
+
+  /// Resolves and plays a trailer/scene clip for whatever item is currently
+  /// showing, in place of its static backdrop. Guarded by
+  /// [_trailerRequestToken] so a resolution that finishes after the user has
+  /// already paged away (during the async gap) can't start playing over the
+  /// wrong item.
+  Future<void> _startTrailer() async {
+    if (_currentIndex.value >= _items.length) return;
+    // The raw hub item's own viewOffsetMs can be stale — it's whatever Plex
+    // returned whenever this hub was last fetched, not necessarily the
+    // user's actual latest position (e.g. updated from another
+    // session/device since). WatchStateStore tracks the real current value
+    // separately; _buildPlayButton already refreshes through it for the
+    // same reason. Without this, Continue Watching's resume-clip preview
+    // (_isContinueWatching below) only worked for whichever items' stale
+    // hub data happened to still be accurate — the "works for some movies"
+    // bug reported 2026-09-10.
+    final item = context.readFreshWatchState(_items[_currentIndex.value]);
+    final client = _clientFor(item);
+    if (client == null) {
+      _advancePage(); // no client to resolve against - don't freeze here
+      return;
+    }
+    final requestIndex = _currentIndex.value;
+    final token = ++_trailerRequestToken;
+    final HoverPreviewSource source;
+    try {
+      source = await _trailerResolver.resolve(client, item, preferResumePosition: _isContinueWatching);
+    } catch (e) {
+      appLogger.d('[hero-trailer] resolve FAILED id=${item.id}: $e');
+      if (token == _trailerRequestToken) _advancePage();
+      return;
+    }
+    // Also bail if hover ended during the resolve gap — otherwise a trailer
+    // can start playing for a card the pointer has already left, which is
+    // exactly the "should just sit on the poster card" case the hover gate
+    // exists to prevent.
+    if (!mounted || token != _trailerRequestToken || !_isHovering) return;
+    switch (source) {
+      case TrailerPreviewSource(:final streamUrl):
+        appLogger.i('[hero-trailer] playing trailer for "${item.title}": $streamUrl');
+        setState(() => _trailerIndex = requestIndex);
+        await _waitForNextFrame();
+        if (!mounted || token != _trailerRequestToken || !_isHovering) return;
+        await widget.playerController.play(streamUrl);
+      case SceneClipPreviewSource(:final streamUrl, :final startOffset):
+        appLogger.i('[hero-trailer] playing scene clip for "${item.title}" at $startOffset: $streamUrl');
+        setState(() => _trailerIndex = requestIndex);
+        await _waitForNextFrame();
+        if (!mounted || token != _trailerRequestToken || !_isHovering) return;
+        await widget.playerController.play(streamUrl, startAt: startOffset);
+        if (_isContinueWatching && mounted && token == _trailerRequestToken) {
+          _resumeClipCapTimer?.cancel();
+          _resumeClipCapTimer = Timer(_resumeClipPreviewCap, () {
+            if (!mounted || token != _trailerRequestToken || _trailerIndex != requestIndex) return;
+            setState(() => _trailerIndex = null);
+            unawaited(widget.playerController.stop());
+            _startAutoScroll();
+          });
+        }
+      case NoPreviewSource():
+        // Nothing to play for this item - move on rather than freezing here
+        // forever (this dwell timer is one-shot, nothing else would ever
+        // re-arm it otherwise).
+        appLogger.d('[hero-trailer] no preview source for "${item.title}"');
+        _advancePage();
+    }
+  }
+
+  /// Stops any trailer this row started and clears its slide marker. Called
+  /// on any manual navigation (paging, tapping away) so leaving an item
+  /// always leaves its trailer behind rather than carrying it onto the next
+  /// one, per spec ("moving to the next hero item stops the preview
+  /// instantly"). Safe to call even if a DIFFERENT row is the one actually
+  /// playing — only tears down playback if this row believes it owns it.
+  void _stopTrailer() {
+    _trailerRequestToken++; // invalidate any in-flight resolve/play
+    _resumeClipCapTimer?.cancel();
+    if (_trailerIndex == null) return;
+    setState(() => _trailerIndex = null);
+    unawaited(widget.playerController.stop());
   }
 
   void _startIndicatorProgress() {
     if (!mounted) return;
     _indicatorTimer?.cancel();
     _indicatorProgress.value = 0.0;
+    // Only ever called for the plain auto-advance schedule now — hover-
+    // gated trailer dwell doesn't drive this indicator.
     final totalSteps = _autoScrollDuration.inMilliseconds ~/ _indicatorUpdateInterval.inMilliseconds;
     var step = 0;
     _indicatorTimer = Timer.periodic(_indicatorUpdateInterval, (timer) {
@@ -157,6 +514,33 @@ class HeroHubSectionState extends State<HeroHubSection> {
     final center = _currentIndex.value;
     final start = (center - 2).clamp(0, total - 5);
     return (start: start, end: start + 4);
+  }
+
+  Widget _buildArrowButton({required bool isLeft, required int currentIndex}) {
+    final enabled = isLeft ? currentIndex > 0 : currentIndex < _items.length - 1;
+    return ClickableCursor(
+      child: GestureDetector(
+        onTap: !enabled
+            ? null
+            : () {
+                if (isLeft) {
+                  _pageController.previousPage(duration: tokens(context).slow, curve: Curves.easeInOut);
+                } else {
+                  _pageController.nextPage(duration: tokens(context).slow, curve: Curves.easeInOut);
+                }
+              },
+        child: Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(color: Colors.black.withValues(alpha: 0.4), shape: BoxShape.circle),
+          child: AppIcon(
+            isLeft ? Symbols.chevron_left_rounded : Symbols.chevron_right_rounded,
+            color: Colors.white.withValues(alpha: enabled ? 1.0 : 0.3),
+            size: 22,
+          ),
+        ),
+      ),
+    );
   }
 
   double _dotSize(int dotIndex, int start, int end) {
@@ -196,14 +580,72 @@ class HeroHubSectionState extends State<HeroHubSection> {
               controller: _pageController,
               itemCount: _items.length,
               onPageChanged: (index) {
-                if (index >= 0 && index < _items.length) {
-                  _currentIndex.value = index;
-                  _autoScrollTimer?.cancel();
+                if (index < 0 || index >= _items.length) return;
+                _stopTrailer();
+                _currentIndex.value = index;
+                _autoScrollTimer?.cancel();
+                _indicatorTimer?.cancel();
+                _hoverDwellTimer?.cancel();
+                // Arriving at a new item — by arrow, by auto-rotate, or by
+                // the previous item's trailer finishing — always shows its
+                // poster first, never chains straight into its trailer, even
+                // if the pointer never physically left the card (e.g. it's
+                // still sitting over an arrow button). Only a genuinely
+                // fresh dwell earns that new item a trailer.
+                if (_isHovering && _trailerEnabled) {
+                  _hoverDwellTimer = Timer(_trailerDwellDuration, () {
+                    if (!mounted || !_isHovering) return;
+                    unawaited(_startTrailer());
+                  });
+                } else {
                   _startAutoScroll();
                 }
               },
-              itemBuilder: (context, index) => _buildHeroItem(context, _items[index], heroHeight),
+              itemBuilder: (context, index) => _buildHeroItem(context, _items[index], index, heroHeight),
             ),
+            // Row name — multiple hero rows can be on screen at once, so
+            // unlike the old single-hero-slot version there's otherwise no
+            // way to tell which configured row a given card is showing.
+            Positioned(
+              top: MediaQuery.paddingOf(context).top + (isTv ? TvLayoutConstants.horizontalInset : 16),
+              left: isTv ? TvLayoutConstants.horizontalInset : 16,
+              child: IgnorePointer(
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withValues(alpha: 0.35),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Text(
+                    widget.hub.title,
+                    style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.85),
+                      fontSize: isTv ? 16 : 12,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            if (!isTv && _items.length > 1)
+              Positioned.fill(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      ValueListenableBuilder<int>(
+                        valueListenable: _currentIndex,
+                        builder: (context, index, _) => _buildArrowButton(isLeft: true, currentIndex: index),
+                      ),
+                      ValueListenableBuilder<int>(
+                        valueListenable: _currentIndex,
+                        builder: (context, index, _) => _buildArrowButton(isLeft: false, currentIndex: index),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             if (!isTv)
               Positioned(
                 bottom: 16,
@@ -287,13 +729,162 @@ class HeroHubSectionState extends State<HeroHubSection> {
     );
   }
 
-  Widget _buildHeroItem(BuildContext context, MediaItem heroItem, double heroHeight) {
+  Widget _buildHeroItem(BuildContext context, MediaItem heroItem, int index, double heroHeight) {
     final client = _clientFor(heroItem);
     final isEpisode = heroItem.isEpisode;
-    final showName = heroItem.grandparentTitle ?? heroItem.displayTitle;
+    final isTv = PlatformDetector.isTV();
     final screenWidth = MediaQuery.sizeOf(context).width;
     final heroAspectRatio = screenWidth / heroHeight;
     final heroArtPaths = heroItem.heroArtCandidates(containerAspectRatio: heroAspectRatio);
+    final colorScheme = Theme.of(context).colorScheme;
+    final heroLabel = isEpisode ? '${heroItem.grandparentTitle}, ${heroItem.title}' : heroItem.title;
+
+    return Semantics(
+      label: heroLabel,
+      button: true,
+      hint: t.accessibility.tapToPlay,
+      child: MouseRegion(
+        onEnter: (_) => _onHoverEnter(index),
+        onExit: (_) => _onHoverExit(),
+        child: ClickableCursor(
+          child: GestureDetector(
+            onTap: () async {
+              // Captured before stop() below — that call doesn't touch
+              // _trailerIndex itself (only _stopTrailer does), but reading
+              // it after an await risks a rebuild changing it first.
+              final wasShowingTrailer = _trailerIndex == index;
+              // Stop and await the shared controller before handing off to
+              // real playback — Windows backs the whole app with one
+              // process-wide native video core; the video player screen
+              // initializing before this controller's own teardown finishes
+              // races for that same channel (observed as a hard crash on the
+              // old branch this was ported from). Resolves near-instantly
+              // when nothing's actually playing. Also worth doing before
+              // opening details — a trailer shouldn't keep playing in the
+              // background once the user has navigated away from the card.
+              await widget.playerController.stop();
+              if (!context.mounted) return;
+              // User-configurable (Home layout settings → "Hero cards") —
+              // some people want a tap to act like a remote (play
+              // immediately), others want it to browse first (open details,
+              // decide from there). Tapping the static poster and tapping a
+              // playing trailer are independently configurable (per user
+              // request 2026-09-10) — the same card can play on a poster tap
+              // but open details on a mid-trailer tap, or vice versa. The
+              // Play button in the overlay always plays directly regardless
+              // of either setting.
+              final tapAction = SettingsService.instance.read(
+                wasShowingTrailer ? SettingsService.heroCardTrailerTapAction : SettingsService.heroCardTapAction,
+              );
+              unawaited(navigateToMediaItem(context, heroItem, playDirectly: tapAction == HeroCardTapAction.play));
+            },
+            child: Stack(
+              fit: StackFit.expand,
+              clipBehavior: Clip.none,
+              children: [
+                // Backdrop art — always rendered, independent of trailer
+                // state, and unconditionally painted whether or not a
+                // trailer is currently showing over it.
+                if (heroArtPaths.isNotEmpty)
+                  TweenAnimationBuilder<double>(
+                    key: ValueKey(heroItem.globalKey),
+                    tween: Tween(begin: 0.0, end: 1.0),
+                    duration: const Duration(milliseconds: 800),
+                    curve: Curves.easeOut,
+                    builder: (context, value, child) {
+                      return Transform.scale(
+                        scale: 1.0 + (0.1 * (1 - value)),
+                        child: Opacity(opacity: value, child: child),
+                      );
+                    },
+                    child: blurArtwork(
+                      CyclingMediaBackdrop(
+                        mediaKey: heroItem.globalKey,
+                        imagePaths: heroItem.heroRotationPaths(containerAspectRatio: heroAspectRatio),
+                        fallbackImagePaths: heroArtPaths,
+                        client: client,
+                        active: true,
+                        width: screenWidth,
+                        height: heroHeight,
+                        fallbackColor: colorScheme.surfaceContainerHighest,
+                      ),
+                    ),
+                  )
+                else
+                  ColoredBox(color: colorScheme.surfaceContainerHighest),
+                // Reactive to widget.playerController, not a plain local bool —
+                // play() marks player non-null synchronously, before the
+                // stream has actually opened or decoded, and a resolved-but-
+                // broken stream only reveals itself asynchronously afterward
+                // via playbackFailed. Without listening here, a failed stream
+                // left a dead black video surface up permanently instead of
+                // falling back to the backdrop (the actual bug reported
+                // 2026-09-10) — this controller's own doc comment describes
+                // exactly this scenario and the fallback it's meant to enable;
+                // the hover-preview cards elsewhere already rely on it too.
+                //
+                // Inset, not full-bleed — confirmed via the native source
+                // (not a guess or an empirical trial-and-error): mpv's video
+                // child HWND is created as a child of
+                // registrar_->GetView()->GetNativeWindow() (mpv_plugin.cpp,
+                // FlutterWindow::OnCreate in flutter_window.cpp) — Flutter's
+                // OWN rendering surface. A Win32 child window always paints
+                // over its parent's content within its bounds; this is
+                // structural, not a z-order setting, so NO Flutter widget
+                // anywhere in the tree can ever appear on top of this video
+                // within its rect, full stop. Three different placements
+                // were tried and failed for exactly this reason (separate
+                // Positioned sibling, Video's own `controls` slot, and a
+                // row-level Stack) before finding this in the native code.
+                // The only sound fix is genuine non-overlap: keep the
+                // video's rect and _buildOverlayContent's rect from ever
+                // intersecting on screen. Side inset clears the arrow
+                // buttons; bottom inset is [_measuredVideoBottomInset] — the
+                // content block's actual measured height, not a guessed
+                // fraction — so the video gets as much of the card as it
+                // genuinely can (per spec: "add a space on the bottom that
+                // all that information can sit... [rest is] full video").
+                ListenableBuilder(
+                  listenable: widget.playerController,
+                  builder: (context, _) {
+                    final showTrailer =
+                        _trailerIndex == index &&
+                        widget.playerController.player != null &&
+                        !widget.playerController.playbackFailed;
+                    if (!showTrailer) return const SizedBox.shrink();
+                    return Positioned(
+                      top: 0,
+                      left: _videoSideInset,
+                      right: _videoSideInset,
+                      bottom: _videoBottomInset(heroHeight, isTv),
+                      child: ClipRect(child: Video(player: widget.playerController.player!)),
+                    );
+                  },
+                ),
+                _buildOverlayContent(context, heroItem, heroHeight, index),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Gradient + title/facts/summary/play button for one hero item. Called
+  /// unconditionally from [_buildHeroItem] (not gated on trailer state) so
+  /// this content never moves or flickers when playback starts or stops —
+  /// see the video inset comment there for why it has to stay genuinely
+  /// outside the video's own rect rather than drawn over it.
+  ///
+  /// [index] gates [_contentBlockKey] to only the currently-displayed page —
+  /// PageView keeps neighboring pages built (viewport/cache extent), so
+  /// every visible `_buildOverlayContent` call happens at once; attaching a
+  /// single GlobalKey to more than one of them at a time is an assertion
+  /// failure, not just a measurement bug.
+  Widget _buildOverlayContent(BuildContext context, MediaItem heroItem, double heroHeight, int index) {
+    final client = _clientFor(heroItem);
+    final showName = heroItem.grandparentTitle ?? heroItem.displayTitle;
+    final screenWidth = MediaQuery.sizeOf(context).width;
     final isLargeScreen = ScreenBreakpoints.isWideTabletOrLarger(screenWidth);
     final isTv = PlatformDetector.isTV();
     final alignLeft = isTv || isLargeScreen;
@@ -310,155 +901,214 @@ class HeroHubSectionState extends State<HeroHubSection> {
     final contentTypeLabel = heroItem.isMovie ? t.discover.movie : t.discover.tvShow;
     final hideSpoilers = SettingsService.instance.read(SettingsService.hideSpoilers);
     final shouldHideSpoiler = hideSpoilers && heroItem.shouldHideSpoiler;
-    final heroLabel = isEpisode ? '${heroItem.grandparentTitle}, ${heroItem.title}' : heroItem.title;
+    final isCurrentPage = index == _currentIndex.value;
+    final factsText = [
+      contentTypeLabel,
+      if (heroItem.rating != null) '★ ${formatRating(heroItem.rating!)}',
+      if (heroItem.contentRating != null) formatContentRating(heroItem.contentRating!),
+      if (heroItem.year != null) heroItem.year.toString(),
+    ].join(' • ');
+    // Title specifically opens the details/metadata page (playDirectly:
+    // false) rather than starting playback — a deliberately different
+    // action from tapping the rest of the card (plays directly) or the
+    // Play button (also plays directly). Nested inside the card's own
+    // GestureDetector in both layouts below; Flutter's gesture arena
+    // resolves a plain tap to whichever recognizer is innermost, so this
+    // wins over the card's own onTap without also triggering it.
+    void openDetails() => unawaited(navigateToMediaItem(context, heroItem));
 
-    return Semantics(
-      label: heroLabel,
-      button: true,
-      hint: t.accessibility.tapToPlay,
-      child: ClickableCursor(
-        child: GestureDetector(
-          onTap: () => navigateToMediaItem(context, heroItem, playDirectly: true),
-          child: Stack(
-            fit: StackFit.expand,
-            clipBehavior: Clip.none,
-            children: [
-              if (heroArtPaths.isNotEmpty)
-                TweenAnimationBuilder<double>(
-                  key: ValueKey(heroItem.globalKey),
-                  tween: Tween(begin: 0.0, end: 1.0),
-                  duration: const Duration(milliseconds: 800),
-                  curve: Curves.easeOut,
-                  builder: (context, value, child) {
-                    return Transform.scale(
-                      scale: 1.0 + (0.1 * (1 - value)),
-                      child: Opacity(opacity: value, child: child),
-                    );
-                  },
-                  child: blurArtwork(
-                    CyclingMediaBackdrop(
-                      mediaKey: heroItem.globalKey,
-                      imagePaths: heroItem.heroRotationPaths(containerAspectRatio: heroAspectRatio),
-                      fallbackImagePaths: heroArtPaths,
-                      client: client,
-                      active: true,
-                      width: screenWidth,
-                      height: heroHeight,
-                      fallbackColor: colorScheme.surfaceContainerHighest,
+    return Stack(
+      fit: StackFit.expand,
+      clipBehavior: Clip.none,
+      children: [
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: -4,
+          child: IgnorePointer(
+            child: Builder(
+              builder: (context) {
+                final bgColor = Theme.of(context).scaffoldBackgroundColor;
+                return Container(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Colors.transparent, bgColor.withValues(alpha: 0.9), bgColor, bgColor],
+                      stops: isTv ? const [0.25, 0.78, 0.94, 1.0] : const [0.5, 0.85, 0.94, 1.0],
                     ),
                   ),
-                )
-              else
-                ColoredBox(color: colorScheme.surfaceContainerHighest),
-              Positioned(
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: -4,
-                child: IgnorePointer(
-                  child: Builder(
-                    builder: (context) {
-                      final bgColor = Theme.of(context).scaffoldBackgroundColor;
-                      return Container(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [Colors.transparent, bgColor.withValues(alpha: 0.9), bgColor, bgColor],
-                            stops: isTv ? const [0.25, 0.78, 0.94, 1.0] : const [0.5, 0.85, 0.94, 1.0],
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ),
-              Positioned(
-                bottom: isTv
-                    ? 88
-                    : isLargeScreen
-                    ? 80
-                    : 50,
-                left: 0,
-                right: isTv
-                    ? screenWidth * 0.36
-                    : isLargeScreen
-                    ? 200
-                    : 0,
-                child: Padding(
-                  padding: EdgeInsets.symmetric(
-                    horizontal: isTv
-                        ? TvLayoutConstants.horizontalInset
-                        : isLargeScreen
-                        ? 40
-                        : 24,
-                  ),
-                  child: Align(
-                    alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        maxWidth: isTv ? TvLayoutConstants.heroContentMaxWidth : double.infinity,
-                      ),
-                      child: Column(
-                        crossAxisAlignment: alignLeft ? CrossAxisAlignment.start : CrossAxisAlignment.center,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          ClearLogoImage(
-                            client: client,
-                            logoPath: heroItem.clearLogoPath,
-                            width: heroLogoWidth,
-                            height: heroLogoHeight,
-                            alignment: alignLeft ? Alignment.bottomLeft : Alignment.bottomCenter,
-                            fallbackBuilder: (context) => FittingTitleText(
-                              showName,
-                              style: heroTitleStyle,
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                              alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
-                            ),
-                          ),
-                          if (heroItem.year != null || heroItem.contentRating != null || heroItem.rating != null) ...[
-                            const SizedBox(height: 16),
-                            Text(
-                              [
-                                contentTypeLabel,
-                                if (heroItem.rating != null) '★ ${formatRating(heroItem.rating!)}',
-                                if (heroItem.contentRating != null) formatContentRating(heroItem.contentRating!),
-                                if (heroItem.year != null) heroItem.year.toString(),
-                              ].join(' • '),
-                              style: TextStyle(
-                                color: colorScheme.onSurface,
-                                fontSize: isTv ? 18 : 14,
-                                fontWeight: FontWeight.w600,
-                              ),
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                            ),
-                          ],
-                          if (!alignLeft) ...[const SizedBox(height: 20), _buildPlayButton(context, heroItem)],
-                          if (heroItem.summary != null && !shouldHideSpoiler) ...[
-                            const SizedBox(height: 12),
-                            Text(
-                              heroItem.summary!,
-                              maxLines: isTv ? 3 : 2,
-                              overflow: TextOverflow.ellipsis,
-                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
-                              style: TextStyle(
-                                color: colorScheme.onSurface.withValues(alpha: 0.7),
-                                fontSize: isTv ? 18 : 14,
-                                height: isTv ? 1.45 : 1.4,
-                              ),
-                            ),
-                          ],
-                          if (alignLeft) ...[const SizedBox(height: 20), _buildPlayButton(context, heroItem)],
-                        ],
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
+                );
+              },
+            ),
           ),
         ),
-      ),
+        // Reactive: a genuinely compact strip while a trailer plays (per
+        // spec — "full screen like before and a strip at the bottom with
+        // the info" — so the video gets nearly the whole card), the full
+        // logo/facts/summary/play-button block otherwise, for the static
+        // poster where there's no video to make room for. Only the compact
+        // strip's height feeds [_measureContentBlock] — the full block
+        // never needs measuring since nothing insets around it.
+        ListenableBuilder(
+          listenable: widget.playerController,
+          builder: (context, _) {
+            final showTrailer =
+                _trailerIndex == index &&
+                widget.playerController.player != null &&
+                !widget.playerController.playbackFailed;
+            if (showTrailer) {
+              const compactBottomAnchor = 20.0;
+              if (isCurrentPage) _measureContentBlock(compactBottomAnchor);
+              return Positioned(
+                bottom: compactBottomAnchor,
+                left: 0,
+                right: 0,
+                child: Padding(
+                  key: isCurrentPage ? _contentBlockKey : null,
+                  padding: EdgeInsets.symmetric(horizontal: isTv ? TvLayoutConstants.horizontalInset : 24),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Expanded(
+                        child: ClickableCursor(
+                          child: GestureDetector(
+                            onTap: openDetails,
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  showName,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: colorScheme.onSurface,
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: isTv ? 24 : 18,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  factsText,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: colorScheme.onSurface.withValues(alpha: 0.8),
+                                    fontSize: isTv ? 14 : 12,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                if (heroItem.summary != null && !shouldHideSpoiler) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    heroItem.summary!,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: colorScheme.onSurface.withValues(alpha: 0.6),
+                                      fontSize: isTv ? 13 : 11,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      _buildPlayButton(context, heroItem),
+                    ],
+                  ),
+                ),
+              );
+            }
+            return Positioned(
+              bottom: isTv
+                  ? 88
+                  : isLargeScreen
+                  ? 80
+                  : 50,
+              left: 0,
+              right: isTv
+                  ? screenWidth * 0.36
+                  : isLargeScreen
+                  ? 200
+                  : 0,
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: isTv
+                      ? TvLayoutConstants.horizontalInset
+                      : isLargeScreen
+                      ? 40
+                      : 24,
+                ),
+                child: Align(
+                  alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      maxWidth: isTv ? TvLayoutConstants.heroContentMaxWidth : double.infinity,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: alignLeft ? CrossAxisAlignment.start : CrossAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        ClickableCursor(
+                          child: GestureDetector(
+                            onTap: openDetails,
+                            child: ClearLogoImage(
+                              client: client,
+                              logoPath: heroItem.clearLogoPath,
+                              width: heroLogoWidth,
+                              height: heroLogoHeight,
+                              alignment: alignLeft ? Alignment.bottomLeft : Alignment.bottomCenter,
+                              fallbackBuilder: (context) => FittingTitleText(
+                                showName,
+                                style: heroTitleStyle,
+                                textAlign: alignLeft ? TextAlign.left : TextAlign.center,
+                                alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
+                              ),
+                            ),
+                          ),
+                        ),
+                        if (heroItem.year != null || heroItem.contentRating != null || heroItem.rating != null) ...[
+                          const SizedBox(height: 16),
+                          Text(
+                            factsText,
+                            style: TextStyle(
+                              color: colorScheme.onSurface,
+                              fontSize: isTv ? 18 : 14,
+                              fontWeight: FontWeight.w600,
+                            ),
+                            textAlign: alignLeft ? TextAlign.left : TextAlign.center,
+                          ),
+                        ],
+                        if (!alignLeft) ...[const SizedBox(height: 20), _buildPlayButton(context, heroItem)],
+                        if (heroItem.summary != null && !shouldHideSpoiler) ...[
+                          const SizedBox(height: 12),
+                          Text(
+                            heroItem.summary!,
+                            maxLines: isTv ? 3 : 2,
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: alignLeft ? TextAlign.left : TextAlign.center,
+                            style: TextStyle(
+                              color: colorScheme.onSurface.withValues(alpha: 0.7),
+                              fontSize: isTv ? 18 : 14,
+                              height: isTv ? 1.45 : 1.4,
+                            ),
+                          ),
+                        ],
+                        if (alignLeft) ...[const SizedBox(height: 20), _buildPlayButton(context, heroItem)],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ],
     );
   }
 

--- a/lib/widgets/hero_hub_section.dart
+++ b/lib/widgets/hero_hub_section.dart
@@ -1,0 +1,511 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:material_symbols_icons/symbols.dart';
+import 'package:plezy/widgets/app_icon.dart';
+
+import '../focus/input_mode_tracker.dart';
+import '../media/ids.dart';
+import '../media/media_hub.dart';
+import '../media/media_item.dart';
+import '../media/media_item_types.dart';
+import '../media/media_server_client.dart';
+import '../providers/watch_state_store.dart';
+import '../utils/provider_extensions.dart';
+import '../services/settings_service.dart';
+import '../theme/mono_tokens.dart';
+import '../utils/content_utils.dart';
+import '../utils/formatters.dart';
+import '../utils/layout_constants.dart';
+import '../utils/media_navigation_helper.dart';
+import '../utils/platform_detector.dart';
+import '../utils/video_player_navigation.dart';
+import '../widgets/clickable_cursor.dart';
+import '../widgets/cycling_media_backdrop.dart';
+import '../widgets/fitting_title_text.dart';
+import '../widgets/optimized_media_image.dart' show ClearLogoImage, blurArtwork;
+import '../i18n/strings.g.dart';
+
+/// A per-row hero banner: backdrop, title, play button, description, paging
+/// dots — the same visual language as the old screen-level "Continue
+/// Watching only" hero, but self-contained so any number of Home rows can
+/// each be one of these at once, each with its own rotation/paging state.
+///
+/// Deliberately NOT a port of the outer-scroll-linked parallax the old
+/// single-hero version had (`_scrollController.offset * 0.3`) — that only
+/// made sense for a hero pinned at the very top of the page. A hero row
+/// anywhere else in the list has no single sensible "outer scroll offset"
+/// to parallax against, so this uses only the fade/zoom-in entrance effect,
+/// independent of scroll position.
+///
+/// Trailer-preview (dwell-triggered playback) is intentionally not wired up
+/// here yet — hero-row rendering is the must-have per the spec, trailer is
+/// the stretch goal layered on top in a follow-up pass.
+class HeroHubSection extends StatefulWidget {
+  const HeroHubSection({
+    super.key,
+    required this.hub,
+    required this.onVerticalNavigation,
+    this.onNavigateUp,
+    this.onNavigateToSidebar,
+  });
+
+  final MediaHub hub;
+
+  /// Same contract as [HubSection.onVerticalNavigation]: return true if this
+  /// row handled the up/down request itself (e.g. moving between paged
+  /// items), false to let the screen move focus to the next/previous row.
+  final bool Function(bool isUp) onVerticalNavigation;
+  final VoidCallback? onNavigateUp;
+  final VoidCallback? onNavigateToSidebar;
+
+  @override
+  State<HeroHubSection> createState() => HeroHubSectionState();
+}
+
+class HeroHubSectionState extends State<HeroHubSection> {
+  static const _autoScrollDuration = Duration(seconds: 8);
+  static const _indicatorUpdateInterval = Duration(milliseconds: 50);
+
+  final _pageController = PageController();
+  final _focusNode = FocusNode(debugLabel: 'hero_hub_section');
+  final _indicatorProgress = ValueNotifier<double>(0.0);
+  final _currentIndex = ValueNotifier<int>(0);
+
+  Timer? _autoScrollTimer;
+  Timer? _indicatorTimer;
+  bool _isAutoScrollPaused = false;
+
+  List<MediaItem> get _items => widget.hub.items;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _startAutoScroll());
+  }
+
+  @override
+  void didUpdateWidget(HeroHubSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.hub.items.length != widget.hub.items.length && _currentIndex.value >= _items.length) {
+      _currentIndex.value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _autoScrollTimer?.cancel();
+    _indicatorTimer?.cancel();
+    _pageController.dispose();
+    _focusNode.dispose();
+    _indicatorProgress.dispose();
+    _currentIndex.dispose();
+    super.dispose();
+  }
+
+  void requestFocusAt(int index) => _focusNode.requestFocus();
+
+  void requestFocusFromMemory() => _focusNode.requestFocus();
+
+  void _startAutoScroll() {
+    _autoScrollTimer?.cancel();
+    if (PlatformDetector.isTV() || _isAutoScrollPaused || !mounted) return;
+
+    _startIndicatorProgress();
+    _autoScrollTimer = Timer.periodic(_autoScrollDuration, (timer) {
+      if (_items.isEmpty || !_pageController.hasClients || _isAutoScrollPaused) return;
+      if (_currentIndex.value >= _items.length) _currentIndex.value = 0;
+      final nextPage = (_currentIndex.value + 1) % _items.length;
+      _pageController.animateToPage(nextPage, duration: const Duration(milliseconds: 500), curve: Curves.easeInOut);
+      Future.delayed(const Duration(milliseconds: 500), () {
+        if (mounted && !_isAutoScrollPaused) _startIndicatorProgress();
+      });
+    });
+  }
+
+  void _startIndicatorProgress() {
+    if (!mounted) return;
+    _indicatorTimer?.cancel();
+    _indicatorProgress.value = 0.0;
+    final totalSteps = _autoScrollDuration.inMilliseconds ~/ _indicatorUpdateInterval.inMilliseconds;
+    var step = 0;
+    _indicatorTimer = Timer.periodic(_indicatorUpdateInterval, (timer) {
+      if (!mounted) {
+        timer.cancel();
+        return;
+      }
+      step++;
+      _indicatorProgress.value = (step / totalSteps).clamp(0.0, 1.0);
+      if (step >= totalSteps) timer.cancel();
+    });
+  }
+
+  void _pauseAutoScroll() {
+    setState(() => _isAutoScrollPaused = true);
+    _autoScrollTimer?.cancel();
+    _indicatorTimer?.cancel();
+  }
+
+  void _resumeAutoScroll() {
+    setState(() => _isAutoScrollPaused = false);
+    _startAutoScroll();
+  }
+
+  ({int start, int end}) _visibleDotRange() {
+    final total = _items.length;
+    if (total <= 5) return (start: 0, end: total - 1);
+    final center = _currentIndex.value;
+    final start = (center - 2).clamp(0, total - 5);
+    return (start: start, end: start + 4);
+  }
+
+  double _dotSize(int dotIndex, int start, int end) {
+    if (_items.length <= 5) return 8.0;
+    if (dotIndex == start || dotIndex == end) return 4.0;
+    if (dotIndex == start + 1 || dotIndex == end - 1) return 6.0;
+    return 8.0;
+  }
+
+  MediaServerClient? _clientFor(MediaItem item) {
+    final serverId = item.serverId;
+    if (serverId == null) return context.tryGetMediaClientForServer(null);
+    return context.tryGetMediaClientForServer(ServerId(serverId));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_items.isEmpty) return const SizedBox.shrink();
+
+    final statusBarHeight = MediaQuery.paddingOf(context).top;
+    final useSideNav = PlatformDetector.shouldUseSideNavigation(context);
+    final isTv = PlatformDetector.isTV();
+    final heroHeight = isTv
+        ? MediaQuery.sizeOf(context).height * 0.82
+        : useSideNav
+        ? MediaQuery.sizeOf(context).height * 0.75
+        : 500 + statusBarHeight;
+
+    return Focus(
+      focusNode: _focusNode,
+      child: SizedBox(
+        height: heroHeight,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            PageView.builder(
+              controller: _pageController,
+              itemCount: _items.length,
+              onPageChanged: (index) {
+                if (index >= 0 && index < _items.length) {
+                  _currentIndex.value = index;
+                  _autoScrollTimer?.cancel();
+                  _startAutoScroll();
+                }
+              },
+              itemBuilder: (context, index) => _buildHeroItem(context, _items[index], heroHeight),
+            ),
+            if (!isTv)
+              Positioned(
+                bottom: 16,
+                left: -26,
+                right: 0,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ClickableCursor(
+                      child: GestureDetector(
+                        onTap: () => _isAutoScrollPaused ? _resumeAutoScroll() : _pauseAutoScroll(),
+                        child: AppIcon(
+                          _isAutoScrollPaused ? Symbols.play_arrow_rounded : Symbols.pause_rounded,
+                          fill: 1,
+                          color: Theme.of(context).colorScheme.onSurface,
+                          size: 18,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    ValueListenableBuilder<int>(
+                      valueListenable: _currentIndex,
+                      builder: (context, current, _) {
+                        final range = _visibleDotRange();
+                        return Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: List.generate(range.end - range.start + 1, (i) {
+                            final index = range.start + i;
+                            final isActive = current == index;
+                            final dotSize = _dotSize(index, range.start, range.end);
+                            final onSurface = Theme.of(context).colorScheme.onSurface;
+                            return isActive
+                                ? ValueListenableBuilder<double>(
+                                    valueListenable: _indicatorProgress,
+                                    builder: (context, progress, child) {
+                                      final maxWidth = dotSize * 3;
+                                      final fillWidth = dotSize + ((maxWidth - dotSize) * progress);
+                                      return Container(
+                                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                                        width: maxWidth,
+                                        height: dotSize,
+                                        decoration: BoxDecoration(
+                                          color: onSurface.withValues(alpha: 0.4),
+                                          borderRadius: BorderRadius.circular(dotSize / 2),
+                                        ),
+                                        child: Align(
+                                          alignment: Alignment.centerLeft,
+                                          child: Container(
+                                            width: fillWidth,
+                                            height: dotSize,
+                                            decoration: BoxDecoration(
+                                              color: onSurface,
+                                              borderRadius: BorderRadius.circular(dotSize / 2),
+                                            ),
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  )
+                                : AnimatedContainer(
+                                    duration: tokens(context).slow,
+                                    curve: Curves.easeInOut,
+                                    margin: const EdgeInsets.symmetric(horizontal: 4),
+                                    width: dotSize,
+                                    height: dotSize,
+                                    decoration: BoxDecoration(
+                                      color: onSurface.withValues(alpha: 0.4),
+                                      borderRadius: BorderRadius.circular(dotSize / 2),
+                                    ),
+                                  );
+                          }),
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeroItem(BuildContext context, MediaItem heroItem, double heroHeight) {
+    final client = _clientFor(heroItem);
+    final isEpisode = heroItem.isEpisode;
+    final showName = heroItem.grandparentTitle ?? heroItem.displayTitle;
+    final screenWidth = MediaQuery.sizeOf(context).width;
+    final heroAspectRatio = screenWidth / heroHeight;
+    final heroArtPaths = heroItem.heroArtCandidates(containerAspectRatio: heroAspectRatio);
+    final isLargeScreen = ScreenBreakpoints.isWideTabletOrLarger(screenWidth);
+    final isTv = PlatformDetector.isTV();
+    final alignLeft = isTv || isLargeScreen;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final heroLogoWidth = isTv ? TvLayoutConstants.heroLogoWidth : 400.0;
+    final heroLogoHeight = isTv ? TvLayoutConstants.heroLogoHeight : 120.0;
+    final heroTitleStyle = theme.textTheme.displaySmall?.copyWith(
+      color: colorScheme.onSurface,
+      fontWeight: FontWeight.bold,
+      fontSize: isTv ? 52 : null,
+      shadows: [Shadow(color: colorScheme.surface.withValues(alpha: 0.8), blurRadius: 8)],
+    );
+    final contentTypeLabel = heroItem.isMovie ? t.discover.movie : t.discover.tvShow;
+    final hideSpoilers = SettingsService.instance.read(SettingsService.hideSpoilers);
+    final shouldHideSpoiler = hideSpoilers && heroItem.shouldHideSpoiler;
+    final heroLabel = isEpisode ? '${heroItem.grandparentTitle}, ${heroItem.title}' : heroItem.title;
+
+    return Semantics(
+      label: heroLabel,
+      button: true,
+      hint: t.accessibility.tapToPlay,
+      child: ClickableCursor(
+        child: GestureDetector(
+          onTap: () => navigateToMediaItem(context, heroItem, playDirectly: true),
+          child: Stack(
+            fit: StackFit.expand,
+            clipBehavior: Clip.none,
+            children: [
+              if (heroArtPaths.isNotEmpty)
+                TweenAnimationBuilder<double>(
+                  key: ValueKey(heroItem.globalKey),
+                  tween: Tween(begin: 0.0, end: 1.0),
+                  duration: const Duration(milliseconds: 800),
+                  curve: Curves.easeOut,
+                  builder: (context, value, child) {
+                    return Transform.scale(
+                      scale: 1.0 + (0.1 * (1 - value)),
+                      child: Opacity(opacity: value, child: child),
+                    );
+                  },
+                  child: blurArtwork(
+                    CyclingMediaBackdrop(
+                      mediaKey: heroItem.globalKey,
+                      imagePaths: heroItem.heroRotationPaths(containerAspectRatio: heroAspectRatio),
+                      fallbackImagePaths: heroArtPaths,
+                      client: client,
+                      active: true,
+                      width: screenWidth,
+                      height: heroHeight,
+                      fallbackColor: colorScheme.surfaceContainerHighest,
+                    ),
+                  ),
+                )
+              else
+                ColoredBox(color: colorScheme.surfaceContainerHighest),
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: -4,
+                child: IgnorePointer(
+                  child: Builder(
+                    builder: (context) {
+                      final bgColor = Theme.of(context).scaffoldBackgroundColor;
+                      return Container(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [Colors.transparent, bgColor.withValues(alpha: 0.9), bgColor, bgColor],
+                            stops: isTv ? const [0.25, 0.78, 0.94, 1.0] : const [0.5, 0.85, 0.94, 1.0],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+              Positioned(
+                bottom: isTv
+                    ? 88
+                    : isLargeScreen
+                    ? 80
+                    : 50,
+                left: 0,
+                right: isTv
+                    ? screenWidth * 0.36
+                    : isLargeScreen
+                    ? 200
+                    : 0,
+                child: Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: isTv
+                        ? TvLayoutConstants.horizontalInset
+                        : isLargeScreen
+                        ? 40
+                        : 24,
+                  ),
+                  child: Align(
+                    alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        maxWidth: isTv ? TvLayoutConstants.heroContentMaxWidth : double.infinity,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: alignLeft ? CrossAxisAlignment.start : CrossAxisAlignment.center,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          ClearLogoImage(
+                            client: client,
+                            logoPath: heroItem.clearLogoPath,
+                            width: heroLogoWidth,
+                            height: heroLogoHeight,
+                            alignment: alignLeft ? Alignment.bottomLeft : Alignment.bottomCenter,
+                            fallbackBuilder: (context) => FittingTitleText(
+                              showName,
+                              style: heroTitleStyle,
+                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
+                              alignment: alignLeft ? Alignment.centerLeft : Alignment.center,
+                            ),
+                          ),
+                          if (heroItem.year != null || heroItem.contentRating != null || heroItem.rating != null) ...[
+                            const SizedBox(height: 16),
+                            Text(
+                              [
+                                contentTypeLabel,
+                                if (heroItem.rating != null) '★ ${formatRating(heroItem.rating!)}',
+                                if (heroItem.contentRating != null) formatContentRating(heroItem.contentRating!),
+                                if (heroItem.year != null) heroItem.year.toString(),
+                              ].join(' • '),
+                              style: TextStyle(
+                                color: colorScheme.onSurface,
+                                fontSize: isTv ? 18 : 14,
+                                fontWeight: FontWeight.w600,
+                              ),
+                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
+                            ),
+                          ],
+                          if (!alignLeft) ...[const SizedBox(height: 20), _buildPlayButton(context, heroItem)],
+                          if (heroItem.summary != null && !shouldHideSpoiler) ...[
+                            const SizedBox(height: 12),
+                            Text(
+                              heroItem.summary!,
+                              maxLines: isTv ? 3 : 2,
+                              overflow: TextOverflow.ellipsis,
+                              textAlign: alignLeft ? TextAlign.left : TextAlign.center,
+                              style: TextStyle(
+                                color: colorScheme.onSurface.withValues(alpha: 0.7),
+                                fontSize: isTv ? 18 : 14,
+                                height: isTv ? 1.45 : 1.4,
+                              ),
+                            ),
+                          ],
+                          if (alignLeft) ...[const SizedBox(height: 20), _buildPlayButton(context, heroItem)],
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlayButton(BuildContext context, MediaItem rawHeroItem) {
+    return Builder(
+      builder: (context) {
+        final heroItem = context.withFreshWatchState(rawHeroItem);
+        final hasProgress = heroItem.hasActiveProgress;
+        final isTv = PlatformDetector.isTV();
+        final minutesLeft = hasProgress ? ((heroItem.durationMs! - heroItem.viewOffsetMs!) / 60_000).round() : 0;
+        return ListenableBuilder(
+          listenable: _focusNode,
+          builder: (context, _) {
+            final showFocus = isTv && _focusNode.hasFocus && InputModeTracker.isKeyboardMode(context);
+            final colorScheme = Theme.of(context).colorScheme;
+            final backgroundColor = showFocus ? colorScheme.primary : Colors.white;
+            final foregroundColor = showFocus ? colorScheme.onPrimary : Colors.black;
+            return InkWell(
+              onTap: () => navigateToVideoPlayer(context, metadata: heroItem),
+              borderRadius: BorderRadius.all(Radius.circular(isTv ? 32 : 24)),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 150),
+                curve: Curves.easeOutCubic,
+                padding: EdgeInsets.symmetric(horizontal: isTv ? 34 : 24, vertical: isTv ? 16 : 12),
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                  borderRadius: BorderRadius.all(Radius.circular(isTv ? 32 : 24)),
+                  boxShadow: showFocus
+                      ? [BoxShadow(color: colorScheme.primary.withValues(alpha: 0.35), blurRadius: 28, spreadRadius: 4)]
+                      : null,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    AppIcon(Symbols.play_arrow_rounded, fill: 1, size: isTv ? 28 : 20, color: foregroundColor),
+                    const SizedBox(width: 8),
+                    Text(
+                      hasProgress ? '$minutesLeft min left' : t.common.play,
+                      style: TextStyle(color: foregroundColor, fontWeight: FontWeight.bold, fontSize: isTv ? 18 : 14),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/hover_preview/hover_preview_card.dart
+++ b/lib/widgets/hover_preview/hover_preview_card.dart
@@ -1,0 +1,763 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+
+import '../../media/ids.dart';
+import '../../media/media_item.dart';
+import '../../media/media_kind.dart';
+import '../../media/media_role.dart';
+import '../../media/media_server_client.dart';
+import '../../mpv/video.dart';
+import '../../services/hover_trailer_service.dart';
+import '../../services/settings_service.dart' show EpisodePosterMode;
+import '../../utils/content_utils.dart';
+import '../../utils/media_image_helper.dart';
+import '../../utils/media_navigation_helper.dart';
+import '../../utils/provider_extensions.dart';
+import '../media_card.dart';
+import '../optimized_media_image.dart';
+import 'hover_preview_player_controller.dart';
+
+/// Wraps [MediaCard] with a Netflix-style hover-expand preview — does not
+/// modify [MediaCard] itself, which stays exactly as every other screen
+/// uses it. Only present where this wrapper is explicitly used (home rows,
+/// Discover), never injected into the shared card widget globally.
+///
+/// The expanded state renders through [Overlay], not a paint-time
+/// transform (`Transform.scale`/`AnimatedScale`), for a real reason: the
+/// native video surface on Windows is positioned via
+/// `VideoRectSupport.setVideoRect`, computed from the hosting widget's
+/// *actual layout size*. A paint transform changes what's drawn but never
+/// the underlying `RenderBox` size, so the video would render at the
+/// pre-expand size while everything else visually scaled up around it —
+/// exactly the small-video/blurry/behind-neighbors bug this replaced.
+///
+/// [playerController] is shared across every card in the surrounding
+/// row/grid, not created per-card — pass the same instance to each
+/// [HoverPreviewCard] so hovering a new card reuses one native player.
+class HoverPreviewCard extends StatefulWidget {
+  const HoverPreviewCard({
+    super.key,
+    required this.item,
+    required this.playerController,
+    this.width,
+    this.height,
+    this.onTap,
+    this.onLongPress,
+    this.mixedHubContext = false,
+    this.episodePosterModeOverride,
+    this.mediaCardKey,
+    this.isContinueWatching = false,
+  });
+
+  final MediaItem item;
+  final HoverPreviewPlayerController playerController;
+  final double? width;
+  final double? height;
+
+  /// Continue Watching cards resolve to the item's own resume position
+  /// instead of a trailer/scene-clip, and auto-collapse back to the cover
+  /// after a short preview window rather than playing indefinitely while
+  /// hovered — see [_HoverPreviewOverlayContentState._resumePreviewTimer].
+  final bool isContinueWatching;
+
+  /// Pass-through to the wrapped [MediaCard] — this wrapper only adds
+  /// hover-expand behavior, it doesn't own tap semantics itself (the base,
+  /// non-expanded card still needs the same keyboard-mode tap/long-press
+  /// override its callers already rely on elsewhere).
+  final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
+  final bool mixedHubContext;
+  final EpisodePosterMode? episodePosterModeOverride;
+
+  /// The `key` that identifies *[MediaCard]'s own state* (e.g. for
+  /// `currentState?.showContextMenu()` from a caller) — kept distinct from
+  /// this widget's own [Key] (`super.key`, for Flutter's element diffing),
+  /// which the wrapped card must not also receive or two different call
+  /// sites would collide on the same identity.
+  final Key? mediaCardKey;
+
+  @override
+  State<HoverPreviewCard> createState() => _HoverPreviewCardState();
+}
+
+class _HoverPreviewCardState extends State<HoverPreviewCard> {
+  // Long enough that sweeping the mouse across a row to reach a title
+  // doesn't trigger a preview on every card it passes over on the way.
+  static const _hoverDebounce = Duration(milliseconds: 1200);
+
+  final _cardKey = GlobalKey();
+  Timer? _debounceTimer;
+  OverlayEntry? _overlayEntry;
+
+  @override
+  void dispose() {
+    // Deliberately not calling _removeOverlay() here — its setState() call
+    // is illegal during dispose(). `mounted` is still true for the entire
+    // duration of dispose() (the framework only flips it after this method
+    // returns), so the `if (mounted)` guard in _removeOverlay() does not
+    // actually protect against this; it throws a defunct-element assertion
+    // that cascades into duplicate-GlobalKey and lifecycle errors elsewhere
+    // in the tree. This inlines the same cleanup, minus the state update a
+    // disposing widget will never read again anyway.
+    _debounceTimer?.cancel();
+    widget.playerController.unregisterActive(_removeOverlay);
+    unawaited(widget.playerController.stop());
+    _overlayEntry?.remove();
+    super.dispose();
+  }
+
+  void _onEnter(PointerEvent _) {
+    if (_overlayEntry != null) return; // already expanded — overlay owns exit detection now
+    // A genuinely different card just got engaged — collapse whatever else
+    // is currently expanded immediately rather than letting it linger out
+    // its own exit grace period. Without this, hovering across a row could
+    // leave several overlays alive at once, all fighting over the single
+    // shared player.
+    widget.playerController.collapseActive();
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(_hoverDebounce, _showOverlay);
+  }
+
+  void _onExit(PointerEvent _) {
+    // Once the overlay exists it visually covers this widget's area, so this
+    // fires as the overlay takes over hit-testing — not a real "left the
+    // card" signal. Only relevant before expansion, to cancel a pending show.
+    if (_overlayEntry != null) return;
+    _debounceTimer?.cancel();
+  }
+
+  Future<void> _showOverlay() async {
+    if (!mounted || _overlayEntry != null) return;
+
+    // Deliberately NOT scrolling a barely-visible edge card into view here.
+    // An earlier version called Scrollable.ensureVisible() first, which
+    // shifted the row's content out from under a stationary cursor — that
+    // relocated whatever card the cursor was resting on, which fired ITS
+    // hover, which could itself trigger another scroll, cascading into the
+    // preview appearing to jump between titles on its own with no mouse
+    // movement. Several rounds of trying to guard that scroll (suppression
+    // windows, waiting an extra frame for layout to catch up) never fully
+    // closed the race. The edge-card cutoff case this served is a much
+    // smaller loss than that cascade, and _computeTargetRect below already
+    // clamps the expanded rect to stay fully on-screen regardless.
+    final renderBox = _cardKey.currentContext?.findRenderObject();
+    if (renderBox is! RenderBox || !renderBox.hasSize) return;
+
+    // Positioned coordinates inside an Overlay are relative to that
+    // Overlay's OWN origin, not the screen's global origin — passing
+    // `ancestor: overlayBox` here converts to that local space. Without it,
+    // a plain `localToGlobal(Offset.zero)` only happens to be correct when
+    // the Overlay's own origin coincides with the screen's, which breaks
+    // the moment there's any offsetting ancestor (a side nav rail, a nested
+    // Navigator's own Overlay, etc.) between them — exactly the kind of
+    // mismatch that snaps the animated rect toward (0,0), clamped to the
+    // corner, regardless of which card was actually hovered.
+    final overlayBox = Overlay.of(context).context.findRenderObject();
+    final origin = overlayBox is RenderBox
+        ? renderBox.localToGlobal(Offset.zero, ancestor: overlayBox)
+        : renderBox.localToGlobal(Offset.zero);
+    late final OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (overlayContext) => _HoverPreviewOverlayContent(
+        item: widget.item,
+        originRect: origin & renderBox.size,
+        playerController: widget.playerController,
+        isContinueWatching: widget.isContinueWatching,
+        onCollapse: () {
+          if (_overlayEntry == entry) _removeOverlay();
+        },
+      ),
+    );
+    setState(() => _overlayEntry = entry);
+    Overlay.of(context).insert(entry);
+    widget.playerController.registerActive(_removeOverlay);
+  }
+
+  void _removeOverlay() {
+    widget.playerController.unregisterActive(_removeOverlay);
+    unawaited(widget.playerController.stop());
+    _overlayEntry?.remove();
+    if (mounted) {
+      setState(() => _overlayEntry = null);
+    } else {
+      _overlayEntry = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      onEnter: _onEnter,
+      onExit: _onExit,
+      // Keep the original card's layout space reserved (and itself visible
+      // as the base layer) even while the overlay floats above it — the
+      // grid shouldn't reflow just because a neighbor is being previewed.
+      child: KeyedSubtree(
+        key: _cardKey,
+        child: MediaCard(
+          key: widget.mediaCardKey,
+          item: widget.item,
+          width: widget.width,
+          height: widget.height,
+          onTap: widget.onTap == null ? null : () => _stopThenInvoke(widget.onTap!),
+          onLongPress: widget.onLongPress == null ? null : () => _stopThenInvoke(widget.onLongPress!),
+          mixedHubContext: widget.mixedHubContext,
+          episodePosterModeOverride: widget.episodePosterModeOverride,
+          forceGridMode: true,
+        ),
+      ),
+    );
+  }
+
+  /// Stops the shared native player and waits for it before running a tap
+  /// action that may itself start real playback (Continue Watching's tap-
+  /// to-resume, in particular). Windows backs the whole app with a single
+  /// process-wide native video core — real playback initializing before
+  /// this controller's own teardown finishes races for that same channel
+  /// and can fail outright ("Failed to initialize player", observed as a
+  /// hard crash from the video player screen). `stop()` resolves almost
+  /// immediately when nothing is actually playing, so this only adds real
+  /// delay in exactly the case it exists to prevent.
+  Future<void> _stopThenInvoke(VoidCallback callback) async {
+    await widget.playerController.stop();
+    callback();
+  }
+}
+
+/// The actual expanded preview, rendered inside an [OverlayEntry] so it has
+/// a real, independently laid-out `RenderBox` — see [HoverPreviewCard]'s
+/// doc comment for why that matters for video rendering specifically.
+class _HoverPreviewOverlayContent extends StatefulWidget {
+  const _HoverPreviewOverlayContent({
+    required this.item,
+    required this.originRect,
+    required this.playerController,
+    required this.onCollapse,
+    this.isContinueWatching = false,
+  });
+
+  final MediaItem item;
+  final Rect originRect;
+  final HoverPreviewPlayerController playerController;
+  final VoidCallback onCollapse;
+  final bool isContinueWatching;
+
+  @override
+  State<_HoverPreviewOverlayContent> createState() => _HoverPreviewOverlayContentState();
+}
+
+class _HoverPreviewOverlayContentState extends State<_HoverPreviewOverlayContent>
+    with SingleTickerProviderStateMixin {
+  // Target shape is a landscape "big thumbnail", not a scaled-up portrait
+  // poster: about two poster-widths across, only slightly taller than one
+  // poster — this is what actually makes it read as a preview thumbnail
+  // rather than just a zoomed poster. Anchored so growth is downward/sideways
+  // from the original top edge, not a centered zoom that eats into the row
+  // above just as much as the row below.
+  //
+  // Continue Watching's own cards are already landscape thumbnails, not
+  // portrait posters — applying the same 2.0x multiplier to an
+  // already-wide originRect compounded into a card noticeably wider than
+  // every other row's, so it gets a smaller multiplier here instead.
+  double get _widthMultiplier => widget.isContinueWatching ? 1.4 : 2.0;
+  double get _heightMultiplier => widget.isContinueWatching ? 1.3 : 1.15;
+
+  final _resolver = HoverPreviewSourceResolver();
+  late final AnimationController _controller;
+  Animation<Rect?>? _rectAnimation;
+
+  HoverPreviewSource? _previewSource;
+  MediaItem? _detailItem;
+  bool _requestSuperseded = false;
+
+  // Short, not zero: a raw MouseRegion.onExit fires on any sub-pixel gap
+  // between nested widgets (e.g. moving toward the mute button in the
+  // corner), so collapsing on the very same event tears the overlay down
+  // before the pointer can ever reach it. This just bridges that gap — the
+  // preview should stop as soon as the cursor genuinely leaves it, not
+  // linger for seconds after.
+  static const _collapseGracePeriod = Duration(milliseconds: 120);
+  Timer? _collapseTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 220));
+    unawaited(_loadPreview());
+  }
+
+  void _scheduleCollapse() {
+    _collapseTimer?.cancel();
+    _collapseTimer = Timer(_collapseGracePeriod, widget.onCollapse);
+  }
+
+  void _cancelScheduledCollapse() {
+    _collapseTimer?.cancel();
+    _collapseTimer = null;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // MediaQuery (needed to clamp the target rect on-screen) isn't
+    // guaranteed resolved yet in initState() for a widget just inserted
+    // into an Overlay — reading it there risks a bad/zero size feeding
+    // invalid bounds into the clamp math below, which throws. This is the
+    // correct lifecycle point for a first-time InheritedWidget-dependent
+    // computation.
+    if (_rectAnimation == null) {
+      _rectAnimation = RectTween(
+        begin: widget.originRect,
+        end: _computeTargetRect(context),
+      ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeOutCubic));
+      _controller.forward();
+    }
+  }
+
+  @override
+  void dispose() {
+    _requestSuperseded = true;
+    _collapseTimer?.cancel();
+    _resumePreviewTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Rect _computeTargetRect(BuildContext context) {
+    // Clamp against the Overlay's own size, not MediaQuery's — [originRect]
+    // is already expressed relative to the Overlay's local origin (see
+    // HoverPreviewCard._showOverlay), and if the Overlay doesn't fill the
+    // full window (e.g. sits beside a persistent nav rail), MediaQuery's
+    // size would overstate the actually-available space and let the clamp
+    // allow an out-of-bounds rect through.
+    final overlayBox = Overlay.of(context).context.findRenderObject();
+    final screen = overlayBox is RenderBox ? overlayBox.size : MediaQuery.sizeOf(context);
+    final origin = widget.originRect;
+
+    var targetWidth = origin.width * _widthMultiplier;
+    var targetHeight = origin.height * _heightMultiplier;
+    var left = origin.left - (targetWidth - origin.width) / 2;
+    final top = origin.top;
+
+    // Clamp fully on-screen. Every clamp lower-bounds its own upper bound
+    // first so a tiny/zero screen size can never produce lower > upper,
+    // which `num.clamp` throws on — that failure mode is exactly what
+    // silently blanks the overlay while still absorbing input.
+    const margin = 8.0;
+    final maxWidth = (screen.width - margin * 2).clamp(0.0, double.infinity);
+    targetWidth = targetWidth.clamp(0.0, maxWidth);
+    final maxLeft = (screen.width - targetWidth - margin).clamp(margin, double.infinity);
+    left = left.clamp(margin, maxLeft);
+    final maxHeight = (screen.height - top - margin).clamp(0.0, double.infinity);
+    targetHeight = targetHeight.clamp(0.0, maxHeight);
+
+    return Rect.fromLTWH(left, top, targetWidth, targetHeight);
+  }
+
+  Future<void> _loadPreview() async {
+    final client = context.tryGetMediaClientWithFallback(serverIdOrNull(widget.item.serverId));
+    if (client == null) return;
+
+    final results = await Future.wait([
+      _resolver.resolve(client, widget.item, preferResumePosition: widget.isContinueWatching),
+      client.fetchItem(widget.item.id),
+    ]);
+    if (_requestSuperseded || !mounted) return;
+
+    final source = results[0] as HoverPreviewSource;
+    final detail = results[1] as MediaItem?;
+    setState(() {
+      _previewSource = source;
+      _detailItem = detail ?? widget.item;
+    });
+
+    switch (source) {
+      case TrailerPreviewSource(:final streamUrl):
+        await widget.playerController.play(streamUrl);
+        _scheduleResumePreviewCollapse();
+      case SceneClipPreviewSource(:final streamUrl, :final startOffset):
+        await widget.playerController.play(streamUrl, startAt: startOffset);
+        _scheduleResumePreviewCollapse();
+      case NoPreviewSource():
+        break;
+    }
+  }
+
+  /// Continue Watching cards preview for a fixed window, not indefinitely —
+  /// unlike every other row, this one is showing the user's actual resume
+  /// point, and letting it run on while still hovered would just replay
+  /// footage they've already watched. No-op for regular hover-preview cards.
+  static const _resumePreviewDuration = Duration(seconds: 12);
+  Timer? _resumePreviewTimer;
+
+  void _scheduleResumePreviewCollapse() {
+    if (!widget.isContinueWatching) return;
+    _resumePreviewTimer?.cancel();
+    _resumePreviewTimer = Timer(_resumePreviewDuration, () {
+      if (mounted) widget.onCollapse();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Not yet resolved on the very first build (didChangeDependencies runs
+    // after initState but the animation is set up there) — render at the
+    // pre-expand rect for that one frame rather than crashing on a null
+    // Listenable.
+    final animation = _rectAnimation;
+    if (animation == null) {
+      return Positioned.fromRect(rect: widget.originRect, child: const SizedBox.shrink());
+    }
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        final rect = animation.value ?? widget.originRect;
+        // Interactive area stays at the ORIGINAL card's width, centered
+        // within the wider animated rect. The visual content still paints
+        // across the full expanded width (see below) — that's what gives
+        // the "lifts in front, covers a sliver of the neighboring posters"
+        // effect — but it's wrapped in IgnorePointer, so that overflow
+        // slice no longer intercepts pointer events. Without this split,
+        // the expanded card's overflow was physically sitting on top of
+        // neighboring cards, stealing their hover/click events: moving
+        // toward a neighbor got attributed to this card instead, made
+        // clicking a neighbor impossible while this one was expanded, and
+        // fed bad state into the exclusivity/collapse logic (stuck overlays,
+        // preview jumping to the wrong spot).
+        final coreLeft = (rect.width - widget.originRect.width) / 2;
+        return Positioned.fromRect(
+          rect: rect,
+          // Rebuilds on mute-state AND playback-failure changes — the mute
+          // button's visibility and the video-vs-backdrop background choice
+          // both depend on live controller state, not just the one-time
+          // preview-source resolution.
+          child: ListenableBuilder(
+            listenable: widget.playerController,
+            builder: (context, _) {
+              // TEMP DIAGNOSTIC: the mute button visually vanishes ~1s into
+              // playback while the rest of the preview stays put. Logging
+              // _hasVideo on every rebuild this widget sees tells us whether
+              // the button is being removed from the tree (a logic bug) or
+              // staying in the tree but getting visually covered (a native
+              // video-window z-order issue, since the video renders via a
+              // separate native HWND on Windows, not a normal texture).
+              debugPrint(
+                '[hover-preview] mute button rebuild: hasVideo=$_hasVideo previewSource=${_previewSource.runtimeType} playbackFailed=${widget.playerController.playbackFailed}',
+              );
+              return Stack(
+            fit: StackFit.expand,
+            children: [
+              // Decorative visual layer — full expanded size. Tracks hover
+              // for collapse purposes (opaque: true, so it also claims the
+              // overlap sliver away from whatever neighboring card sits
+              // underneath it — otherwise crossing that sliver to reach the
+              // mute button fell through to the neighbor's own hover,
+              // collapsing this card mid-move) but carries no GestureDetector
+              // of its own, so a tap here is a no-op rather than accidentally
+              // navigating to either card.
+              MouseRegion(
+                opaque: true,
+                onEnter: (_) => _cancelScheduledCollapse(),
+                onExit: (_) => _scheduleCollapse(),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    boxShadow: [BoxShadow(color: Colors.black.withValues(alpha: 0.6), blurRadius: 24, offset: const Offset(0, 12))],
+                  ),
+                  child: ClipRRect(borderRadius: BorderRadius.circular(8), child: _buildContent(context)),
+                ),
+              ),
+              // Interactive core: tap-to-navigate and "stay expanded" hover
+              // tracking, confined to the original card's footprint.
+              Positioned(
+                left: coreLeft,
+                top: 0,
+                width: widget.originRect.width,
+                height: rect.height,
+                child: MouseRegion(
+                  onEnter: (_) => _cancelScheduledCollapse(),
+                  onExit: (_) => _scheduleCollapse(),
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () {
+                      // Navigate first, while this widget's context is still
+                      // definitely mounted — collapsing tears the overlay entry
+                      // down, and doing that before the Navigator call risks
+                      // racing this widget's own disposal against still-using its
+                      // context.
+                      unawaited(navigateToMediaItemDetails(context, _detailItem ?? widget.item));
+                      widget.onCollapse();
+                    },
+                  ),
+                ),
+              ),
+            ],
+            );
+            },
+          ),
+        );
+      },
+    );
+  }
+
+  bool get _hasVideo =>
+      (_previewSource is TrailerPreviewSource || _previewSource is SceneClipPreviewSource) &&
+      !widget.playerController.playbackFailed &&
+      !widget.playerController.playbackCompleted;
+
+  // Real video content is ~16:9; the card's own overall shape (2.0x wide,
+  // only 1.15x tall) isn't that ratio, so a full-bleed video would letterbox
+  // with dead black bars top/bottom. Instead of fighting that, the video
+  // gets its own properly-shaped 16:9 zone and the remaining space becomes a
+  // dedicated metadata panel — turns wasted letterbox space into the info
+  // panel on purpose, rather than overlaying text on top of the video.
+  static const _videoAspectRatio = 16 / 9;
+
+  Widget _buildContent(BuildContext context) {
+    final detail = _detailItem ?? widget.item;
+    final client = context.tryGetMediaClientWithFallback(serverIdOrNull(widget.item.serverId));
+
+    return ColoredBox(
+      color: const Color(0xFF141414),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          // A true 16:9 zone sized purely from width, like AspectRatio did,
+          // can come out taller than the whole card for a landscape-shaped
+          // original (e.g. Continue Watching's wide thumbnails give this
+          // widget a much wider originRect than a portrait poster would) —
+          // AspectRatio doesn't know or care that a metadata panel sibling
+          // still needs room below it, which is exactly what overflowed for
+          // those cards. Deriving from height first, capped by the natural
+          // width-based value, guarantees the metadata panel always gets its
+          // share regardless of the original card's own proportions.
+          final naturalVideoHeight = constraints.maxWidth / _videoAspectRatio;
+          final videoHeight = naturalVideoHeight.clamp(0.0, constraints.maxHeight * 0.7);
+          return Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SizedBox(height: videoHeight, child: _buildBackground(client)),
+          // Mute button lives here, over the metadata panel's own plain dark
+          // background — NOT over the video zone above. On Windows, video
+          // renders via a native child HWND (see mpv_player.cpp), which
+          // visually covers ordinary Flutter content painted over its own
+          // screen rect regardless of widget tree position — confirmed by
+          // moving the button through Video's own `controls` slot (thought
+          // to carry a native "stay above video" guarantee) and it still
+          // vanished. Placing it outside the video's rect entirely sidesteps
+          // the problem rather than fighting native z-order further.
+          // Continue Watching skips the mute button — it's a short, silent
+          // resume-position preview capped at a fixed duration (see
+          // _scheduleResumePreviewCollapse), not something worth an audio
+          // control for.
+          if (_hasVideo && !widget.isContinueWatching)
+            Flexible(
+              child: Stack(
+                children: [
+                  _buildMetadataPanel(detail),
+                  Positioned(
+                    top: 6,
+                    right: 6,
+                    child: MouseRegion(
+                      onEnter: (_) => _cancelScheduledCollapse(),
+                      onExit: (_) => _scheduleCollapse(),
+                      child: _buildMuteButton(),
+                    ),
+                  ),
+                ],
+              ),
+            )
+          else
+            Flexible(child: _buildMetadataPanel(detail)),
+        ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildMuteButton() {
+    return ListenableBuilder(
+      listenable: widget.playerController,
+      builder: (context, _) {
+        final muted = widget.playerController.isMuted;
+        return Material(
+          color: Colors.black.withValues(alpha: 0.55),
+          shape: const CircleBorder(),
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: () => unawaited(widget.playerController.toggleMuted()),
+            child: Padding(
+              padding: const EdgeInsets.all(6),
+              child: Icon(
+                muted ? Icons.volume_off_rounded : Icons.volume_up_rounded,
+                color: Colors.white,
+                size: 16,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildBackground(MediaServerClient? client) {
+    // `_hasVideo` already excludes a source whose playback actually failed
+    // (see HoverPreviewPlayerController.playbackFailed) — falls through to
+    // the same static-backdrop rendering used when there was never a
+    // preview source to begin with, instead of a dead blank video surface.
+    if (_hasVideo) {
+      final player = widget.playerController.player;
+      // No controls passed here — the mute button lives in the metadata
+      // panel below instead (see _buildContent), outside the video's own
+      // rect entirely. Content placed over the video's rect on Windows gets
+      // visually covered by the native video window regardless of where in
+      // the widget tree it comes from, Video's own `controls` slot included
+      // (confirmed empirically — moving the button there didn't help).
+      if (player != null) return Video(player: player);
+    }
+
+    final backdropPath = widget.item.backdropPaths?.firstOrNull;
+    return OptimizedMediaImage(
+      client: client,
+      imagePath: backdropPath,
+      width: double.infinity,
+      height: double.infinity,
+      fit: BoxFit.cover,
+      imageType: ImageType.thumb,
+    );
+  }
+
+  Widget _buildMetadataPanel(MediaItem detail) {
+    final roles = detail.roles?.take(5).toList() ?? const [];
+    // Wrapped in a scroll view as an overflow safety net — panel height
+    // varies with card width (16:9 video zone eats a different share of the
+    // total height at different card sizes), so this guards against a
+    // RenderFlex overflow if a title/summary combination doesn't quite fit
+    // rather than clipping or crashing.
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            detail.displayTitle,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 15),
+          ),
+          const SizedBox(height: 4),
+          _buildFactsRow(detail),
+          if (detail.summary case final summary? when summary.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              summary,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: Colors.white70, fontSize: 11, height: 1.2),
+            ),
+          ],
+          if (roles.isNotEmpty) ...[const SizedBox(height: 6), _buildCastBubbles(roles, context)],
+        ],
+      ),
+    );
+  }
+
+  /// Coarse type label. [MediaKind] only distinguishes movie/show at the
+  /// model level — a genre tag (when present) narrows this further, which
+  /// naturally surfaces things like "Stand-up" for libraries organized that
+  /// way, without needing a dedicated content-type taxonomy.
+  String _typeLabel(MediaItem detail) {
+    final base = switch (detail.kind) {
+      MediaKind.movie => 'Movie',
+      MediaKind.show => 'Series',
+      _ => null,
+    };
+    final genre = detail.genres?.firstOrNull;
+    if (base == null) return genre ?? '';
+    return genre != null ? '$base • $genre' : base;
+  }
+
+  /// Prefers an explicitly IMDb-sourced rating over the generic `.rating`
+  /// field, which reflects whatever the server's configured primary rating
+  /// agent happens to be (not necessarily IMDb) — mislabeling a Rotten
+  /// Tomatoes or TMDb score as "IMDb" would just be wrong.
+  double? _imdbRating(MediaItem detail) {
+    final imdbSource = detail.ratings?.firstWhereOrNull((r) => r.source == 'imdb');
+    return imdbSource?.value;
+  }
+
+  Widget _buildFactsRow(MediaItem detail) {
+    final episodeCount = detail.childCount ?? detail.leafCount;
+    final formattedContentRating = formatContentRating(detail.contentRating);
+    final imdbRating = _imdbRating(detail);
+    final parts = <String>[
+      if (_typeLabel(detail) case final type when type.isNotEmpty) type,
+      if (detail.year case final year?) '$year',
+      if (detail.kind == MediaKind.show && episodeCount != null)
+        '$episodeCount episodes'
+      else if (detail.durationMs case final ms?)
+        '${(ms / 60000).round()}m',
+      if (formattedContentRating.isNotEmpty) formattedContentRating,
+      if (imdbRating != null)
+        'IMDb ${imdbRating.toStringAsFixed(1)}'
+      else if (detail.rating case final rating?)
+        '${rating.toStringAsFixed(1)}★',
+    ];
+    if (parts.isEmpty) return const SizedBox.shrink();
+    return Text(parts.join('  •  '), style: const TextStyle(color: Colors.white70, fontSize: 11));
+  }
+
+  static const _castBubbleDiameter = 22.0;
+
+  Widget _buildCastBubbles(List<MediaRole> roles, BuildContext context) {
+    final client = context.tryGetMediaClientWithFallback(serverIdOrNull(widget.item.serverId));
+    return SizedBox(
+      height: _castBubbleDiameter,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (final role in roles)
+            Padding(
+              padding: const EdgeInsets.only(right: 3),
+              child: Tooltip(
+                message: role.tag,
+                child: ClipOval(
+                  child: SizedBox(
+                    width: _castBubbleDiameter,
+                    height: _castBubbleDiameter,
+                    child: role.thumbPath == null
+                        ? _castInitial(role)
+                        : OptimizedMediaImage(
+                            client: client,
+                            imagePath: role.thumbPath,
+                            width: _castBubbleDiameter,
+                            height: _castBubbleDiameter,
+                            fit: BoxFit.cover,
+                            imageType: ImageType.square,
+                            errorWidget: (_, _, _) => _castInitial(role),
+                          ),
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _castInitial(MediaRole role) {
+    return ColoredBox(
+      color: Colors.white24,
+      child: Center(
+        child: Text(
+          role.tag.isNotEmpty ? role.tag[0] : '?',
+          style: const TextStyle(color: Colors.white, fontSize: 10),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/hover_preview/hover_preview_player_controller.dart
+++ b/lib/widgets/hover_preview/hover_preview_player_controller.dart
@@ -110,6 +110,20 @@ class HoverPreviewPlayerController extends ChangeNotifier {
       await player.setProperty('tunneled-playback', 'no');
     }
 
+    // Preview cards and hero rows both size this player's surface to a
+    // container whose aspect ratio rarely matches the source clip's — mpv's
+    // default is to fit the whole frame inside that box (letterboxed/
+    // pillarboxed, i.e. black bars), which reads as broken on a small
+    // preview surface ("big black side bar", reported 2026-09-10). `panscan`
+    // is the same mpv property VideoFilterManager uses for the real player's
+    // "cover" box-fit mode (video_filter_manager.dart) — 1.0 scales the
+    // video up just enough to fill the box completely, cropping the
+    // overflow instead of padding with black. Set once per native player
+    // instance; it persists across every later `open()` on the same player.
+    if (isNewPlayer) {
+      await player.setProperty('panscan', '1.0');
+    }
+
     _playbackFailed = false;
     _playbackCompleted = false;
     notifyListeners();
@@ -197,6 +211,12 @@ class HoverPreviewPlayerController extends ChangeNotifier {
     } catch (e) {
       debugPrint('[hover-preview] player.stop() failed (non-fatal): $e');
     }
+    // Every other mutating method here (play, toggleMuted) already notifies;
+    // this one didn't, so a caller stopping playback from outside whichever
+    // widget started it (e.g. DiscoverScreen stopping a hero row's trailer
+    // when the whole tab is navigated away from) had no way to tell that
+    // widget its local "am I the one playing" state is now stale.
+    notifyListeners();
   }
 
   /// Like [stop], but fully releases the native player instead of leaving it

--- a/lib/widgets/hover_preview/hover_preview_player_controller.dart
+++ b/lib/widgets/hover_preview/hover_preview_player_controller.dart
@@ -1,0 +1,254 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+import '../../mpv/models.dart';
+import '../../mpv/player/player.dart';
+import '../../utils/app_logger.dart';
+
+/// Single shared native player reused across every hover-preview card,
+/// instead of spinning up a new native player instance per hover — mirrors
+/// the existing single-instance discipline already used for the audio
+/// player elsewhere in this codebase.
+///
+/// Muted by default: Netflix's own hover previews are silent, and muting
+/// sidesteps any native-audio contention with a background music session
+/// (the real video player screen and the music engine already arbitrate
+/// that through [PlaybackCoordinator]; this controller intentionally stays
+/// out of that entirely by never producing audio in the first place). Users
+/// can opt into sound via [toggleMuted] — a [ChangeNotifier] so a speaker
+/// icon in the UI can reflect and drive the current state.
+class HoverPreviewPlayerController extends ChangeNotifier {
+  Player? _player;
+  bool _muted = true;
+
+  /// Whether the most recent [play] request failed to actually produce
+  /// video — a bad/expired stream URL, a codec the native backend can't
+  /// handle, etc. Some titles resolve a trailer/scene-clip URL successfully
+  /// but the URL itself doesn't actually play, which otherwise showed up as
+  /// a dead blank video surface instead of the same graceful static-backdrop
+  /// fallback already used when no preview source resolves at all.
+  bool _playbackFailed = false;
+  bool get playbackFailed => _playbackFailed;
+  StreamSubscription<PlayerError>? _errorSub;
+
+  /// Whether the most recent [play] request reached the end of its clip on
+  /// its own (not stopped externally). Callers that show video in place of a
+  /// static image (hover-preview cards, the hero banner) should revert to
+  /// that image once this flips true rather than freezing on the last frame.
+  bool _playbackCompleted = false;
+  bool get playbackCompleted => _playbackCompleted;
+  StreamSubscription<bool>? _completedSub;
+
+  /// The collapse callback of whichever card currently has its overlay
+  /// expanded, if any. Only one card in a row should ever be expanded at
+  /// once — without this, hovering across several cards in quick succession
+  /// left multiple overlays alive simultaneously, all fighting over this
+  /// same shared player and never cleanly tearing each other down.
+  VoidCallback? _activeCollapse;
+
+  /// Called by a card the moment it genuinely engages hover (not after the
+  /// show-debounce — as soon as the pointer enters), so switching to a new
+  /// card collapses whatever was previously expanded immediately instead of
+  /// waiting out that card's own exit grace period.
+  void collapseActive() {
+    _activeCollapse?.call();
+    _activeCollapse = null;
+  }
+
+  /// Called by a card once its own overlay is actually showing, so a later
+  /// [collapseActive] call (from the next card to engage) knows what to
+  /// collapse.
+  void registerActive(VoidCallback collapseSelf) {
+    _activeCollapse = collapseSelf;
+  }
+
+  /// Called by a card when its own overlay is going away on its own (e.g.
+  /// its exit grace period elapsed) — only clears the slot if it's still
+  /// the one that registered it, so it can't accidentally clear a different
+  /// card's more recent registration.
+  void unregisterActive(VoidCallback collapseSelf) {
+    if (_activeCollapse == collapseSelf) {
+      _activeCollapse = null;
+    }
+  }
+
+  /// Monotonically-increasing token so a slow [open] that resolves after
+  /// the user has already moved to a different card does not clobber it —
+  /// only the request matching the current token is allowed to act.
+  int _requestToken = 0;
+
+  /// The underlying player, for widgets (e.g. [Video]) that render its
+  /// output directly. Null until the first [play] call.
+  Player? get player => _player;
+
+  bool get isMuted => _muted;
+
+  /// Starts playing [streamUrl] at the current mute setting, seeking to
+  /// [startAt] first if given. Safe to call again with a different URL
+  /// while a preview is already playing — reuses the same native player
+  /// rather than disposing and recreating it.
+  Future<void> play(String streamUrl, {Duration? startAt}) async {
+    final token = ++_requestToken;
+    final isNewPlayer = _player == null;
+    _player ??= Player();
+    final player = _player!;
+
+    // Tunneled playback hands the decoder a dedicated hardware overlay plane
+    // — built for one exclusive, stable, fullscreen consumer (the real video
+    // player), which is why it defaults on there. This shared preview player
+    // is the opposite of that: small-scale, transient, frequently opened and
+    // torn down. On Android TV that mismatch showed up as audio playing with
+    // no visible video — logcat showed the tunnel resource being allocated
+    // and released again within ~150ms of every single preview open()
+    // ("Alloc tunnel playback_0 resources" / "release tunnel playback_0
+    // resources"), i.e. the hardware overlay never actually held still long
+    // enough to paint a frame. Only needs setting once per native player
+    // instance, before its first initialize().
+    if (isNewPlayer && Platform.isAndroid) {
+      await player.setProperty('tunneled-playback', 'no');
+    }
+
+    _playbackFailed = false;
+    _playbackCompleted = false;
+    notifyListeners();
+
+    unawaited(_errorSub?.cancel());
+    _errorSub = player.streams.error.listen((error) {
+      if (token != _requestToken) return; // stale error from an abandoned hover
+      appLogger.w('[hover-preview] player error event (marking playbackFailed): $error');
+      _playbackFailed = true;
+      notifyListeners();
+    });
+
+    unawaited(_completedSub?.cancel());
+    _completedSub = player.streams.completed.listen((completed) {
+      if (token != _requestToken || !completed) return;
+      _playbackCompleted = true;
+      notifyListeners();
+    });
+
+    try {
+      await player.open(
+        Media(streamUrl, start: (startAt != null && startAt > Duration.zero) ? startAt : null),
+        play: true,
+      );
+      appLogger.i('[hover-preview] player.open() succeeded for $streamUrl');
+    } catch (e) {
+      appLogger.w('[hover-preview] player.open() threw (marking playbackFailed): $e');
+      if (token == _requestToken) {
+        _playbackFailed = true;
+        notifyListeners();
+      }
+      return;
+    }
+    if (token != _requestToken) return; // superseded by a newer hover
+    // Set volume AFTER open(), not before — loading a new source resets the
+    // backend's internal volume/audio-track state, which was silently
+    // undoing a pre-open setVolume call (the main video player screen
+    // applies its own saved volume after opening for the same reason).
+    await player.setVolume(_muted ? 0 : 100);
+  }
+
+  /// Flips mute on/off and applies it immediately to whatever is currently
+  /// playing. Persists across hovers (shared controller, not per-card
+  /// state) — matches the expected feel of "I turned the sound on, it
+  /// should stay on as I move between previews," not resetting every hover.
+  Future<void> toggleMuted() async {
+    _muted = !_muted;
+    final player = _player;
+    if (player != null && !player.disposed) {
+      // Called via `unawaited(...)` from the mute button's onTap — same
+      // reasoning as stop() below: nothing downstream can catch a thrown
+      // Future here, so a transient native hiccup must not become an
+      // unhandled exception.
+      try {
+        await player.setVolume(_muted ? 0 : 100);
+      } catch (e) {
+        debugPrint('[hover-preview] player.setVolume() failed (non-fatal): $e');
+      }
+    }
+    notifyListeners();
+  }
+
+  /// Stops playback without disposing the native player, so the next hover
+  /// can reuse it immediately.
+  ///
+  /// Called via `unawaited(...)` from the card that's collapsing — nothing
+  /// downstream can catch a thrown Future here, so a failure must be
+  /// swallowed locally rather than propagate as an unhandled exception.
+  /// This is a real, observed failure mode: stopping one card's playback
+  /// right as the next card's `open()` is racing to (re)initialize the same
+  /// shared native player can throw "Failed to initialize player" from the
+  /// native layer. That's a transient native-layer hiccup, not something a
+  /// hover preview should ever crash over — the next hover's own `play()`
+  /// gets a fresh attempt at initializing regardless.
+  Future<void> stop() async {
+    _requestToken++; // invalidate any in-flight open()/seek()
+    unawaited(_errorSub?.cancel());
+    _errorSub = null;
+    unawaited(_completedSub?.cancel());
+    _completedSub = null;
+    final player = _player;
+    if (player == null || player.disposed) return;
+    try {
+      await player.stop();
+    } catch (e) {
+      debugPrint('[hover-preview] player.stop() failed (non-fatal): $e');
+    }
+  }
+
+  /// Like [stop], but fully releases the native player instead of leaving it
+  /// alive for reuse. Call this — not [stop] — right before handing off to
+  /// real full-screen playback.
+  ///
+  /// Android's plugin (ExoPlayerPlugin.kt) is a single app-wide native
+  /// instance: `handleInitialize()` early-returns without reinitializing (and
+  /// without advancing its own session-generation counter) whenever a
+  /// `playerCore` object already exists, regardless of which Dart `Player()`
+  /// created it. A plain [stop] leaves that native core alive, so the real
+  /// player's own subsequent `Player()` silently inherits a stale session and
+  /// its `open()` can hang indefinitely waiting on events tagged with a
+  /// generation it never advanced to. Disposing here forces the native side
+  /// through its real teardown path (`teardownSession()`), which nulls the
+  /// core and bumps the generation — the next [play] call on this
+  /// controller builds a fresh [Player] from scratch, and the real player's
+  /// own initialize() gets a genuinely clean native core.
+  Future<void> stopForHandoff() async {
+    _requestToken++;
+    unawaited(_errorSub?.cancel());
+    _errorSub = null;
+    unawaited(_completedSub?.cancel());
+    _completedSub = null;
+    final player = _player;
+    _player = null;
+    if (player == null || player.disposed) return;
+    try {
+      await player.dispose();
+    } catch (e) {
+      debugPrint('[hover-preview] player.dispose() (handoff) failed (non-fatal): $e');
+    }
+  }
+
+  /// Fully releases the native player. Call when the surface hosting hover
+  /// previews (e.g. the whole row/grid) is leaving the tree, not per-card.
+  ///
+  /// `ChangeNotifier.dispose()` is synchronous, so the actual async native
+  /// player teardown can't happen inside this override — it's fired and
+  /// left to complete on its own rather than awaited, which is fine here
+  /// since nothing needs to observe its completion once the controller
+  /// itself is going away.
+  @override
+  void dispose() {
+    _requestToken++;
+    unawaited(_errorSub?.cancel());
+    unawaited(_completedSub?.cancel());
+    final player = _player;
+    _player = null;
+    if (player != null && !player.disposed) {
+      unawaited(player.dispose());
+    }
+    super.dispose();
+  }
+}

--- a/test/providers/discover_provider_test.dart
+++ b/test/providers/discover_provider_test.dart
@@ -109,6 +109,7 @@ class _FakeAggregationService extends DataAggregationService {
     bool useGlobalHubs = true,
     bool includePlaybackHubs = true,
     Set<String>? serverIds,
+    Set<MediaKind> additionalLibraryHubKinds = const {},
   }) async {
     hubCalls++;
     lastHubsServerIds = serverIds;

--- a/test/providers/discover_provider_test.dart
+++ b/test/providers/discover_provider_test.dart
@@ -213,7 +213,7 @@ void main() {
     await Future.wait([provider.load(), provider.load(), provider.load()]);
 
     expect(provider.onDeck.map((i) => i.id), ['a']);
-    expect(provider.hubs.map((h) => h.id), ['hub-1']);
+    expect(provider.hubs.map((h) => h.id), ['continue_watching', 'hub-1']);
     expect(provider.isLoading, isFalse);
     expect(provider.areHubsLoading, isFalse);
     expect(provider.errorMessage, isNull);
@@ -539,7 +539,7 @@ void main() {
 
     expect(sawImmediateRemoval, isTrue);
     expect(provider.onDeck.map((i) => i.id), ['ep-2']);
-    expect(provider.hubs.single.items.map((i) => i.id), ['other']);
+    expect(provider.hubs.firstWhere((h) => h.id == 'hub-1').items.map((i) => i.id), ['other']);
     expect(aggregation.onDeckCalls, onDeckCallsBefore + 1);
     expect(aggregation.hubCalls, hubCallsBefore);
   });
@@ -568,7 +568,7 @@ void main() {
     await pumpEventQueue();
 
     expect(provider.onDeck.map((i) => i.id), ['ep-1']);
-    expect(provider.hubs.single.items.map((i) => i.id), ['ep-1']);
+    expect(provider.hubs.firstWhere((h) => h.id == 'hub-1').items.map((i) => i.id), ['ep-1']);
     expect(aggregation.onDeckCalls, onDeckCallsBefore);
     expect(aggregation.hubCalls, hubCallsBefore);
   });
@@ -676,7 +676,7 @@ void main() {
     await provider.load();
 
     expect(provider.onDeck.map((i) => i.id), ['a']);
-    expect(provider.hubs.map((h) => h.id), ['hub-1']);
+    expect(provider.hubs.map((h) => h.id), ['continue_watching', 'hub-1']);
     expect(provider.isLoading, isFalse);
     expect(provider.areHubsLoading, isFalse);
   });
@@ -723,7 +723,7 @@ void main() {
     await provider.load();
 
     expect(provider.onDeck.map((i) => i.id), ['a']);
-    expect(provider.hubs.map((h) => h.id), ['hub-1']);
+    expect(provider.hubs.map((h) => h.id), ['continue_watching', 'hub-1']);
     expect(provider.isLoading, isFalse);
     expect(provider.areHubsLoading, isFalse);
     // No new data: a failed pass must not reset the hero carousel.
@@ -756,7 +756,7 @@ void main() {
       // Retained content still renders: the error is surfaced by the caller as
       // a snackbar, never by blanking the screen.
       expect(provider.onDeck.map((i) => i.id), ['a']);
-      expect(provider.hubs.map((h) => h.id), ['hub-1']);
+      expect(provider.hubs.map((h) => h.id), ['continue_watching', 'hub-1']);
       expect(provider.errorMessage, isNull);
     });
 
@@ -842,6 +842,7 @@ void main() {
     final onDeckCallsBefore = aggregation.onDeckCalls;
     final hubCallsBefore = aggregation.hubCalls;
     final source = provider.hubs
+        .where((hub) => hub.id != 'continue_watching')
         .expand((hub) => hub.items)
         .singleWhere((item) => item.globalKey == serverTwoItem.globalKey);
     final updated = serverTwoItem.copyWith(title: 'Server Two Refreshed');
@@ -953,7 +954,7 @@ void main() {
     expect(aggregation.onDeckCalls, onDeckCallsBefore);
     expect(aggregation.hubCalls, hubCallsBefore + 1);
     expect(aggregation.lastHubsServerIds, {'server_1'});
-    expect(provider.hubs.map((h) => h.id), ['hub-1']);
+    expect(provider.hubs.map((h) => h.id), ['continue_watching', 'hub-1']);
   });
 
   test('delta partial hub failure retries only the missing surface', () async {

--- a/test/services/data_aggregation_bridge_test.dart
+++ b/test/services/data_aggregation_bridge_test.dart
@@ -1393,6 +1393,83 @@ void main() {
       ]);
     });
 
+    test('additionalLibraryHubKinds drops unrelated hub types the per-library fetch also returns', () async {
+      // The per-library hubs endpoint returns every hub Plex has for that
+      // library in one response — collection hubs, genre hubs, top rated,
+      // not just Recently Added/Released. additionalLibraryHubKinds exists
+      // only to feed a configured merge row (#1652) its recently-added/
+      // -released source hub, so anything else it drags along must not ride
+      // through — those hub types have no relation to any user setting and
+      // nowhere in Settings to see or turn them off once they're on Home.
+      final client = testPlexClient(
+        config: PlexConfig(
+          baseUrl: 'https://plex.example.com',
+          token: 'token',
+          clientIdentifier: 'client-id',
+          product: 'Plezy',
+          version: 'test',
+        ),
+        serverId: ServerId('plex-1'),
+        serverName: 'Plex',
+        promotedHubKey: '/hubs/promoted',
+        httpClient: MockClient((req) async {
+          if (req.url.path == '/library/sections') {
+            return _json({
+              'MediaContainer': {
+                'Directory': [
+                  {'key': '1', 'type': 'movie', 'title': 'Movies'},
+                ],
+              },
+            });
+          }
+          if (req.url.path == '/hubs/promoted') {
+            return _json({
+              'MediaContainer': {'Hub': <Object?>[]},
+            });
+          }
+          if (req.url.path == '/hubs/sections/1') {
+            return _json({
+              'MediaContainer': {
+                'Hub': [
+                  {
+                    'key': '/library/sections/1/all?sort=addedAt:desc',
+                    'title': 'Recently Added',
+                    'type': 'movie',
+                    'hubIdentifier': 'movie.recentlyadded.1',
+                    'size': 1,
+                    'Metadata': [
+                      {'ratingKey': 'movie-1', 'type': 'movie', 'title': 'Movie', 'librarySectionID': 1},
+                    ],
+                  },
+                  {
+                    'key': '/library/sections/1/collections/1',
+                    'title': 'Survival',
+                    'type': 'movie',
+                    'hubIdentifier': 'collection.survival',
+                    'size': 1,
+                    'Metadata': [
+                      {'ratingKey': 'movie-2', 'type': 'movie', 'title': 'Cast Away', 'librarySectionID': 1},
+                    ],
+                  },
+                ],
+              },
+            });
+          }
+          return http.Response('unexpected request', 500);
+        }),
+      );
+      addTearDown(client.close);
+      manager.debugRegisterClientForTesting(client);
+
+      final result = await service.getHubsFromAllServers(
+        useGlobalHubs: true,
+        includePlaybackHubs: false,
+        additionalLibraryHubKinds: const {MediaKind.movie},
+      );
+
+      expect(result.hubs.map((h) => h.identifier), ['movie.recentlyadded.1']);
+    });
+
     test('Plex server with a failed global leg is not marked succeeded by the optional music append', () async {
       // /hubs/promoted failures are recorded in diagnostics and returned as []
       // (never thrown), so only the success accounting separates "promoted

--- a/test/services/data_aggregation_bridge_test.dart
+++ b/test/services/data_aggregation_bridge_test.dart
@@ -1311,6 +1311,88 @@ void main() {
       ]);
     });
 
+    test(
+        'additionalLibraryHubKinds appends per-library hubs for a library the '
+        'promoted endpoint never surfaces (#1652)', () async {
+      // A configured "Recently Added"/"Recently Released" Home section can
+      // reference a library that Plex's own server never promotes to the
+      // global /hubs/promoted endpoint (only "promoted" libraries appear
+      // there) — without an explicit per-library fetch, that library's
+      // recently-added/-released row silently has nothing to match against
+      // and the whole custom section renders empty.
+      final captured = <Uri>[];
+
+      final client = testPlexClient(
+        config: PlexConfig(
+          baseUrl: 'https://plex.example.com',
+          token: 'token',
+          clientIdentifier: 'client-id',
+          product: 'Plezy',
+          version: 'test',
+        ),
+        serverId: ServerId('plex-1'),
+        serverName: 'Plex',
+        promotedHubKey: '/hubs/promoted',
+        httpClient: MockClient((req) async {
+          captured.add(req.url);
+          if (req.url.path == '/library/sections') {
+            return _json({
+              'MediaContainer': {
+                'Directory': [
+                  {'key': '1', 'type': 'movie', 'title': 'Movies'},
+                ],
+              },
+            });
+          }
+          if (req.url.path == '/hubs/promoted') {
+            // The promoted endpoint has nothing for library 1 at all — this
+            // is the exact shape that left a configured recently-added/
+            // recently-released row empty before the per-library append.
+            return _json({
+              'MediaContainer': {'Hub': <Object?>[]},
+            });
+          }
+          if (req.url.path == '/hubs/sections/1') {
+            return _json({
+              'MediaContainer': {
+                'Hub': [
+                  {
+                    'key': '/library/sections/1/all?sort=addedAt:desc',
+                    'title': 'Recently Added',
+                    'type': 'movie',
+                    'hubIdentifier': 'movie.recentlyadded.1',
+                    'size': 1,
+                    'Metadata': [
+                      {'ratingKey': 'movie-1', 'type': 'movie', 'title': 'Movie', 'librarySectionID': 1},
+                    ],
+                  },
+                ],
+              },
+            });
+          }
+          return http.Response('unexpected request', 500);
+        }),
+      );
+      addTearDown(client.close);
+      manager.debugRegisterClientForTesting(client);
+
+      final withoutAppend = await service.getHubsFromAllServers(useGlobalHubs: true, includePlaybackHubs: false);
+      expect(withoutAppend.hubs, isEmpty);
+      expect(captured.where((uri) => uri.path.startsWith('/hubs/sections/')), isEmpty);
+
+      captured.clear();
+      final withAppend = await service.getHubsFromAllServers(
+        useGlobalHubs: true,
+        includePlaybackHubs: false,
+        additionalLibraryHubKinds: const {MediaKind.movie},
+      );
+
+      expect(withAppend.hubs.map((h) => h.identifier), ['movie.recentlyadded.1']);
+      expect(captured.where((uri) => uri.path.startsWith('/hubs/sections/')).map((uri) => uri.path), [
+        '/hubs/sections/1',
+      ]);
+    });
+
     test('Plex server with a failed global leg is not marked succeeded by the optional music append', () async {
       // /hubs/promoted failures are recorded in diagnostics and returned as []
       // (never thrown), so only the success accounting separates "promoted

--- a/test/utils/home_section_builder_test.dart
+++ b/test/utils/home_section_builder_test.dart
@@ -1,0 +1,286 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/media/media_hub.dart';
+import 'package:plezy/media/media_item.dart';
+import 'package:plezy/models/home_section_config.dart';
+import 'package:plezy/utils/home_section_builder.dart';
+import '../test_helpers/media_items.dart';
+
+MediaHub _hub(String identifier, List<MediaItem> items) => MediaHub(
+  id: identifier,
+  identifier: identifier,
+  title: identifier,
+  type: 'movie',
+  serverId: 'srv',
+  libraryId: identifier,
+  items: items,
+);
+
+HomeSectionConfig _section(HomeSectionKind kind) =>
+    HomeSectionConfig(id: 'merged', title: 'Merged', kind: kind, showOnHome: true);
+
+void main() {
+  group('buildConfiguredHomeSections merged-row ordering', () {
+    test('recently added interleaves items across libraries by addedAt, newest first', () {
+      final hubs = [
+        _hub('library.1.recentlyAdded', [
+          testMediaItem(id: 'movie-old', addedAt: 100),
+          testMediaItem(id: 'movie-newest', addedAt: 400),
+        ]),
+        _hub('library.2.recentlyAdded', [
+          testMediaItem(id: 'show-mid', addedAt: 300),
+          testMediaItem(id: 'show-oldest', addedAt: 50),
+        ]),
+      ];
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: hubs,
+        collections: const [],
+        sections: [_section(HomeSectionKind.recentlyAdded)],
+        rowOrder: const ['custom:merged'],
+      );
+
+      expect(result, hasLength(1));
+      expect(
+        result.single.items.map((item) => item.id),
+        ['movie-newest', 'show-mid', 'movie-old', 'show-oldest'],
+      );
+    });
+
+    test('recently released interleaves items across libraries by originallyAvailableAt, newest first', () {
+      final hubs = [
+        _hub('library.1.recentlyReleased', [
+          testMediaItem(id: 'movie-2020', originallyAvailableAt: '2020-01-01'),
+          testMediaItem(id: 'movie-2024', originallyAvailableAt: '2024-06-15'),
+        ]),
+        _hub('library.2.recentlyReleased', [
+          testMediaItem(id: 'show-2023', originallyAvailableAt: '2023-03-10'),
+        ]),
+      ];
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: hubs,
+        collections: const [],
+        sections: [_section(HomeSectionKind.recentlyReleased)],
+        rowOrder: const ['custom:merged'],
+      );
+
+      expect(result, hasLength(1));
+      expect(
+        result.single.items.map((item) => item.id),
+        ['movie-2024', 'show-2023', 'movie-2020'],
+      );
+    });
+
+    test('items missing the sort field sort after items that have it', () {
+      final hubs = [
+        _hub('library.1.recentlyAdded', [
+          testMediaItem(id: 'no-date'),
+          testMediaItem(id: 'has-date', addedAt: 10),
+        ]),
+      ];
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: hubs,
+        collections: const [],
+        sections: [_section(HomeSectionKind.recentlyAdded)],
+        rowOrder: const ['custom:merged'],
+      );
+
+      expect(result.single.items.map((item) => item.id), ['has-date', 'no-date']);
+    });
+  });
+
+  group('buildConfiguredHomeSections row order is the single source of truth', () {
+    test('an empty rowOrder shows everything unfiltered: the merge plus every raw hub', () {
+      final matchedHub = _hub('library.1.recentlyAdded', [testMediaItem(id: 'merged-item', addedAt: 10)]);
+      final unrelatedHub = MediaHub(
+        id: 'genre-hub',
+        identifier: 'custom.genre.horror',
+        title: 'Horror Collection',
+        type: 'collection',
+        items: [testMediaItem(id: 'horror-item')],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [matchedHub, unrelatedHub],
+        collections: const [],
+        sections: [_section(HomeSectionKind.recentlyAdded)],
+      );
+
+      expect(result.map((h) => h.identifier), ['configured.recently_added', 'library.1.recentlyAdded', 'custom.genre.horror']);
+    });
+
+    test('a merged row and the specific raw hub it draws from can both show, each by its own token', () {
+      // Both are legitimate, independently-ordered rows once the Organizer
+      // lists both tokens -- there is no separate content-matching heuristic
+      // deciding to hide one of them behind the scenes.
+      final matchedHub = MediaHub(
+        id: 'library.1.recentlyAdded',
+        identifier: 'library.1.recentlyAdded',
+        title: 'library.1.recentlyAdded',
+        type: 'movie',
+        serverId: 'srv',
+        libraryId: 'lib1',
+        items: [testMediaItem(id: 'merged-item', addedAt: 10)],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [matchedHub],
+        collections: const [],
+        sections: [_section(HomeSectionKind.recentlyAdded)],
+        rowOrder: const ['plex:srv:lib1:library.1.recentlyAdded', 'custom:merged'],
+      );
+
+      expect(result.map((h) => h.identifier), ['library.1.recentlyAdded', 'configured.recently_added']);
+    });
+
+    test('a token removed from rowOrder is genuinely gone, not re-added as "new" content', () {
+      final matchedHub = MediaHub(
+        id: 'library.1.recentlyAdded',
+        identifier: 'library.1.recentlyAdded',
+        title: 'library.1.recentlyAdded',
+        type: 'movie',
+        serverId: 'srv',
+        libraryId: 'lib1',
+        items: [testMediaItem(id: 'merged-item', addedAt: 10)],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [matchedHub],
+        collections: const [],
+        sections: [_section(HomeSectionKind.recentlyAdded)],
+        // Only the merged row's own token is listed -- the raw hub's token
+        // was removed (e.g. via the Organizer's own remove button) and must
+        // not silently reappear.
+        rowOrder: const ['custom:merged'],
+      );
+
+      expect(result.map((h) => h.identifier), ['configured.recently_added']);
+    });
+
+    test('a hub with no libraryId can never get a token, so it always shows regardless of rowOrder', () {
+      final untrackable = MediaHub(
+        id: 'synthetic',
+        identifier: 'synthetic.hub',
+        title: 'Synthetic',
+        type: 'mixed',
+        items: const [],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [untrackable],
+        collections: const [],
+        sections: const [],
+        rowOrder: const ['custom:something-else'],
+      );
+
+      expect(result.map((h) => h.identifier), ['synthetic.hub']);
+    });
+
+    test('a hub with no libraryId of its own borrows one from its items, matching its Organizer token', () {
+      // Live root cause (#1652 follow-up): the Plex client never sets
+      // MediaHub.libraryId itself -- the section id it computes per hub only
+      // gets pushed down onto that hub's own items. Without this fallback,
+      // every real hub was "untrackable" and the Organizer could never
+      // filter or order anything.
+      final hubWithNoOwnLibraryId = MediaHub(
+        id: 'movie.recentlyreleased.7',
+        identifier: 'movie.recentlyreleased.7',
+        title: 'Recently Released Movies',
+        type: 'movie',
+        serverId: 'srv',
+        items: [testMediaItem(id: 'item-1', libraryId: '7')],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [hubWithNoOwnLibraryId],
+        collections: const [],
+        sections: const [],
+        rowOrder: const ['plex:srv:7:movie.recentlyreleased.7'],
+      );
+
+      expect(result.map((h) => h.identifier), ['movie.recentlyreleased.7']);
+    });
+
+    test('two fetch legs returning the same hub collapse into one row, not a duplicate', () {
+      // Live root cause: additionalLibraryHubKinds' per-library fetch can
+      // return the exact same hub the global/promoted fetch already did,
+      // producing a literal duplicate entry in sourceHubs.
+      MediaHub sameHub() => MediaHub(
+        id: 'movie.recentlyreleased.7',
+        identifier: 'movie.recentlyreleased.7',
+        title: 'Recently Released Movies',
+        type: 'movie',
+        serverId: 'srv',
+        items: [testMediaItem(id: 'item-1', libraryId: '7')],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [sameHub(), sameHub()],
+        collections: const [],
+        sections: const [],
+        rowOrder: const ['plex:srv:7:movie.recentlyreleased.7'],
+      );
+
+      expect(result, hasLength(1));
+    });
+
+    test('the Organizer\'s saved identifier matches a differently-suffixed content identifier', () {
+      // Live root cause: Plex's hub-management API (what the Organizer's
+      // saved token is built from) and its hub-content API (what actually
+      // renders on Home) return DIFFERENT identifier strings for the same
+      // conceptual hub -- e.g. "movie.recentlyreleased" (managed) vs.
+      // "movie.recentlyreleased.7" (content), confirmed live. Matching must
+      // tolerate the content identifier extending the managed one, not
+      // require exact equality.
+      final contentHub = MediaHub(
+        id: 'movie.recentlyreleased.7',
+        identifier: 'movie.recentlyreleased.7',
+        title: 'Recently Released Movies',
+        type: 'movie',
+        serverId: 'srv',
+        items: [testMediaItem(id: 'item-1', libraryId: '7')],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [contentHub],
+        collections: const [],
+        sections: const [],
+        // The Organizer saved the shorter, managed-API identifier.
+        rowOrder: const ['plex:srv:7:movie.recentlyreleased'],
+      );
+
+      expect(result.map((h) => h.identifier), ['movie.recentlyreleased.7']);
+    });
+
+    test('a managed identifier does not cross-match a same-named hub from a different library', () {
+      final library1Hub = MediaHub(
+        id: 'movie.recentlyreleased.1',
+        identifier: 'movie.recentlyreleased.1',
+        title: 'Recently Released Movies',
+        type: 'movie',
+        serverId: 'srv',
+        items: [testMediaItem(id: 'item-1', libraryId: '1')],
+      );
+      final library7Hub = MediaHub(
+        id: 'movie.recentlyreleased.7',
+        identifier: 'movie.recentlyreleased.7',
+        title: 'Recently Released Movies',
+        type: 'movie',
+        serverId: 'srv',
+        items: [testMediaItem(id: 'item-2', libraryId: '7')],
+      );
+
+      final result = buildConfiguredHomeSections(
+        sourceHubs: [library1Hub, library7Hub],
+        collections: const [],
+        sections: const [],
+        rowOrder: const ['plex:srv:7:movie.recentlyreleased'],
+      );
+
+      // Only library 7's hub is in the Organizer's saved order -- library
+      // 1's same-titled hub must not be pulled in by mistake.
+      expect(result.map((h) => h.identifier), ['movie.recentlyreleased.7']);
+    });
+  });
+}


### PR DESCRIPTION
closes #1652.

adds configurable home rows:
- merge recently added / recently released across whichever libraries you pick. one combined row instead of one per library
- movie/show collection rows, scoped to whichever libraries or specific collections you pick. pick one collection and the row shows its titles directly, pick more and each shows as a poster you tap to open

settings > home layout:
- "add home row" to create one. pick the type, which libraries or collections feed it, and whether it also shows in library recommended and/or home
- new rows land at the top of the organizer, use the arrows to reorder
- tap a row in settings to edit it, delete removes it (asks to confirm)
- plex-managed rows (the ones from plex's own home manager) live in the same organizer. promote/demote with the "home" checkbox, remove entirely with the x

whatever order you set in the organizer is what shows on home now.

also added a line to the README's feature list for this.

tested: 81 tests, plus a manual pass adding/editing/deleting/reordering rows on a real windows build.

---

update: hero cards + trailer preview

any row (custom, plex-managed, or continue watching) can now be toggled to render as a hero card instead of a normal poster shelf, same row order, just bigger. on top of that, hero rows can optionally preview a trailer on hover:

- mouse hover dwells 3s before it plays, stops the instant you move off, goes back to the poster when the clip ends on its own
- continue watching hero cards preview your actual resume point instead of a trailer (capped at 30s), and clicking play still resumes from where you actually left off, not the preview's start
- hero/trailer settings follow the row wherever it's shown, not just home. a library's own recommended tab now respects the same per-row toggle
- tapping a hero card's poster and tapping it mid-trailer are separately configurable (play the item directly, or open its details page)
- continue watching gets its own per-library toggle + hero/trailer controls for that library's recommended tab, independent of the global home one
- reordering the organizer and each library's row list is click-hold-drag anywhere on the row now instead of arrow buttons, locked by default so a stray click can't reorder things
- continue watching's organizer entry is a checkbox now instead of an x, it had no way to get re-added once removed unlike every other row type

fixed along the way: the native video surface popping up in the wrong spot for a frame before snapping into place, letterboxed trailers showing black bars instead of filling their box, and a real bug where home and a library's recommended tab each had their own video controller and fought over the one video core the app actually has (showed up as a silently-black video on whichever one lost).

AI-assisted: Claude (Sonnet 5), used throughout for implementation, debugging, and testing.