### PR TITLE
fix(android): gate the DTS-HD IEC carrier on advertised DTS-HD support

### DIFF
--- a/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/AudioOutputPolicy.kt
+++ b/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/AudioOutputPolicy.kt
@@ -163,10 +163,7 @@ internal fun mpvSpdifCodecs(
 @Suppress("DEPRECATION")
 @OptIn(UnstableApi::class)
 internal fun supportedMpvSpdifCodecs(context: Context): String {
-  val audioAttributes = AudioAttributes.Builder()
-    .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
-    .setUsage(C.USAGE_MEDIA)
-    .build()
+  val audioAttributes = movieMedia3AudioAttributes()
   val capabilities = try {
     AudioCapabilities.getCapabilities(context, audioAttributes, null)
   } catch (error: Exception) {
@@ -302,6 +299,31 @@ internal fun supportsIecCarrier(context: Context): Boolean = iecRouteSupported(
 )
 
 /**
+ * Whether the route carries the IEC 61937 tuple *and* advertises DTS-HD. TrueHD rides the same
+ * tuple, so carrying it says nothing about whether the receiver decodes DTS-HD.
+ */
+internal fun dtsHdCarrierUsable(
+  supportsEncoding: (Int) -> Boolean,
+  supportsCarrier: () -> Boolean
+): Boolean = supportsEncoding(C.ENCODING_DTS_HD) && supportsCarrier()
+
+/** [dtsHdCarrierUsable] resolved against the audio route [context] is currently routed to. */
+internal fun supportsDtsHdIecCarrier(context: Context): Boolean = dtsHdCarrierUsable(
+  // Encoding first: it skips the carrier tiering's several route calls.
+  supportsEncoding = { encoding -> routeSupportsEncoding(context, encoding) },
+  supportsCarrier = { supportsIecCarrier(context) }
+)
+
+@Suppress("DEPRECATION")
+@OptIn(UnstableApi::class)
+private fun routeSupportsEncoding(context: Context, encoding: Int): Boolean = try {
+  AudioCapabilities.getCapabilities(context, movieMedia3AudioAttributes(), null).supportsEncoding(encoding)
+} catch (error: Exception) {
+  Log.w(TAG, "Audio route capabilities unavailable; DTS-HD will not bitstream", error)
+  false
+}
+
+/**
  * [supportsIecCarrier]/[supportsMpvIecShape] with the platform probes injected. Probes are only
  * consulted on the API tiers where they exist: [bitstreamSupported] (`getDirectPlaybackSupport`)
  * on 33+, [directPlaybackSupported] (`AudioTrack.isDirectPlaybackSupported`) on 29–32, and
@@ -378,8 +400,9 @@ private fun directProbeFormat(encoding: Int, sampleRate: Int, channelMask: Int):
   .setSampleRate(sampleRate)
   .build()
 
-private fun movieAudioAttributes(): android.media.AudioAttributes = AudioAttributes.Builder()
+private fun movieMedia3AudioAttributes(): AudioAttributes = AudioAttributes.Builder()
   .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
   .setUsage(C.USAGE_MEDIA)
   .build()
-  .getPlatformAudioAttributes()
+
+private fun movieAudioAttributes(): android.media.AudioAttributes = movieMedia3AudioAttributes().getPlatformAudioAttributes()

--- a/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/ExoPlayerCore.kt
+++ b/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/ExoPlayerCore.kt
@@ -2445,7 +2445,7 @@ class ExoPlayerCore(private val activity: Activity) :
    * is false the stream decodes regardless of the passthrough setting.
    */
   private fun routeCanBitstreamDts(mimeType: String): Boolean {
-    if (mimeType == MimeTypes.AUDIO_DTS_HD && supportsIecCarrier(activity)) return true
+    if (mimeType == MimeTypes.AUDIO_DTS_HD && supportsDtsHdIecCarrier(activity)) return true
     val audioAttributes = buildMovieAudioAttributes()
     return try {
       AudioCapabilities

--- a/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/IecCarrierSink.kt
+++ b/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/IecCarrierSink.kt
@@ -45,8 +45,11 @@ import java.util.concurrent.atomic.AtomicInteger
 internal class IecCarrierSink(
   private val defaultSink: AudioSink,
   private val carrierSink: AudioSink,
-  /** Whether the current route can bitstream the carrier tuple. Evaluated per format. */
-  private val carrierRouteAvailable: () -> Boolean,
+  /**
+   * Whether the current route can bitstream this format on the carrier. Per format: the tuple is
+   * shared, but a route carrying it does not necessarily advertise every codec riding it.
+   */
+  private val carrierRouteAvailable: (Format) -> Boolean,
   /** Whether policy currently forbids bitstreaming at all (downmix, normalization, user setting). */
   private val directOutputBlocked: (Format) -> Boolean,
   private val log: ((String, String, String) -> Unit)? = null
@@ -126,7 +129,7 @@ internal class IecCarrierSink(
     if (!isCarrierRateFamily(format.sampleRate)) return false
     if (playbackParameters.speed != 1f) return false
     if (directOutputBlocked(format)) return false
-    return carrierRouteAvailable()
+    return carrierRouteAvailable(format)
   }
 
   /**
@@ -172,14 +175,14 @@ internal class IecCarrierSink(
   override fun supportsFormat(format: Format): Boolean = when {
     shouldUseCarrier(format) -> true
     isTrueHd(format) -> false
-    isDtsHd(format) && carrierRouteAvailable() -> false
+    isDtsHd(format) && carrierRouteAvailable(format) -> false
     else -> defaultSink.supportsFormat(format)
   }
 
   override fun getFormatSupport(format: Format): Int = when {
     shouldUseCarrier(format) -> AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY
     isTrueHd(format) -> AudioSink.SINK_FORMAT_UNSUPPORTED
-    isDtsHd(format) && carrierRouteAvailable() -> AudioSink.SINK_FORMAT_UNSUPPORTED
+    isDtsHd(format) && carrierRouteAvailable(format) -> AudioSink.SINK_FORMAT_UNSUPPORTED
     else -> defaultSink.getFormatSupport(format)
   }
 

--- a/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/PlezyRenderersFactory.kt
+++ b/android/app/src/main/kotlin/com/edde746/plezy/exoplayer/PlezyRenderersFactory.kt
@@ -207,11 +207,14 @@ class PlezyRenderersFactory(context: Context) : DefaultRenderersFactory(context)
     return IecCarrierSink(
       defaultSink = processedSink,
       carrierSink = buildCarrierSink(context, bufferSizeProvider),
-      carrierRouteAvailable = { supportsIecCarrier(context) },
+      carrierRouteAvailable = { format -> carrierRouteAvailableFor(context, format) },
       directOutputBlocked = { format -> shouldBlockDirectAudioOutput?.invoke(format) == true },
       log = audioDiagnosticsLogger
     ).also { iecCarrierSink = it }
   }
+
+  /** TrueHD needs only the carrier tuple (#1804); DTS-HD also needs the route to advertise it. */
+  private fun carrierRouteAvailableFor(context: Context, format: Format): Boolean = if (format.sampleMimeType == MimeTypes.AUDIO_DTS_HD) supportsDtsHdIecCarrier(context) else supportsIecCarrier(context)
 
   /**
    * The delegate that carries packed TrueHD and DTS-HD (#1804, #1988).

--- a/android/app/src/test/kotlin/com/edde746/plezy/exoplayer/AudioOutputPolicyTest.kt
+++ b/android/app/src/test/kotlin/com/edde746/plezy/exoplayer/AudioOutputPolicyTest.kt
@@ -81,6 +81,20 @@ class AudioOutputPolicyTest {
   }
 
   @Test
+  fun dtsHdTakesTheCarrierOnlyWhenTheRouteAdvertisesDtsHd() {
+    assertTrue(dtsHdCarrierUsable({ it == C.ENCODING_DTS_HD }, { true }))
+    // Carries the tuple for TrueHD but decodes no DTS-HD: the burst would drain unheard.
+    assertFalse(dtsHdCarrierUsable({ false }, { true }))
+    assertFalse(dtsHdCarrierUsable({ true }, { false }))
+  }
+
+  @Test
+  fun theCarrierProbeIsSkippedWhenDtsHdIsNotAdvertised() {
+    // The carrier tiering costs several route calls; a route without DTS-HD must not pay them.
+    assertFalse(dtsHdCarrierUsable({ false }, { throw AssertionError("carrier probed without DTS-HD") }))
+  }
+
+  @Test
   fun nonDtsMimesNeverConsultTheDtsProbes() {
     // Decoder selection runs this predicate for every mime, video included; the probes make
     // binder calls and must stay behind the mime gate.

--- a/android/app/src/test/kotlin/com/edde746/plezy/exoplayer/IecCarrierSinkTest.kt
+++ b/android/app/src/test/kotlin/com/edde746/plezy/exoplayer/IecCarrierSinkTest.kt
@@ -126,6 +126,20 @@ class IecCarrierSinkTest {
     assertEquals(AudioSink.SINK_FORMAT_SUPPORTED_DIRECTLY, carrierSink.getFormatSupport(dtsHdFormat()))
   }
 
+  /** The tuple is shared, so the gate is per format: TrueHD keeps the carrier while DTS-HD leaves. */
+  @Test
+  fun theCarrierGateIsEvaluatedPerFormat() {
+    val carrier = FakeSink()
+    val normal = FakeSink()
+    val carrierSink = IecCarrierSink(normal, carrier, { it.sampleMimeType != MimeTypes.AUDIO_DTS_HD }, { false })
+
+    carrierSink.configure(audioSinkConfig(trueHdFormat()))
+    assertEquals(IecCarrier.SAMPLE_RATE, checkNotNull(carrier.configuredConfig).format.sampleRate)
+
+    carrierSink.configure(audioSinkConfig(dtsHdFormat()))
+    assertEquals(MimeTypes.AUDIO_DTS_HD, checkNotNull(normal.configuredConfig).format.sampleMimeType)
+  }
+
   /** DTS Express shares the DTS-HD mime prefix but carries `;profile=lbr`; it keeps decoding. */
   @Test
   fun dtsExpressIsLeftToTheNormalSink() {


### PR DESCRIPTION
The ExoPlayer carrier gate only asked whether the route could open a 192kHz/7.1 IEC 61937 track. TrueHD rides that same tuple, so a sink that decodes Dolby but no DTS-HD passed the probe and was handed a DTS-HD burst it discards: the AudioTrack initialises and drains, Android reports no error, and neither the audio-recovery ladder nor the mpv fallback fires, so the file plays with no audio at all.

Evaluate the gate per format. TrueHD keeps the transport-only probe, so the #1804 routes are unchanged; DTS-HD additionally requires the route to advertise ENCODING_DTS_HD, the pairing mpvSpdifCodecs already applies and the reason mpv plays these files while ExoPlayer does not.

Declining the carrier is not a forced decode: the format falls through to media3's raw path, which downgrades DTS-HD to the DTS core for receivers that take the core but not the lossless stream.

My setup is a Fire TV Cube connected to an LG 4K OLED, with audio routed over eARC to a Sonos Arc Ultra. The Arc Ultra supports lossy DTS 5.1, but not DTS-HD MA or DTS:X.

Both affected MKV tracks are exposed to ExoPlayer as audio/vnd.dts.hd. Because the route supports the 192 kHz/7.1 IEC 61937 carrier used by TrueHD, Plezy incorrectly assumes it can also carry DTS-HD and sends the lossless DTS stream unchanged. The AudioTrack initializes successfully, but the Sonos cannot decode the stream, so playback has no audio. Android reports no error, preventing recovery or mpv fallback.

BTW, MPV does work correctly with DTS MA/DTS-X and I get audio output, but MPV stutters and drops frames on nearly all content I play. So I was forced to switch the default back to ExoPlayer, which triggered this particular issue.

Per the contribution guidelines: This code/PR was written by Claude Opus 5, high effort, and 1M context.