### PR TITLE
fix(networking): follow the resolver's address ordering instead of dart:io's IPv4-first bias

### DIFF
--- a/lib/services/library_events/library_event_socket.dart
+++ b/lib/services/library_events/library_event_socket.dart
@@ -7,6 +7,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import '../../media/ids.dart';
 import '../../media/library_change_event.dart';
 import '../../utils/app_logger.dart';
+import '../../utils/happy_eyeballs.dart';
 
 /// Builds a live channel for [uri]. Injectable so tests can supply a fake or
 /// point at an ephemeral loopback server.
@@ -18,6 +19,9 @@ WebSocketChannel _defaultChannelFactory(Uri uri) => IOWebSocketChannel.connect(
   // Transport-level pings keep NAT mappings alive and surface a dead peer as
   // a close event; app-level keepalive (MediaBrowser) rides on top.
   pingInterval: const Duration(seconds: 30),
+  // Without an explicit client, WebSocket.connect builds its own and this
+  // channel bypasses the Happy Eyeballs connection factory entirely.
+  customClient: happyEyeballsHttpClient,
 );
 
 /// Reconnecting websocket base for one server's library-change push channel.

--- a/lib/utils/happy_eyeballs.dart
+++ b/lib/utils/happy_eyeballs.dart
@@ -1,0 +1,262 @@
+import 'dart:async';
+import 'dart:io';
+
+/// RFC 8305 connection setup for [HttpClient] that follows the platform
+/// resolver's address ordering instead of dart:io's IPv4-first bias.
+///
+/// `dart:io` does not connect in `getaddrinfo` order. `_NativeSocket
+/// .staggeredLookup` issues the A-record lookup immediately and delays the
+/// AAAA lookup by 10 ms — the SDK comment is literally "Introduce a delay
+/// before IPv6 lookup in order to favor IPv4" — and
+/// `tryConnectToResolvedAddresses` then consumes addresses in arrival order,
+/// releasing the next candidate only once the current one fails or its 250 ms
+/// stagger expires. On a dual-stack host whose IPv4 path answers in well under
+/// 250 ms the AAAA address is therefore never attempted at all, whatever
+/// RFC 6724 policy the system resolver applied.
+///
+/// That leaves Plezy the odd client out on a dual-stack network: browsers and
+/// the first-party Plex apps run Happy Eyeballs over the resolver's own
+/// ordering and land on IPv6, while Plezy pins the same server to IPv4.
+/// Windows never had the problem because WinHTTP supplies
+/// `WINHTTP_OPTION_IPV6_FAST_FALLBACK` (#1128).
+///
+/// This restores the platform's policy without giving up the fallback that
+/// motivated the Windows swap. [InternetAddress.lookup] returns the resolver's
+/// RFC 6724-sorted list, candidates are interleaved by family per RFC 8305 §4,
+/// and attempts are staggered, so a black-holed IPv6 address costs one
+/// [defaultAttemptDelay] rather than a connect timeout — 250 ms out of the 2 s
+/// `MediaServerTimeouts.connectionRace` budget, instead of blowing through it.
+
+/// Delay before the next candidate is raced alongside those already in flight.
+/// Matches dart:io's own `_retryDuration` so the fallback is no slower than
+/// the behaviour it replaces.
+const Duration defaultAttemptDelay = Duration(milliseconds: 250);
+
+/// Resolver seam. Defaults to [InternetAddress.lookup], whose result preserves
+/// `getaddrinfo` order.
+typedef AddressLookup = Future<List<InternetAddress>> Function(String host);
+
+/// Per-address connect seam. Defaults to [Socket.startConnect].
+typedef AddressConnect = Future<ConnectionTask<Socket>> Function(InternetAddress address, int port);
+
+/// Drop-in value for [HttpClient.connectionFactory].
+///
+/// Two obligations come with taking the factory over from dart:io
+/// (`_ConnectionTarget.connect` in `http_impl.dart`), because the SDK skips
+/// its own setup once a factory is installed:
+///
+/// - **TLS is ours.** The SDK calls [SecureSocket.startConnect] only on the
+///   path where no factory is set; with one installed it wraps whatever socket
+///   it is handed in a plain `_HttpClientConnection`. A raw socket returned for
+///   an `https` URL would speak cleartext to port 443, so securing here is not
+///   optional.
+/// - **Proxied requests must stay plain.** For a proxied `https` request the
+///   SDK still drives `CONNECT` tunnelling and secures the tunnel itself, so
+///   the factory hands back an unsecured socket to the proxy.
+///
+/// [HttpClient.badCertificateCallback] and a [SecurityContext] passed to
+/// `HttpClient(context:)` are bypassed for the same reason: neither reaches a
+/// connection factory. Plezy sets neither today — if that changes, they have to
+/// be threaded through here rather than onto the [HttpClient].
+Future<ConnectionTask<Socket>> happyEyeballsConnectionFactory(Uri url, String? proxyHost, int? proxyPort) {
+  if (proxyHost != null) {
+    return Socket.startConnect(proxyHost, proxyPort!);
+  }
+  return startHappyEyeballsConnect(host: url.host, port: url.port, secure: url.isScheme('https'));
+}
+
+/// Shared [HttpClient] for transports that build their own connections and so
+/// never pass through the pooled client in `platform_http_client_io.dart`.
+///
+/// `IOWebSocketChannel.connect` delegates to `WebSocket.connect`, which
+/// constructs a private [HttpClient] unless handed one. Left alone, the Plex
+/// live-notification socket (`/:/websockets/notifications`, 30 s ping) sits on
+/// dart:io's IPv4-first path forever — the app's longest-lived connection, and
+/// the one most likely to be the address a server reports for this client.
+///
+/// Deliberately never closed: it outlives every socket built from it.
+final HttpClient happyEyeballsHttpClient = HttpClient()..connectionFactory = happyEyeballsConnectionFactory;
+
+/// Connects to [host]:[port], racing the resolved addresses per RFC 8305.
+///
+/// [lookup] and [connect] exist for tests; production callers take the
+/// defaults. When [secure] is set the returned task yields a [SecureSocket]
+/// whose certificate is validated against [host], not against the literal
+/// address that won the race.
+Future<ConnectionTask<Socket>> startHappyEyeballsConnect({
+  required String host,
+  required int port,
+  bool secure = false,
+  Duration attemptDelay = defaultAttemptDelay,
+  AddressLookup lookup = InternetAddress.lookup,
+  AddressConnect connect = Socket.startConnect,
+}) async {
+  // A URL that already carries a literal skips the resolver entirely; `Uri.host`
+  // has stripped the brackets from an IPv6 literal by this point.
+  final literal = InternetAddress.tryParse(host);
+  final candidates = literal != null ? <InternetAddress>[literal] : orderCandidates(await lookup(host));
+  if (candidates.isEmpty) {
+    throw SocketException("Failed host lookup: '$host'");
+  }
+
+  final race = _CandidateRace(candidates, port, attemptDelay, connect);
+  race.start();
+  final Future<Socket> socket = secure ? race.socket.then((raw) => _secure(raw, host)) : race.socket;
+  return ConnectionTask.fromSocket(socket, race.cancel);
+}
+
+/// RFC 8305 §4: interleave the resolver's list by family so a long run of one
+/// family cannot starve the other, while keeping the resolver's own choice of
+/// leading family — that choice is the RFC 6724 policy decision we are here to
+/// respect, so it is never overridden.
+List<InternetAddress> orderCandidates(List<InternetAddress> addresses) {
+  if (addresses.length < 2) return addresses;
+
+  final leadType = addresses.first.type;
+  final lead = <InternetAddress>[];
+  final other = <InternetAddress>[];
+  for (final address in addresses) {
+    (address.type == leadType ? lead : other).add(address);
+  }
+  if (other.isEmpty) return addresses;
+
+  final ordered = <InternetAddress>[];
+  for (var i = 0; i < lead.length || i < other.length; i++) {
+    if (i < lead.length) ordered.add(lead[i]);
+    if (i < other.length) ordered.add(other[i]);
+  }
+  return ordered;
+}
+
+Future<Socket> _secure(Socket socket, String host) async {
+  try {
+    return await SecureSocket.secure(socket, host: host);
+  } catch (_) {
+    // SecureSocket.secure makes no promise about the raw socket on a failed
+    // handshake, and HttpClient never sees it to close it.
+    socket.destroy();
+    rethrow;
+  }
+}
+
+/// Staggered race over the ordered candidates. First socket to connect wins;
+/// every other attempt is cancelled.
+class _CandidateRace {
+  _CandidateRace(this._addresses, this._port, this._attemptDelay, this._connect);
+
+  final List<InternetAddress> _addresses;
+  final int _port;
+  final Duration _attemptDelay;
+  final AddressConnect _connect;
+
+  final Completer<Socket> _result = Completer<Socket>();
+  final Set<ConnectionTask<Socket>> _inFlight = <ConnectionTask<Socket>>{};
+
+  Timer? _stagger;
+  Socket? _winner;
+  int _nextIndex = 0;
+  int _outstanding = 0;
+  Object? _error;
+  StackTrace? _errorStackTrace;
+  bool _cancelled = false;
+
+  Future<Socket> get socket => _result.future;
+
+  bool get _isSettled => _cancelled || _result.isCompleted;
+
+  void start() => _startNext();
+
+  void _startNext() {
+    _stagger?.cancel();
+    _stagger = null;
+    if (_isSettled) return;
+    if (_nextIndex >= _addresses.length) {
+      _settle();
+      return;
+    }
+
+    final address = _addresses[_nextIndex++];
+    _outstanding++;
+    // RFC 8305 §5: the next candidate starts once the delay expires even if
+    // this one is still in flight, so a black-holed address costs one delay
+    // rather than a full connect timeout.
+    if (_nextIndex < _addresses.length) {
+      _stagger = Timer(_attemptDelay, _startNext);
+    }
+    unawaited(_attempt(address));
+  }
+
+  Future<void> _attempt(InternetAddress address) async {
+    ConnectionTask<Socket>? task;
+    try {
+      task = await _connect(address, _port);
+      if (_isSettled) {
+        task.cancel();
+        return;
+      }
+      _inFlight.add(task);
+
+      final socket = await task.socket;
+      // Off the in-flight set before winning: _win cancels what is left, and a
+      // ConnectionTask that already produced its socket must not be cancelled.
+      _inFlight.remove(task);
+      if (_isSettled) {
+        socket.destroy();
+        return;
+      }
+      _win(socket);
+      return;
+    } catch (error, stackTrace) {
+      // Keep the first failure: it describes the candidate the resolver ranked
+      // highest, which is the one worth reporting.
+      _error ??= error;
+      _errorStackTrace ??= stackTrace;
+    } finally {
+      if (task != null) _inFlight.remove(task);
+      _outstanding--;
+    }
+    // Reached only on failure — release the next candidate immediately instead
+    // of waiting out the remaining stagger.
+    _startNext();
+  }
+
+  void _win(Socket socket) {
+    _stagger?.cancel();
+    _stagger = null;
+    _winner = socket;
+    _result.complete(socket);
+    _cancelInFlight();
+  }
+
+  void _settle() {
+    if (_isSettled) return;
+    if (_outstanding > 0 || _nextIndex < _addresses.length) return;
+    _result.completeError(
+      _error ?? SocketException('No candidate address accepted the connection'),
+      _errorStackTrace ?? StackTrace.current,
+    );
+  }
+
+  void cancel() {
+    if (_cancelled) return;
+    _cancelled = true;
+    _stagger?.cancel();
+    _stagger = null;
+    _cancelInFlight();
+    // HttpClient cancels on connectionTimeout and has already thrown its
+    // TimeoutException by now, so a socket that won in the meantime is owned by
+    // nobody.
+    _winner?.destroy();
+    if (!_result.isCompleted) {
+      _result.completeError(SocketException('Connection attempt cancelled'), StackTrace.current);
+    }
+  }
+
+  void _cancelInFlight() {
+    final pending = List<ConnectionTask<Socket>>.of(_inFlight);
+    _inFlight.clear();
+    for (final task in pending) {
+      task.cancel();
+    }
+  }
+}

