### PR TITLE
fix(player): avoid macOS window resize stalls

### DIFF
--- a/lib/screens/video_player/parts/build.dart
+++ b/lib/screens/video_player/parts/build.dart
@@ -224,6 +224,14 @@ extension _VideoPlayerBuildMethods on VideoPlayerScreenState {
           hideOnExit: hideChromeOnMouseExit,
           child: Stack(
             children: [
+              // Temporary workaround for https://github.com/flutter/flutter/issues/190075
+              // until https://github.com/flutter/flutter/pull/191862 is available.
+              if (Platform.isMacOS)
+                const Positioned(
+                  width: 1,
+                  height: 1,
+                  child: ColoredBox(color: Colors.black),
+                ),
               // macOS PiP placeholder — video is in PiP window, show background with icon
               // Placed before Video so controls render on top
               if (Platform.isMacOS) const VideoPlayerMacPipPlaceholder(),


### PR DESCRIPTION
Added a temporary workaround to an issue that causes the player window on macOS to resize in roughly one-second steps while media is playing or paused.

## Changes
- Keep a 1×1 Flutter backing store alive behind the macOS player UI so Flutter's resize synchronizer does not time out on empty frames.
- Only affects macOS, the native player and other platforms are affected.
- Treat this as a temporary workaround for [Flutter issue #190075](https://github.com/flutter/flutter/issues/190075) while [Flutter PR #191862](https://github.com/flutter/flutter/pull/191862) awaits approval. It can be removed once Plezy uses a Flutter version containing that fix.

## Testing
- Profiled resizing in the main interface and during playing and paused video.
- Reduced average player resize callback gaps from 427–650 ms to 8–10 ms.


https://github.com/user-attachments/assets/240f352e-28bd-4e54-ae00-2914750aa57b


