### PR TITLE
fix(tvos): adopt UIScene lifecycle for Xcode 27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,9 @@ jobs:
 
       - name: Verify tvOS project wiring
         if: matrix.platform == 'tvOS'
-        run: ruby tvos/scripts/test_wire_mpv.rb
+        run: |
+          ruby tvos/scripts/test_wire_mpv.rb
+          ruby tvos/scripts/test_wire_top_shelf.rb
 
       - name: Select Apple test destination
         env:

--- a/tvos/Flutter/AppFrameworkInfo.plist
+++ b/tvos/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>14.0</string>
+  <string>15.0</string>
 </dict>
 </plist>

--- a/tvos/Flutter/Flutter.podspec
+++ b/tvos/Flutter/Flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   s.ios.deployment_target  = '13.0'
-  s.tvos.deployment_target = '14.0'
+  s.tvos.deployment_target = '15.0'
   # Framework linking is handled by Flutter tooling, not CocoaPods.
   # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
   s.vendored_frameworks = 'path/to/nothing'

--- a/tvos/Podfile
+++ b/tvos/Podfile
@@ -1,4 +1,4 @@
-platform :tvos, '14.0'
+platform :tvos, '15.0'
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
 project 'Runner', {
@@ -73,6 +73,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       is_debug = config.name.downcase.include?('debug')
+      config.build_settings['TVOS_DEPLOYMENT_TARGET'] = '15.0'
       config.build_settings['FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]'] = [
         '$(inherited)',
         simulator_engine,

--- a/tvos/Runner.xcodeproj/project.pbxproj
+++ b/tvos/Runner.xcodeproj/project.pbxproj
@@ -851,6 +851,7 @@
 			baseConfigurationReference = 1CC83B6BDD3EF9204BEF754B /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = G88U5B5783;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.edde746.plezy.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1084,6 +1085,7 @@
 			baseConfigurationReference = 41369A2B262AECB35079F6CC /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = G88U5B5783;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.edde746.plezy.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1102,6 +1104,7 @@
 			baseConfigurationReference = A2484B9C94406BF0A99EB64A /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = G88U5B5783;
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.edde746.plezy.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/tvos/Runner.xcodeproj/project.pbxproj
+++ b/tvos/Runner.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		CD1C0534948840272E58248E /* PathMonitorConnectivityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEF79DFBD1D80F00AB39CDA /* PathMonitorConnectivityProvider.swift */; };
 		D2004D7BB4A40340AB7A01E0 /* TvosEventDeliveryCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6C8125B201A8BC3261AE2B /* TvosEventDeliveryCoordinatorTests.swift */; };
 		D2A548D9DE1A0F319B30B74C /* SystemShelfPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0760C00EDC55A4D718BCB406 /* SystemShelfPlugin.swift */; };
+		E2CF133189FD5CD5272A4653 /* SceneLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026EA157972BC2E9A90763AC /* SceneLifecycleTests.swift */; };
 		E3DEAD2AAFC347A2E55AC0F7 /* SharedPreferencesPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0455EBA0EF4A61D3B71D2D7 /* SharedPreferencesPlugin.swift */; };
 		E79A4474D308631AFA59CAE7 /* DeviceInfoPlusPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1F41676FEF1AB57076F8B9 /* DeviceInfoPlusPlugin.swift */; };
 		EA0F4264E7B912702C490109 /* MPVKit in Frameworks */ = {isa = PBXBuildFile; productRef = EA0F4263E7B912702C490108 /* MPVKit */; };
@@ -95,6 +96,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		026EA157972BC2E9A90763AC /* SceneLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SceneLifecycleTests.swift; sourceTree = "<group>"; };
 		035F0D5A5E54BE7AD9AFA23C /* TopShelfExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; name = TopShelfExtension.appex; path = TopShelfExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		04DD35536DEE7C27FFA53862 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		0760C00EDC55A4D718BCB406 /* SystemShelfPlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemShelfPlugin.swift; sourceTree = "<group>"; };
@@ -362,6 +364,7 @@
 				934BC4E316D2AC788C954766 /* ConnectivityPlusPluginTests.swift */,
 				A5E1F001234567890ABCDE01 /* SystemShelfPluginTests.swift */,
 				5D44F4361594F517C002DC45 /* TopShelfFetchContractTests.swift */,
