### PR TITLE
fix(tvos): eliminate runtime and project build warnings

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -751,8 +751,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "75556a968a4a1ebc42fbb8c31942c2418d4326e1"
-      resolved-ref: "75556a968a4a1ebc42fbb8c31942c2418d4326e1"
+      ref: "a27208e641790029ac54d825b97508575caee1a7"
+      resolved-ref: "a27208e641790029ac54d825b97508575caee1a7"
       url: "https://github.com/edde746/media_controls"
     source: git
     version: "0.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   os_media_controls:
     git:
       url: https://github.com/edde746/media_controls
-      ref: 75556a968a4a1ebc42fbb8c31942c2418d4326e1
+      ref: a27208e641790029ac54d825b97508575caee1a7
   rate_limiter: ^1.0.0
   wakelock_plus:
     path: packages/wakelock_plus

--- a/tvos/Runner.xcodeproj/project.pbxproj
+++ b/tvos/Runner.xcodeproj/project.pbxproj
@@ -506,6 +506,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -559,6 +560,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -595,6 +597,7 @@
 		};
 		E2B5A6D75C9F4D1B9E8C7A63 /* Sync Version */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/tvos/Runner.xcodeproj/project.pbxproj
+++ b/tvos/Runner.xcodeproj/project.pbxproj
@@ -867,7 +867,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
-				TVOS_DEPLOYMENT_TARGET = 15.0;
+				TVOS_DEPLOYMENT_TARGET = 17.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1101,7 +1101,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
-				TVOS_DEPLOYMENT_TARGET = 15.0;
+				TVOS_DEPLOYMENT_TARGET = 17.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -1120,7 +1120,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/Runner";
-				TVOS_DEPLOYMENT_TARGET = 15.0;
+				TVOS_DEPLOYMENT_TARGET = 17.0;
 			};
 			name = Debug;
 		};