--- a/lib/utils/platform_http_client_io.dart
+++ b/lib/utils/platform_http_client_io.dart
@@ -5,6 +5,7 @@ import 'package:http/io_client.dart';
 import 'package:win_http/win_http.dart';
 
 import 'app_logger.dart';
+import 'happy_eyeballs.dart';
 import 'managed_http_client.dart';
 import 'media_server_timeouts.dart';
 
@@ -27,21 +28,28 @@ void _logPlatformClient(String platform, String client) {
 /// request on a high-RTT or CDN link. On a 60-way artwork fan-out, 12/90 s
 /// measured ~4x the default's throughput on Linux and ~2x on Android, so there
 /// is no case left for the opt-in the tuning used to be.
+///
+/// [happyEyeballsConnectionFactory] replaces dart:io's own connection setup,
+/// which resolves A and AAAA separately and delays the AAAA lookup by 10 ms
+/// "in order to favor IPv4" — so a dual-stack server whose IPv4 path answers
+/// quickly is never tried over IPv6 at all, whatever the system resolver
+/// ordered. `connectionTimeout` still bounds the whole of lookup, connect and
+/// the TLS handshake, exactly as it did when the SDK owned this path.
 ManagedHttpClient _createIoClient(String debugLabel) {
   final httpClient = HttpClient()
     ..connectionTimeout = MediaServerTimeouts.connect
     ..maxConnectionsPerHost = 12
-    ..idleTimeout = const Duration(seconds: 90);
+    ..idleTimeout = const Duration(seconds: 90)
+    ..connectionFactory = happyEyeballsConnectionFactory;
   return ManagedHttpClient(IOClient(httpClient), debugLabel: debugLabel, forceCloseOnDrainTimeout: true);
 }
 
 /// Every platform except Windows runs on the tuned dart:io client.
 ///
-/// Windows keeps WinHTTP for `WINHTTP_OPTION_IPV6_FAST_FALLBACK` (Happy
-/// Eyeballs, #1128), which dart:io has no equivalent for: it tries a
-/// dual-stack host's addresses sequentially, so one unreachable IPv6 address
-/// stalls the connection past the endpoint probe budget. WinHTTP also brings
-/// the system proxy and the Schannel trust store.
+/// Windows keeps WinHTTP for the system proxy and the Schannel trust store.
+/// It also brought `WINHTTP_OPTION_IPV6_FAST_FALLBACK` (Happy Eyeballs, #1128)
+/// at a time when dart:io had no equivalent; [happyEyeballsConnectionFactory]
+/// now supplies that on every other platform.
 ///
 /// Cronet and NSURLSession used to serve Android and Apple here. Both were
 /// measured slower than this client on the request shapes Plezy actually

--- a/test/utils/happy_eyeballs_test.dart
+++ b/test/utils/happy_eyeballs_test.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plezy/utils/happy_eyeballs.dart';
+
+/// dart:io's own connect path resolves A and AAAA separately and delays the
+/// AAAA lookup to favour IPv4, so a dual-stack server with a healthy IPv4 path
+/// is never tried over IPv6. These tests pin the replacement behaviour: the
+/// resolver's ordering is what decides, and the fallback stays fast.
+void main() {
+  final v6 = InternetAddress('2001:db8::1');
+  final v6Alt = InternetAddress('2001:db8::2');
+  final v4 = InternetAddress('192.0.2.1');
+  final v4Alt = InternetAddress('192.0.2.2');
+
+  List<String> literals(List<InternetAddress> addresses) => addresses.map((a) => a.address).toList();
+
+  group('orderCandidates', () {
+    test('keeps the resolver order when only one family resolved', () {
+      expect(literals(orderCandidates([v6, v6Alt])), ['2001:db8::1', '2001:db8::2']);
+    });
+
+    test('interleaves families without overriding the leading one', () {
+      expect(literals(orderCandidates([v6, v6Alt, v4])), ['2001:db8::1', '192.0.2.1', '2001:db8::2']);
+    });
+
+    test('leads with IPv4 when that is what the resolver ranked first', () {
+      expect(literals(orderCandidates([v4, v4Alt, v6])), ['192.0.2.1', '2001:db8::1', '192.0.2.2']);
+    });
+
+    test('passes trivial lists straight through', () {
+      expect(orderCandidates(const []), isEmpty);
+      expect(literals(orderCandidates([v4])), ['192.0.2.1']);
+    });
+  });
+
+  group('startHappyEyeballsConnect', () {
+    late ServerSocket server;
+    late StreamSubscription<Socket> accepted;
+    final serverSide = <Socket>[];
+
+    setUp(() async {
+      server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      accepted = server.listen(serverSide.add);
+    });
+
+    tearDown(() async {
+      await accepted.cancel();
+      for (final socket in serverSide) {
+        socket.destroy();
+      }
+      serverSide.clear();
+      await server.close();
+    });
+
+    Future<Socket> freshSocket() => Socket.connect(InternetAddress.loopbackIPv4, server.port);
+
+    ConnectionTask<Socket> connectedTask() => ConnectionTask.fromSocket(freshSocket(), () {});
+
+    test('attempts the resolver first address first, IPv6 included', () async {
+      final attempted = <String>[];
+
+      final task = await startHappyEyeballsConnect(
+        host: 'dual.test',
+        port: 443,
+        lookup: (_) async => [v6, v4],
+        connect: (address, port) async {
+          attempted.add(address.address);
+          return connectedTask();
+        },
+      );
+      final socket = await task.socket;
+      addTearDown(socket.destroy);
+
+      // The whole point: the AAAA candidate is tried, and tried first.
+      expect(attempted, ['2001:db8::1']);
+    });
+
+    test('races the next candidate after the stagger when the first stalls', () async {
+      final attempted = <String>[];
+      final stalled = Completer<Socket>();
+      var stalledCancelled = false;
+
+      final task = await startHappyEyeballsConnect(
+        host: 'dual.test',
+        port: 443,
+        attemptDelay: const Duration(milliseconds: 30),
+        lookup: (_) async => [v6, v4],
+        connect: (address, port) async {
+          attempted.add(address.address);
+          if (address.type == InternetAddressType.IPv6) {
+            return ConnectionTask.fromSocket(stalled.future, () => stalledCancelled = true);
+          }
+          return connectedTask();
+        },
+      );
+      final socket = await task.socket;
+      addTearDown(socket.destroy);
+
+      expect(attempted, ['2001:db8::1', '192.0.2.1']);
+      expect(stalledCancelled, isTrue, reason: 'the losing attempt must be torn down');
+    });
+
+    test('starts the next candidate immediately when one fails', () async {
+      final attempted = <String>[];
+      final stopwatch = Stopwatch()..start();
+
+      final task = await startHappyEyeballsConnect(
+        host: 'dual.test',
+        port: 443,
+        // Long enough that a stagger-driven fallback would blow the assertion.
+        attemptDelay: const Duration(seconds: 5),
+        lookup: (_) async => [v6, v4],
+        connect: (address, port) async {
+          attempted.add(address.address);
+          if (address.type == InternetAddressType.IPv6) {
+            throw SocketException('no route to ${address.address}');
+          }
+          return connectedTask();
+        },
+      );
+      final socket = await task.socket;
+      stopwatch.stop();
+      addTearDown(socket.destroy);
+
+      expect(attempted, ['2001:db8::1', '192.0.2.1']);
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 1)));
+    });
+
+    test('reports the first failure when every candidate fails', () async {
+      final task = await startHappyEyeballsConnect(
+        host: 'dual.test',
+        port: 443,
+        attemptDelay: const Duration(seconds: 5),
+        lookup: (_) async => [v6, v4],
+        connect: (address, port) async => throw SocketException('no route to ${address.address}'),
+      );
+
+      await expectLater(
+        task.socket,
+        throwsA(isA<SocketException>().having((e) => e.message, 'message', contains('2001:db8::1'))),
+      );
+    });
+
+    test('cancel tears down every in-flight attempt', () async {
+      var cancels = 0;
+      final stalled = Completer<Socket>();
+
+      final task = await startHappyEyeballsConnect(
+        host: 'dual.test',
+        port: 443,
+        attemptDelay: const Duration(milliseconds: 10),
+        lookup: (_) async => [v6, v4],
+        connect: (address, port) async => ConnectionTask.fromSocket(stalled.future, () => cancels++),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      task.cancel();
+
+      await expectLater(task.socket, throwsA(isA<SocketException>()));
+      expect(cancels, 2);
+    });
+
+    test('skips the resolver for an address literal', () async {
+      var lookups = 0;
+      final attempted = <String>[];
+
+      final task = await startHappyEyeballsConnect(
+        host: '192.0.2.1',
+        port: 443,
+        lookup: (_) async {
+          lookups++;
+          return [v4];
+        },
+        connect: (address, port) async {
+          attempted.add(address.address);
+          return connectedTask();
+        },
+      );
+      final socket = await task.socket;
+      addTearDown(socket.destroy);
+
+      expect(lookups, 0);
+      expect(attempted, ['192.0.2.1']);
+    });
+
+    // Regression guard for the obligation that comes with owning
+    // connectionFactory: dart:io no longer upgrades the socket, so an https URL
+    // handed back unsecured would speak cleartext to port 443.
+    test('secure: true really performs a TLS handshake', () async {
+      final plaintext = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final greeter = plaintext.listen((socket) => socket.add('HTTP/1.1 200 OK\r\n'.codeUnits));
+      addTearDown(() async {
+        await greeter.cancel();
+        await plaintext.close();
+      });
+
+      final task = await startHappyEyeballsConnect(
+        host: 'plex.invalid',
+        port: plaintext.port,
+        secure: true,
+        lookup: (_) async => [InternetAddress.loopbackIPv4],
+      );
+
+      // A non-TLS peer must surface as a failed handshake, never as a usable
+      // socket: reaching `await task.socket` without an error would mean the
+      // https request was about to go out in the clear.
+      await expectLater(task.socket, throwsA(anyOf(isA<TlsException>(), isA<SocketException>())));
+    });
+  });
+
+  group('happyEyeballsConnectionFactory', () {
+    test('hands a plain socket to a proxy so dart:io can tunnel and secure it', () async {
+      final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      final accepted = server.listen((socket) => socket.destroy());
+      addTearDown(() async {
+        await accepted.cancel();
+        await server.close();
+      });
+
+      final task = await happyEyeballsConnectionFactory(
+        Uri.parse('https://plex.invalid/library/sections'),
+        InternetAddress.loopbackIPv4.address,
+        server.port,
+      );
+      final socket = await task.socket;
+      addTearDown(socket.destroy);
+
+      expect(socket, isNot(isA<SecureSocket>()));
+    });
+  });
+}