+				026EA157972BC2E9A90763AC /* SceneLifecycleTests.swift */,
 			);
 			name = RunnerTests;
 			path = RunnerTests;
@@ -617,6 +620,7 @@
 				65AC2C222043B3E6723E2076 /* ConnectivityPlusPluginTests.swift in Sources */,
 				A5E1F001234567890ABCDE02 /* SystemShelfPluginTests.swift in Sources */,
 				0092CB48B2682E3D69B1A09F /* TopShelfFetchContractTests.swift in Sources */,
+				E2CF133189FD5CD5272A4653 /* SceneLifecycleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/tvos/Runner.xcodeproj/project.pbxproj
+++ b/tvos/Runner.xcodeproj/project.pbxproj
@@ -743,7 +743,7 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -811,7 +811,7 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Debug;
 		};
@@ -841,7 +841,7 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -859,7 +859,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -890,7 +890,7 @@
 				SUPPORTED_PLATFORMS = "appletvos appletvsimulator";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -946,7 +946,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Debug;
 		};
@@ -998,7 +998,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1092,7 +1092,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -1110,7 +1110,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
-				TVOS_DEPLOYMENT_TARGET = 14.0;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
 			};
 			name = Debug;
 		};

--- a/tvos/Runner/AppDelegate.swift
+++ b/tvos/Runner/AppDelegate.swift
@@ -113,7 +113,7 @@ import wakelock_plus
 }
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -140,44 +140,50 @@ import wakelock_plus
       _ = SystemShelfPlugin.handleOpenURL(url)
     }
 
-    if let r = self.registrar(forPlugin: "SharedPreferencesPlugin") {
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  // UIScene creates the storyboard's Flutter engine after application launch.
+  // Register plugins against that engine instead of creating a second one.
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    let pluginRegistry = engineBridge.pluginRegistry
+
+    if let r = pluginRegistry.registrar(forPlugin: "SharedPreferencesPlugin") {
       SharedPreferencesPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "MpvPlayerPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "MpvPlayerPlugin") {
       MpvPlayerPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "MpvAudioPlayerPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "MpvAudioPlayerPlugin") {
       MpvAudioPlayerPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "PackageInfoPlusPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "PackageInfoPlusPlugin") {
       PackageInfoPlusPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "PathProviderPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "PathProviderPlugin") {
       PathProviderPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "GamepadPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "GamepadPlugin") {
       GamepadPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "DeviceInfoPlusPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "DeviceInfoPlusPlugin") {
       DeviceInfoPlusPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "ConnectivityPlusPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "ConnectivityPlusPlugin") {
       ConnectivityPlusPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "OsMediaControlsPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "OsMediaControlsPlugin") {
       OsMediaControlsPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "WakelockPlusPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "WakelockPlusPlugin") {
       WakelockPlusPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "SystemShelfPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "SystemShelfPlugin") {
       SystemShelfPlugin.register(with: r)
     }
-    if let r = self.registrar(forPlugin: "VideoDecodeCapabilitiesPlugin") {
+    if let r = pluginRegistry.registrar(forPlugin: "VideoDecodeCapabilitiesPlugin") {
       VideoDecodeCapabilitiesPlugin.register(with: r)
     }
-
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   override func application(

--- a/tvos/Runner/Info.plist
+++ b/tvos/Runner/Info.plist
@@ -33,13 +33,6 @@
 			</array>
 		</dict>
 	</array>
-	<!-- canOpenURL returns false for undeclared schemes, which both blocks the
-	     external-player handoff and hides the players from Settings. -->
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>vlc</string>
-		<string>infuse</string>
-	</array>
 	<key>GCSupportedGameControllers</key>
 	<array>
 		<dict>
@@ -57,10 +50,38 @@
 	<true/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<!-- canOpenURL returns false for undeclared schemes, which both blocks the
+	     external-player handoff and hides the players from Settings. -->
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>vlc</string>
+		<string>infuse</string>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
 	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/tvos/Runner/SystemShelfPlugin.swift
+++ b/tvos/Runner/SystemShelfPlugin.swift
@@ -264,7 +264,7 @@ import TVServices
     let notifyChange: () -> Void
   }
 
-  final class SystemShelfPlugin: NSObject, FlutterPlugin {
+  final class SystemShelfPlugin: NSObject, FlutterPlugin, FlutterSceneLifeCycleDelegate {
     static let schemaVersion = 3
     static let appGroupIdentifier = "group.com.edde746.plezy"
     static let cacheDataKey = "PlezySystemShelfCacheData"
@@ -297,7 +297,10 @@ import TVServices
       }
       methodChannel = channel
       deepLinkDelivery.bindEngine()
-      registrar.addMethodCallDelegate(SystemShelfPlugin(engineEpoch: engineEpoch), channel: channel)
+      let instance = SystemShelfPlugin(engineEpoch: engineEpoch)
+      registrar.addMethodCallDelegate(instance, channel: channel)
+      // Top Shelf links are delivered through UIScene once that lifecycle is enabled.
+      registrar.addSceneDelegate(instance)
       mutationQueue.async { scrubLegacyPayload() }
     }
 
@@ -310,6 +313,33 @@ import TVServices
         break
       }
       return true
+    }
+
+    static func handleSceneURLs(
+      _ urls: [URL],
+      using handler: (URL) -> Bool = SystemShelfPlugin.handleOpenURL
+    ) -> Bool {
+      var handled = false
+      for url in urls where handler(url) {
+        handled = true
+      }
+      return handled
+    }
+
+    func scene(
+      _ scene: UIScene,
+      willConnectTo session: UISceneSession,
+      options connectionOptions: UIScene.ConnectionOptions?
+    ) -> Bool {
+      guard let connectionOptions else { return false }
+      return Self.handleSceneURLs(connectionOptions.urlContexts.map(\.url))
+    }
+
+    func scene(
+      _ scene: UIScene,
+      openURLContexts URLContexts: Set<UIOpenURLContext>
+    ) -> Bool {
+      Self.handleSceneURLs(URLContexts.map(\.url))
     }
 
     private static func contentId(from url: URL) -> String? {

--- a/tvos/RunnerTests/FlutterNativeTextInputTests.mm
+++ b/tvos/RunnerTests/FlutterNativeTextInputTests.mm
@@ -32,8 +32,7 @@
 
 - (void)setUp {
   [super setUp];
-  id<UIApplicationDelegate> appDelegate = UIApplication.sharedApplication.delegate;
-  _window = appDelegate.window;
+  _window = [self windowContainingFlutterViewController];
   _flutterViewController = (FlutterViewController*)_window.rootViewController;
   XCTAssertTrue([_flutterViewController isKindOfClass:[FlutterViewController class]]);
   _engine = _flutterViewController.engine;
@@ -48,6 +47,25 @@
   _flutterViewController = nil;
   _window = nil;
   [super tearDown];
+}
+
+- (UIWindow*)windowContainingFlutterViewController {
+  id<UIApplicationDelegate> appDelegate = UIApplication.sharedApplication.delegate;
+  if ([appDelegate.window.rootViewController isKindOfClass:[FlutterViewController class]]) {
+    return appDelegate.window;
+  }
+
+  for (UIScene* scene in UIApplication.sharedApplication.connectedScenes) {
+    if (![scene isKindOfClass:[UIWindowScene class]]) {
+      continue;
+    }
+    for (UIWindow* window in ((UIWindowScene*)scene).windows) {
+      if ([window.rootViewController isKindOfClass:[FlutterViewController class]]) {
+        return window;
+      }
+    }
+  }
+  return nil;
 }
 
 - (void)testPackagedEngineUsesRealUITextFieldProxyAndNativeSessionRouting {

--- a/tvos/RunnerTests/SceneLifecycleTests.swift
+++ b/tvos/RunnerTests/SceneLifecycleTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Runner
+
+final class SceneLifecycleTests: XCTestCase {
+  func testRunnerDeclaresSingleFlutterSceneLifecycle() throws {
+    let manifest = try XCTUnwrap(
+      Bundle(for: AppDelegate.self).object(forInfoDictionaryKey: "UIApplicationSceneManifest")
+        as? [String: Any]
+    )
+    XCTAssertEqual(manifest["UIApplicationSupportsMultipleScenes"] as? Bool, false)
+
+    let configurations = try XCTUnwrap(manifest["UISceneConfigurations"] as? [String: Any])
+    let applicationScenes = try XCTUnwrap(
+      configurations["UIWindowSceneSessionRoleApplication"] as? [[String: Any]]
+    )
+    let configuration = try XCTUnwrap(applicationScenes.first)
+    XCTAssertEqual(applicationScenes.count, 1)
+    XCTAssertEqual(configuration["UISceneClassName"] as? String, "UIWindowScene")
+    XCTAssertEqual(configuration["UISceneConfigurationName"] as? String, "flutter")
+    XCTAssertEqual(configuration["UISceneDelegateClassName"] as? String, "FlutterSceneDelegate")
+    XCTAssertEqual(configuration["UISceneStoryboardFile"] as? String, "Main")
+  }
+
+  func testSceneURLRoutingReportsAcceptedURLAndVisitsEveryContext() {
+    let urls = [
+      URL(string: "https://example.com/first")!,
+      URL(string: "plezy://play?content_id=server%3Aitem")!,
+      URL(string: "https://example.com/last")!,
+    ]
+    var visited: [URL] = []
+
+    let handled = SystemShelfPlugin.handleSceneURLs(urls) { url in
+      visited.append(url)
+      return url.scheme == "plezy"
+    }
+
+    XCTAssertTrue(handled)
+    XCTAssertEqual(visited, urls)
+  }
+
+  func testSceneURLRoutingReturnsFalseWhenNoContextIsAccepted() {
+    let urls = [URL(string: "https://example.com/unhandled")!]
+
+    XCTAssertFalse(SystemShelfPlugin.handleSceneURLs(urls) { _ in false })
+    XCTAssertFalse(SystemShelfPlugin.handleSceneURLs([]) { _ in true })
+  }
+}

--- a/tvos/scripts/Info.plist
+++ b/tvos/scripts/Info.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>14.0</string>
+  <string>15.0</string>
 </dict>
 </plist>

--- a/tvos/scripts/fetch_engine.sh
+++ b/tvos/scripts/fetch_engine.sh
@@ -95,7 +95,7 @@ fi
 PUB_NAME="${PUB_NAME:-1.0.0}"
 PUB_NUMBER="${PUB_NUMBER:-1}"
 
-# tvOS deployment target is hard-coded at the Podfile / project level to 14.0.
+# tvOS deployment target is hard-coded at the Podfile / project level to 15.0.
 # Write Generated.xcconfig so Xcode (and the Run Script phase) see the engine.
 GEN_XC="${TVOS_DIR}/Flutter/Generated.xcconfig"
 mkdir -p "$(dirname "$GEN_XC")"
@@ -105,7 +105,7 @@ FLUTTER_APPLICATION_PATH=${REPO_ROOT}
 FLUTTER_TARGET=lib/main.dart
 FLUTTER_BUILD_NAME=${PUB_NAME}
 FLUTTER_BUILD_NUMBER=${PUB_NUMBER}
-TVOS_DEPLOYMENT_TARGET=14.0
+TVOS_DEPLOYMENT_TARGET=15.0
 FLUTTER_LOCAL_ENGINE=${ENGINE_DIR}
 PODS_ROOT=${TVOS_DIR}/Pods
 EOF

--- a/tvos/scripts/set_tvos_target_pods.sh
+++ b/tvos/scripts/set_tvos_target_pods.sh
@@ -10,8 +10,6 @@ echo "pathching $PWD/project.pbxproj ..."
 find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/TARGETED_DEVICE_FAMILY[[:space:]]=[[:space:]]\"1,2\"/TARGETED_DEVICE_FAMILY = \"3\"/g'
 find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/SDKROOT[[:space:]]=[[:space:]]iphoneos/SDKROOT = appletvos/g'
 find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/SUPPORTED_PLATFORMS[[:space:]]=[[:space:]]iphoneos/SUPPORTED_PLATFORMS = appletvos/g'
-find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/IPHONEOS_DEPLOYMENT_TARGET[[:space:]]=[[:space:]]9.0/TVOS_DEPLOYMENT_TARGET = 13.0/g'
+find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/IPHONEOS_DEPLOYMENT_TARGET[[:space:]]=[[:space:]][0-9][0-9]*\.[0-9][0-9]*/TVOS_DEPLOYMENT_TARGET = 15.0/g'
 
 cd ../..