--- a/tvos/Runner/AppDelegate.swift
+++ b/tvos/Runner/AppDelegate.swift
@@ -118,13 +118,12 @@ import wakelock_plus
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    // Set the long-form profile before activation so Dolby capabilities are
-    // available before playback.
+    // Configure the long-form profile before playback. The media controls
+    // plugin claims the session when playback actually starts.
     do {
       let session = AVAudioSession.sharedInstance()
       try session.setCategory(
         .playback, mode: .default, policy: .longFormAudio, options: [])
-      try session.setActive(true)
     } catch {
       print("Failed to configure long-form audio session: \(error)")
       do {

--- a/tvos/scripts/test_wire_top_shelf.rb
+++ b/tvos/scripts/test_wire_top_shelf.rb
@@ -73,6 +73,9 @@ class WireTopShelfTest < Minitest::Test
 
     assert_equal 1, project.targets.count { |candidate| candidate.name == 'RunnerTests' }
     assert_equal 1, project.targets.count { |candidate| candidate.name == 'TopShelfExtension' }
+    assert_always_out_of_date(runner, 'Run Script')
+    assert_always_out_of_date(runner, 'Thin Binary')
+    assert_always_out_of_date(top_shelf, 'Sync Version')
   end
 
   private
@@ -89,6 +92,12 @@ class WireTopShelfTest < Minitest::Test
     script = File.join(@tvos_root, 'scripts', 'wire_top_shelf.rb')
     output, status = Open3.capture2e(RbConfig.ruby, script)
     assert status.success?, output
+  end
+
+  def assert_always_out_of_date(target, phase_name)
+    phase = target.shell_script_build_phases.find { |candidate| candidate.name == phase_name }
+    refute_nil phase, "#{target.name} has no #{phase_name} build phase"
+    assert_equal '1', phase.always_out_of_date
   end
 
   def assert_generated_configuration(target, name, expected_team, expected_bundle)

--- a/tvos/scripts/test_wire_top_shelf.rb
+++ b/tvos/scripts/test_wire_top_shelf.rb
@@ -61,13 +61,15 @@ class WireTopShelfTest < Minitest::Test
         runner_tests,
         runner_configuration.name,
         expected_team,
-        "#{expected_bundle}.RunnerTests"
+        "#{expected_bundle}.RunnerTests",
+        '17.0'
       )
       assert_generated_configuration(
         top_shelf,
         runner_configuration.name,
         expected_team,
-        "#{expected_bundle}.TopShelfExtension"
+        "#{expected_bundle}.TopShelfExtension",
+        '15.0'
       )
     end
 
@@ -100,7 +102,7 @@ class WireTopShelfTest < Minitest::Test
     assert_equal '1', phase.always_out_of_date
   end
 
-  def assert_generated_configuration(target, name, expected_team, expected_bundle)
+  def assert_generated_configuration(target, name, expected_team, expected_bundle, deployment_target)
     configuration = target.build_configurations.find { |candidate| candidate.name == name }
     refute_nil configuration, "#{target.name} has no #{name} configuration"
 
@@ -111,6 +113,6 @@ class WireTopShelfTest < Minitest::Test
       assert_nil settings['DEVELOPMENT_TEAM']
     end
     assert_equal expected_bundle, settings['PRODUCT_BUNDLE_IDENTIFIER']
-    assert_equal '15.0', settings['TVOS_DEPLOYMENT_TARGET']
+    assert_equal deployment_target, settings['TVOS_DEPLOYMENT_TARGET']
   end
 end

--- a/tvos/scripts/wire_top_shelf.rb
+++ b/tvos/scripts/wire_top_shelf.rb
@@ -131,7 +131,7 @@ test_target.build_configurations.each do |config|
   settings['SWIFT_VERSION'] = '5.0'
   settings['TARGETED_DEVICE_FAMILY'] = '3'
   settings['TEST_HOST'] = '$(BUILT_PRODUCTS_DIR)/Runner.app/Runner'
-  settings['TVOS_DEPLOYMENT_TARGET'] = '15.0'
+  settings['TVOS_DEPLOYMENT_TARGET'] = '17.0'
 end
 
 event_delivery_ref = ensure_file(runner_group, 'TvosEventDeliveryCoordinator.swift')

--- a/tvos/scripts/wire_top_shelf.rb
+++ b/tvos/scripts/wire_top_shelf.rb
@@ -60,6 +60,7 @@ def ensure_shell_script(target, name, script)
 
   phase.shell_path = '/bin/sh'
   phase.shell_script = script
+  phase.always_out_of_date = '1'
   phase
 end
 

--- a/tvos/scripts/xcode_appletv.sh
+++ b/tvos/scripts/xcode_appletv.sh
@@ -473,8 +473,6 @@ BuildAppDebug() {
       -o "$OUTDIR/App.framework/App" -
   fi
 
-  strip "$OUTDIR/App.framework/App"
-
   echo " └─copy frameworks"
   CopyAppFrameworkInfoPlist "$OUTDIR/App.framework/Info.plist" "$tvos_deployment_target"
 
@@ -630,8 +628,6 @@ BuildAppRelease() {
     -install_name @rpath/App.framework/App \
     -o "$OUTDIR/App.framework/App" \
     "$OUTDIR/snapshot_assembly.o"
-
-  strip "$OUTDIR/App.framework/App"
 
   CopyAppFrameworkInfoPlist "$OUTDIR/App.framework/Info.plist" "$tvos_deployment_target"
 


### PR DESCRIPTION
### Why this is ready now

This pull request was originally opened as a draft because its two commit-pinned dependencies were still under review. Publishing it as ready at that point would either have left the fixes incomplete or required Plezy to reference commits that existed only in contributor forks.

Both prerequisites are now complete:

- [media_controls PR #1](https://github.com/edde746/media_controls/pull/1) merged as public commit `a27208e641790029ac54d825b97508575caee1a7`, which this branch now pins.
- [mpv-build PR #1](https://github.com/edde746/mpv-build/pull/1) merged and its binary publication workflow completed successfully. Current Plezy `main` already pins public descendant `83879375c9e96b46b5711c038bed08690a9e8773`, which contains that correction.

The branch has also been rebased onto current Plezy `main`, and the complete project and tvOS verification has been repeated against those final public revisions. It is therefore ready for review.

### Summary

- configure the long-form playback category at launch without activating the audio session
- use the `media_controls` revision that activates the session away from the main thread
- mark the Runner, Flutter embedding, and Top Shelf version scripts as intentionally always running
- set the RunnerTests deployment target to tvOS 17, matching the current XCTest runtime while retaining tvOS 15 for the shipping targets
- avoid redundant `strip` calls for App.framework binaries that are already emitted without symbols
- extend the Top Shelf project-generation regression coverage

### Context

Xcode reports two AVAudioSession UI-hang risks: one from Plezy's launch-time activation and one from the media-controls plugin when playback state changes. It also reports project-owned warnings for script phases without dependency-analysis outputs, the tvOS 15 test target linking to the tvOS 17 XCTest runtime, and redundant stripping of symbol-free Flutter app binaries.

The previous MPVKit binary graph contributed seven additional warnings because the libuavs3d ARM64 assembly objects declared tvOS 17.5 while Plezy supports tvOS 15. The current Plezy base already contains the merged `mpv-build` correction.

This pull request keeps Plezy's production deployment target unchanged. It addresses each warning at its source and consumes the corresponding fixes from the two dependency repositories.

### Dependency pull requests

- `media_controls`: [PR #1](https://github.com/edde746/media_controls/pull/1) moves audio-session transitions off the main thread and removes the related tvOS compiler warning. This pull request pins its merged public revision.
- `mpv-build`: [PR #1](https://github.com/edde746/mpv-build/pull/1) consumes the corrected upstream libuavs3d binaries. Its publication workflow completed successfully, and the current Plezy base already pins a public descendant containing the fix.

The changes are split across three pull requests only because GitHub pull requests cannot span repositories. This Plezy pull request is the final integration point.

This work follows the remaining warning documented in [PR #2225](https://github.com/edde746/plezy/pull/2225). The open PR #1951 concerns AVFoundation multichannel output selection and does not overlap this session-lifecycle work.

### Scope

This affects tvOS Runner startup, Xcode project configuration, build scripts, tests, and the pinned media-controls dependency. It does not change Dart UI behavior, media-server integrations, codecs, signing, user-visible settings, or production deployment targets. No screenshots or documentation changes are required.

### Verification

The rebased branch and final public dependency revisions have been verified as follows:

- 6,591 Flutter tests passed; 5 skipped; 0 failed
- 43/43 native tests passed with Xcode 27 on an Apple TV 4K (3rd generation) tvOS 27 simulator
- 43/43 native tests passed with Xcode 26.6 on an Apple TV 4K (3rd generation) tvOS 26.5 simulator
- the Xcode 27 test result reported no runtime warnings
- Top Shelf generator regression test passed with 34 assertions
- code generation, Dart formatting, translation checks, workflow guards, icon checks, analyzer, unused-code checks, and unused-file checks passed
- an Xcode 27 Release build for a generic tvOS device completed with 0 build warnings
- a development-signed Debug build for a physical Apple TV 4K (3rd generation) had previously succeeded
- the AVAudioSession hang-risk diagnostic was not reproduced during subsequent manual testing

The complete native-format check remains blocked by two pre-existing ktlint findings in unchanged lines 78 and 91 of `android/libmpv/build.gradle.kts`. The same findings are present on upstream `main` and are unrelated to this tvOS-only change.

AI assistance: GPT-5 was used for research, planning, and review of the changes.