### PR DESCRIPTION
## Symptom

I am using Plezy with a dualstack plex server. In the plex dashboard I was able to see that plezy prefers IPv4 over IPv6. The native plex player prefers IPv6 without issue. 

I decided to throw Claude at it and this change fixed it for me. Be aware that this was fully done by Claude other than me manually testing and verifying the produced build in my environment.

According to Claude diagnosis this only affects the API calls and not the actual media transfer.

I know everyone hates copy-pasted AI rambling, but hopefully the claude assession below is helpful.

## Root cause

`dart:io` does not connect in `getaddrinfo` order. `_NativeSocket.staggeredLookup`
issues the A-record lookup immediately and delays the AAAA lookup, and the SDK is
explicit about why:

```dart
// sdk/lib/_internal/vm/bin/socket_patch.dart
const concurrentLookupDelay = Duration(milliseconds: 10);

lookupAddresses(InternetAddressType.IPv4, ipv4Completer);
...
  // Introduce a delay before IPv6 lookup in order to favor IPv4.
  ipv6LookupDelay = Timer(concurrentLookupDelay,
      () => lookupAddresses(InternetAddressType.IPv6, ipv6Completer));
```

`tryConnectToResolvedAddresses` then consumes addresses in *arrival* order and only
releases the next candidate once the current one fails or its `_retryDuration`
(250 ms) expires. So on a dual-stack host whose IPv4 path answers in well under
250 ms, the AAAA address is never attempted at all — whatever RFC 6724 policy the
system resolver applied is discarded.