-
-

--- a/tvos/scripts/set_tvos_target_runner.sh
+++ b/tvos/scripts/set_tvos_target_runner.sh
@@ -10,8 +10,6 @@ echo "pathching $PWD/project.pbxproj ..."
 find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/TARGETED_DEVICE_FAMILY[[:space:]]=[[:space:]]\"1,2\"/TARGETED_DEVICE_FAMILY = \"3\"/g'
 find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/SDKROOT[[:space:]]=[[:space:]]iphoneos/SDKROOT = appletvos/g'
 find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/SUPPORTED_PLATFORMS[[:space:]]=[[:space:]]iphoneos/SUPPORTED_PLATFORMS = appletvos/g'
-find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/IPHONEOS_DEPLOYMENT_TARGET[[:space:]]=[[:space:]][0-9].[0-9]/TVOS_DEPLOYMENT_TARGET = 13.0/g'
+find . -name 'project.pbxproj' -print0 | xargs -0 sed -i '' -e 's/IPHONEOS_DEPLOYMENT_TARGET[[:space:]]=[[:space:]][0-9][0-9]*\.[0-9][0-9]*/TVOS_DEPLOYMENT_TARGET = 15.0/g'
 
 cd ..
-
-

--- a/tvos/scripts/test_wire_top_shelf.rb
+++ b/tvos/scripts/test_wire_top_shelf.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+require 'minitest/autorun'
+require 'open3'
+require 'rbconfig'
+require 'tmpdir'
+require 'xcodeproj'
+
+class WireTopShelfTest < Minitest::Test
+  def setup
+    @temporary_root = Dir.mktmpdir('wire-top-shelf-test')
+    @tvos_root = File.join(@temporary_root, 'tvos')
+    FileUtils.mkdir_p(File.join(@tvos_root, 'scripts'))
+    FileUtils.cp_r(File.expand_path('../Runner.xcodeproj', __dir__), @tvos_root)
+    FileUtils.cp_r(File.expand_path('../RunnerTests', __dir__), @tvos_root)
+    FileUtils.cp(
+      File.expand_path('wire_top_shelf.rb', __dir__),
+      File.join(@tvos_root, 'scripts')
+    )
+
+    project = Xcodeproj::Project.open(project_path)
+    runner = target(project, 'Runner')
+    runner.build_configurations.each do |configuration|
+      suffix = configuration.name.downcase
+      if configuration.name == 'Profile'
+        configuration.build_settings.delete('DEVELOPMENT_TEAM')
+      else
+        configuration.build_settings['DEVELOPMENT_TEAM'] = "TEAM-#{suffix}"
+      end
+      configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = "dev.plezy.#{suffix}"
+    end
+    %w[RunnerTests TopShelfExtension].each do |name|
+      target(project, name).build_configurations.each do |configuration|
+        configuration.build_settings['DEVELOPMENT_TEAM'] = 'STALE-TEAM'
+        configuration.build_settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'stale.bundle'
+        configuration.build_settings['TVOS_DEPLOYMENT_TARGET'] = '14.0'
+      end
+    end
+    project.save
+  end
+
+  def teardown
+    FileUtils.remove_entry(@temporary_root)
+  end
+
+  def test_inherits_runner_identity_and_sets_supported_deployment_target
+    run_wire_top_shelf
+    run_wire_top_shelf
+
+    project = Xcodeproj::Project.open(project_path)
+    runner = target(project, 'Runner')
+    runner_tests = target(project, 'RunnerTests')
+    top_shelf = target(project, 'TopShelfExtension')
+
+    runner.build_configurations.each do |runner_configuration|
+      expected_team = runner_configuration.build_settings['DEVELOPMENT_TEAM']
+      expected_bundle = runner_configuration.build_settings.fetch('PRODUCT_BUNDLE_IDENTIFIER')
+
+      assert_generated_configuration(
+        runner_tests,
+        runner_configuration.name,
+        expected_team,
+        "#{expected_bundle}.RunnerTests"
+      )
+      assert_generated_configuration(
+        top_shelf,
+        runner_configuration.name,
+        expected_team,
+        "#{expected_bundle}.TopShelfExtension"
+      )
+    end
+
+    assert_equal 1, project.targets.count { |candidate| candidate.name == 'RunnerTests' }
+    assert_equal 1, project.targets.count { |candidate| candidate.name == 'TopShelfExtension' }
+  end
+
+  private
+
+  def project_path
+    File.join(@tvos_root, 'Runner.xcodeproj')
+  end
+
+  def target(project, name)
+    project.targets.find { |candidate| candidate.name == name } || raise("#{name} target not found")
+  end
+
+  def run_wire_top_shelf
+    script = File.join(@tvos_root, 'scripts', 'wire_top_shelf.rb')
+    output, status = Open3.capture2e(RbConfig.ruby, script)
+    assert status.success?, output
+  end
+
+  def assert_generated_configuration(target, name, expected_team, expected_bundle)
+    configuration = target.build_configurations.find { |candidate| candidate.name == name }
+    refute_nil configuration, "#{target.name} has no #{name} configuration"
+
+    settings = configuration.build_settings
+    if expected_team
+      assert_equal expected_team, settings['DEVELOPMENT_TEAM']
+    else
+      assert_nil settings['DEVELOPMENT_TEAM']
+    end
+    assert_equal expected_bundle, settings['PRODUCT_BUNDLE_IDENTIFIER']
+    assert_equal '15.0', settings['TVOS_DEPLOYMENT_TARGET']
+  end
+end

