### PR TITLE
fix(seerr): preserve permissions for local login

### DIFF
--- a/lib/services/seerr/seerr_auth_service.dart
+++ b/lib/services/seerr/seerr_auth_service.dart
@@ -427,7 +427,8 @@ class SeerrAuthService {
   Future<SeerrUser> _resolveUser(SeerrHttpClient client, dynamic loginData) async {
     if (loginData is Map<String, dynamic>) {
       try {
-        return SeerrUser.fromJson(loginData);
+        final user = SeerrUser.fromJson(loginData);
+        if (user.permissions != null) return user;
       } catch (_) {
         // fall through to /auth/me
       }

--- a/test/services/seerr/seerr_client_test.dart
+++ b/test/services/seerr/seerr_client_test.dart
@@ -134,6 +134,36 @@ void main() {
       expect(session.displayName, 'Alice');
     });
 
+    test('local sign-in refreshes an incomplete user from auth/me', () async {
+      final paths = <String>[];
+      String? meCookie;
+      final auth = SeerrAuthService(
+        httpClientFactory: () => MockClient((request) async {
+          paths.add(request.url.path);
+          if (request.url.path == '/api/v1/auth/local') {
+            return _json(
+              {'id': 7, 'displayName': 'Alice'},
+              headers: {'set-cookie': '${SeerrConstants.sessionCookieName}=fresh'},
+            );
+          }
+          expect(request.url.path, '/api/v1/auth/me');
+          meCookie = request.headers['Cookie'];
+          return _json({'id': 7, 'displayName': 'Alice', 'permissions': SeerrPermission.request});
+        }),
+      );
+
+      final session = await auth.signInWithLocal(
+        baseUrl: 'https://seerr.example.com',
+        email: 'a@b.c',
+        password: 'hunter2',
+      );
+
+      expect(paths, ['/api/v1/auth/local', '/api/v1/auth/me']);
+      expect(meCookie, '${SeerrConstants.sessionCookieName}=fresh');
+      expect(session.permissions, SeerrPermission.request);
+      expect(session.permissions, isNot(0));
+    });
+
     test('plex sign-in posts the token and stores no secret', () async {
       late Map<String, dynamic> body;
       final auth = SeerrAuthService(


### PR DESCRIPTION
## Summary

- Root cause: local Seerr login responses can omit `permissions`; Plezy parsed that valid response as complete, skipped `/auth/me`, and stored permissions as `0`.
- Minimal fix: fall through to `/auth/me` whenever the parsed login user has no permissions, using the fresh session cookie.
- Regression test: verifies `/auth/local` without permissions calls `/auth/me` with the fresh cookie and preserves `SeerrPermission.request` in the session.

## Checks

- `flutter pub get` — NOT RUN: `flutter` is unavailable (`command not found`).
- `scripts/codegen.sh` — NOT RUN: `dart` is unavailable (`command not found`).
- `scripts/run_tests.sh test/services/seerr/seerr_client_test.dart` — NOT RUN: `flutter` is unavailable.
- `dart format .` — NOT RUN: `dart` is unavailable (`command not found`).
- `scripts/format_native.sh --fix` — NOT RUN: no JDK 17+ is available.
- `flutter analyze` — NOT RUN: `flutter` is unavailable (`command not found`).
- `scripts/run_tests.sh` — NOT RUN: `flutter` is unavailable.
- `scripts/codegen.sh --check` — NOT RUN: `dart` is unavailable (`command not found`).
- `git diff --check` — PASS.

Closes #2213

AI assistance: GPT-5.6 Sol (ChatGPT) was used for repository analysis, root-cause verification, and patch/test planning. GPT-5.6-Luna was used in this Paseo run for implementation and review.