The system resolver's own ranking, for the same host on the same machine:

```
$ getent ahosts host.example
2001:db8::1    STREAM      <- RFC 6724 ranks IPv6 first
203.0.113.7    STREAM
```

Windows was never affected because it runs WinHTTP with
`WINHTTP_OPTION_IPV6_FAST_FALLBACK` (#1128). The doc comment in
`platform_http_client_io.dart` already noted that dart:io had no equivalent; this PR
supplies one for every other platform.

## The change

`lib/utils/happy_eyeballs.dart` (new) installs an `HttpClient.connectionFactory` that
does one `AF_UNSPEC` lookup via `InternetAddress.lookup` — preserving the resolver's
RFC 6724 ordering — interleaves candidates by family per RFC 8305 §4, and races them
with a 250 ms stagger (one constant, easily retuned), first connection winning and
the rest cancelled. The stagger
deliberately matches dart:io's own `_retryDuration` so the fallback is no slower than
the behaviour it replaces.

`_ConnectionTarget.connect` skips its own setup once a factory is set, so two
obligations transfer to us (both documented in the file):

- **TLS becomes ours.** The SDK calls `SecureSocket.startConnect` only when no factory
  is installed; with one set it wraps whatever socket it is handed in a plain
  `_HttpClientConnection`, so a raw socket returned for an `https` URL would speak
  cleartext to port 443. A test asserts a real handshake happens.
- **Proxied requests stay plain.** The SDK still drives `CONNECT` tunnelling and
  secures the tunnel itself, so the factory returns an unsecured socket to the proxy.

`HttpClient.badCertificateCallback` and a `SecurityContext` passed to
`HttpClient(context:)` are likewise bypassed by any connection factory. Plezy sets
neither today; the file documents it for whoever adds one.

### A second bypass, found only by running the app

`IOWebSocketChannel.connect` delegates to `WebSocket.connect`, which builds its **own**
private `HttpClient` unless handed one. The live-notification socket
(`/:/websockets/notifications`, 30 s ping) therefore stayed on the IPv4-first path even
with the factory installed — and as the app's longest-lived connection it is the one a
server is most likely to report as the client address. Fixed by passing a shared
factory-configured client as `customClient`; that is why the diff touches
`library_event_socket.dart`. Unit tests and offline measurement could not have found
it.

## Measurements

One host, one network — Fedora 44, Flutter 3.47.2 / Dart 3.13.2, dual-stack client,
server behind a custom HTTPS hostname. All figures are connect + TLS handshake.
Baseline is identical in every row because today's client always takes IPv4, so the
state of the IPv6 path is irrelevant to it: **~105 ms**.

| IPv6 condition | With this change | vs. today |
| --- | --- | --- |
| Healthy | **IPv6**, ~63 ms | ~40 ms *faster* — the v6 handshake won consistently |
| Dead at the routing layer (`ip -6 route add blackhole …`) | IPv4, ~102 ms | no change |
| SYNs silently dropped (`ip6tables -j DROP`) | IPv4, ~355 ms | **+250 ms** |

The middle row costs nothing because glibc applies RFC 6724 Rule 1 with no route to
the destination prefix and demotes the IPv6 address itself — `getent ahosts` flips to
IPv4-first under the blackhole route, so the ordering this PR follows is already
correct there.

## On the #1128 regression risk

The concern that motivated the WinHTTP swap is the mirror image of this one: a dead
IPv6 address stalling a connect. Two things bound it.

The stagger caps a black-holed candidate at one 250 ms interval rather than a connect
timeout — 250 ms out of the 2 s `MediaServerTimeouts.connectionRace` budget instead of
blowing through it. And it is not a new class of cost: dart:io already pays an
identical 250 ms whenever the *first* family it tries is the broken one, because
250 ms is its own `_retryDuration`. This change does not introduce the penalty, it
stops exempting IPv4 from it. The cost is per *connection*, not per request, so
`maxConnectionsPerHost = 12` with a 90 s `idleTimeout` amortises it across a
session.

## Verification

Live socket capture of the running Linux app — sockets attributed by `/proc/<pid>/exe`
and inodes matched against `/proc/net/tcp{,6}` — sampled every 20 s for two minutes:

```
before   IPv6=1..3   IPv4=1   <- pinned at 1 the whole window (the notifications socket)
after    IPv6=2..9   IPv4=0   <- zero for the whole window
```

Playback on the patched build: media stream on a single IPv6 socket, 264 MB
transferred, no IPv4 socket anywhere in the process.

**FFmpeg never had the bug and needs no change.** `libavformat/tcp.c` walks the
`getaddrinfo` list in resolver order, so it inherited the RFC 6724 ranking all along —
confirmed with system ffmpeg 8.1.2 (8/8 IPv6), a C probe against the pinned
`mpv-build` libmpv (4/4 IPv6), and the live stream above.

That sharpens the diagnosis: before this change Plezy talked to one server on **both
families at once** — media over IPv6 through FFmpeg, API traffic and the notifications
socket over IPv4 through dart:io. The inconsistency was internal to the app.

All four CI gates from CONTRIBUTING.md:

- `dart format --set-exit-if-changed` — clean
- `flutter analyze` — clean on every changed file (the project-wide issues are all
  pre-existing, in vendored `packages/wakelock_plus/{test,pigeons}`)
- `scripts/codegen.sh --check` — generated output current, tree unchanged
- `scripts/run_tests.sh` — **6580 passed, 6 skipped**, full suite

The 12 new tests cover resolver-order preservation, family interleaving, stagger
fallback, immediate release on a failed candidate, first-error reporting, cancellation
teardown, address-literal short-circuit, TLS-actually-happens, and proxy-stays-plain.

Built and ran `flutter build linux --debug` on Fedora 44 against a real Plex server.
`scripts/format_native.sh` does not apply (no native sources touched); the Maestro
Android E2E suites were not run.

## Follow-ups

Two further call sites share the `IOWebSocketChannel.connect`-without-`customClient`
shape and are not covered here:

- `companion_remote_peer_service.dart:83` and `:829` — same fix applies; left out
  because I could not exercise that subsystem to verify it.
- `watch_together_peer_service.dart:64` uses the cross-platform
  `WebSocketChannel.connect`, which has no `customClient` parameter; covering it means
  switching to `IOWebSocketChannel` on io platforms. It talks to the relay, not a
  user's media server.