--- a/tvos/scripts/wire_top_shelf.rb
+++ b/tvos/scripts/wire_top_shelf.rb
@@ -70,7 +70,7 @@ ensure_file(runner_group, 'Runner.entitlements')
 tests_group = main_group['RunnerTests'] || main_group.new_group('RunnerTests', 'RunnerTests')
 test_target = project.targets.find { |target| target.name == 'RunnerTests' }
 unless test_target
-  test_target = project.new_target(:unit_test_bundle, 'RunnerTests', :tvos, '14.0')
+  test_target = project.new_target(:unit_test_bundle, 'RunnerTests', :tvos, '15.0')
 end
 test_target.product_type = 'com.apple.product-type.bundle.unit-test'
 test_target.frameworks_build_phase.files.delete_if do |build_file|
@@ -115,7 +115,7 @@ test_target.build_configurations.each do |config|
   settings['SWIFT_VERSION'] = '5.0'
   settings['TARGETED_DEVICE_FAMILY'] = '3'
   settings['TEST_HOST'] = '$(BUILT_PRODUCTS_DIR)/Runner.app/Runner'
-  settings['TVOS_DEPLOYMENT_TARGET'] = '14.0'
+  settings['TVOS_DEPLOYMENT_TARGET'] = '15.0'
 end
 
 event_delivery_ref = ensure_file(runner_group, 'TvosEventDeliveryCoordinator.swift')
@@ -128,7 +128,7 @@ ensure_file(extension_group, 'TopShelfExtension.entitlements')
 
 extension_target = project.targets.find { |t| t.name == 'TopShelfExtension' }
 unless extension_target
-  extension_target = project.new_target(:app_extension, 'TopShelfExtension', :tvos, '14.0')
+  extension_target = project.new_target(:app_extension, 'TopShelfExtension', :tvos, '15.0')
 end
 extension_target.product_type = 'com.apple.product-type.app-extension'
 
@@ -209,7 +209,7 @@ extension_target.build_configurations.each do |config|
   settings['SUPPORTED_PLATFORMS'] = 'appletvos appletvsimulator'
   settings['SWIFT_VERSION'] = '5.0'
   settings['TARGETED_DEVICE_FAMILY'] = '3'
-  settings['TVOS_DEPLOYMENT_TARGET'] = '14.0'
+  settings['TVOS_DEPLOYMENT_TARGET'] = '15.0'
 end
 
 ensure_shell_script(

--- a/tvos/scripts/wire_top_shelf.rb
+++ b/tvos/scripts/wire_top_shelf.rb
@@ -63,6 +63,13 @@ def ensure_shell_script(target, name, script)
   phase
 end
 
+def runner_build_settings(runner, configuration_name)
+  configuration = runner.build_configurations.find { |candidate| candidate.name == configuration_name }
+  raise "Runner configuration #{configuration_name} not found" unless configuration
+
+  configuration.build_settings
+end
+
 system_shelf_ref = ensure_file(runner_group, 'SystemShelfPlugin.swift')
 ensure_source(runner, system_shelf_ref)
 ensure_file(runner_group, 'Runner.entitlements')
@@ -106,10 +113,18 @@ test_target.add_dependency(runner) unless test_target.dependencies.any? { |depen
 
 test_target.build_configurations.each do |config|
   settings = config.build_settings
+  runner_settings = runner_build_settings(runner, config.name)
+  runner_team = runner_settings['DEVELOPMENT_TEAM']
+  runner_bundle_identifier = runner_settings.fetch('PRODUCT_BUNDLE_IDENTIFIER')
   settings['BUNDLE_LOADER'] = '$(TEST_HOST)'
   settings.delete('CODE_SIGNING_ALLOWED')
+  if runner_team && !runner_team.empty?
+    settings['DEVELOPMENT_TEAM'] = runner_team
+  else
+    settings.delete('DEVELOPMENT_TEAM')
+  end
   settings['GENERATE_INFOPLIST_FILE'] = 'YES'
-  settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'com.edde746.plezy.RunnerTests'
+  settings['PRODUCT_BUNDLE_IDENTIFIER'] = "#{runner_bundle_identifier}.RunnerTests"
   settings['SDKROOT'] = 'appletvos'
   settings['SUPPORTED_PLATFORMS'] = 'appletvos appletvsimulator'
   settings['SWIFT_VERSION'] = '5.0'
@@ -187,13 +202,20 @@ extension_target.build_configurations.each do |config|
   config.base_configuration_reference = generated_config_ref
 
   settings = config.build_settings
+  runner_settings = runner_build_settings(runner, config.name)
+  runner_team = runner_settings['DEVELOPMENT_TEAM']
+  runner_bundle_identifier = runner_settings.fetch('PRODUCT_BUNDLE_IDENTIFIER')
   settings['APPLICATION_EXTENSION_API_ONLY'] = 'YES'
   settings['CLANG_ENABLE_MODULES'] = 'YES'
   settings['CODE_SIGN_ENTITLEMENTS'] = 'TopShelfExtension/TopShelfExtension.entitlements'
   settings['CODE_SIGN_IDENTITY'] = 'Apple Development'
   settings['CODE_SIGN_STYLE'] = 'Automatic'
   settings['CURRENT_PROJECT_VERSION'] = '$(FLUTTER_BUILD_NUMBER)'
-  settings['DEVELOPMENT_TEAM'] = 'G88U5B5783'
+  if runner_team && !runner_team.empty?
+    settings['DEVELOPMENT_TEAM'] = runner_team
+  else
+    settings.delete('DEVELOPMENT_TEAM')
+  end
   settings['ENABLE_BITCODE'] = 'NO'
   settings['INFOPLIST_FILE'] = 'TopShelfExtension/Info.plist'
   settings['LD_RUNPATH_SEARCH_PATHS'] = [
@@ -202,7 +224,7 @@ extension_target.build_configurations.each do |config|
     '@executable_path/../../Frameworks',
   ]
   settings['MARKETING_VERSION'] = '$(FLUTTER_BUILD_NAME)'
-  settings['PRODUCT_BUNDLE_IDENTIFIER'] = 'com.edde746.plezy.TopShelfExtension'
+  settings['PRODUCT_BUNDLE_IDENTIFIER'] = "#{runner_bundle_identifier}.TopShelfExtension"
   settings['PRODUCT_NAME'] = '$(TARGET_NAME)'
   settings['SDKROOT'] = 'appletvos'
   settings['SKIP_INSTALL'] = 'YES'


### PR DESCRIPTION
## Summary

- raise the minimum tvOS deployment target from 14.0 to 15.0 across the Runner, Flutter pod, generated targets, and build scripts
- adopt Flutter's UIScene lifecycle and register plugins with the implicit Flutter engine
- forward Top Shelf deep links through `FlutterSceneLifeCycleDelegate`
- make generated test and Top Shelf targets inherit the Runner's signing identity
- add regression coverage for scene configuration, URL routing, and generated target signing

## Context

This is a follow-up to #2092. After the Flutter 3.47.1 migration, the tvOS Runner still used the legacy application lifecycle and a deployment target no longer supported by Xcode 27.

Registering plugins from `application(_:didFinishLaunchingWithOptions:)` under the scene lifecycle could initialize the Flutter engine twice, resulting in a breakpoint or black screen at launch. Top Shelf URLs also need to enter through scene callbacks once UIScene is active.

## Implementation

The Runner now follows Flutter's UIScene migration pattern: its `AppDelegate` implements `FlutterImplicitEngineDelegate`, plugins register against the implicit engine, and the application manifest selects `FlutterSceneDelegate`. The System Shelf plugin registers as a scene lifecycle delegate and forwards both cold-start and already-running URL contexts through the existing deep-link path.

The minimum deployment target is consistently set to tvOS 15.0 in the checked-in project, CocoaPods configuration, Flutter framework metadata, and regeneration scripts. Generated test and Top Shelf targets derive their team and bundle identifiers from the matching Runner build configuration instead of retaining hard-coded signing values.

## Scope

This change affects tvOS only. It does not change Dart UI behavior, media-server integrations, or user-facing settings. No screenshots or documentation changes are included because there is no user-facing UI change.

## Verification

- 6,554 Flutter tests passed; 5 skipped; 0 failed
- 43/43 native tests passed on an Apple TV 4K (3rd generation) tvOS 27 simulator, with no runtime warnings in the test result
- a development-signed Debug build for a physical Apple TV 4K (3rd generation) running tvOS 27 succeeded
- the Top Shelf generator regression test passed with 28 assertions
- the MPV project-wiring test passed with 138 assertions
- code generation, Dart formatting, translations, UI string checks, workflow guards, icon checks, analyzer, unused-code, and unused-file checks passed

The complete native-format command remains blocked by two pre-existing ktlint violations in the unchanged `android/libmpv/build.gradle.kts` file. The same Native Formatting job is currently failing on upstream `main`; this focused tvOS change does not include unrelated Android formatting churn.

## Follow-up

Xcode 27 reports existing `AVAudioSession` hang-risk diagnostics for synchronous audio-session activation in the Runner and the `media_controls` dependency. Those calls predate this change and are intentionally left for a separate fix that can introduce the tvOS 27 asynchronous activation API while retaining a fallback for tvOS 15–26.

AI assistance: GPT-5 was used for research, planning, and review of the changes.
