### PR TITLE
fix(linux): restore the texture fallback, with the bootstrap surface 9cdfe759 left behind

### DIFF
--- a/lib/i18n/az.i18n.json
+++ b/lib/i18n/az.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Hər yerdə",
     "playerScopeLibrary": "Kitabxana üzrə",
     "playerScopeTitle": "Serial və ya film üzrə",
-    "exportDialogTitle": "Plezy tənzimləmələrini ixrac et"
+    "exportDialogTitle": "Plezy tənzimləmələrini ixrac et",
+    "linuxVideoRenderMode": "Video göstərmə rejimi",
+    "linuxVideoRenderModeDescription": "Avtomatik yerli Wayland müstəvisinə üstünlük verir (HDR dəstəkləyir); Texture SDR ehtiyat yolunu məcbur edir.",
+    "linuxVideoRenderModeAuto": "Avtomatik",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Kino, serial, musiqi axtar...",

--- a/lib/i18n/bg.i18n.json
+++ b/lib/i18n/bg.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Навсякъде",
     "playerScopeLibrary": "По библиотека",
     "playerScopeTitle": "По сериал или филм",
-    "exportDialogTitle": "Експортиране на настройките на Plezy"
+    "exportDialogTitle": "Експортиране на настройките на Plezy",
+    "linuxVideoRenderMode": "Режим на видеото",
+    "linuxVideoRenderModeDescription": "Автоматично предпочита родната Wayland равнина (HDR-съвместима); Texture принуждава SDR резервния път.",
+    "linuxVideoRenderModeAuto": "Автоматично",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Търсене на филми, сериали, музика...",

--- a/lib/i18n/da.i18n.json
+++ b/lib/i18n/da.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Overalt",
     "playerScopeLibrary": "Pr. bibliotek",
     "playerScopeTitle": "Pr. serie eller film",
-    "exportDialogTitle": "Eksportér Plezy-indstillinger"
+    "exportDialogTitle": "Eksportér Plezy-indstillinger",
+    "linuxVideoRenderMode": "Video-gengivelsestilstand",
+    "linuxVideoRenderModeDescription": "Automatisk foretrækker det native Wayland-plan (HDR-kompatibelt); Texture tvinger SDR-fallback-stien.",
+    "linuxVideoRenderModeAuto": "Automatisk",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Søg film, serier, musik...",

--- a/lib/i18n/de.i18n.json
+++ b/lib/i18n/de.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Überall",
     "playerScopeLibrary": "Pro Bibliothek",
     "playerScopeTitle": "Pro Serie oder Film",
-    "exportDialogTitle": "Plezy-Einstellungen exportieren"
+    "exportDialogTitle": "Plezy-Einstellungen exportieren",
+    "linuxVideoRenderMode": "Video-Rendermodus",
+    "linuxVideoRenderModeDescription": "Automatisch bevorzugt die native Wayland-Ebene (HDR-fähig); Texture erzwingt den SDR-Fallback-Pfad.",
+    "linuxVideoRenderModeAuto": "Automatisch",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Filme, Serien und Musik suchen …",

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Everywhere",
     "playerScopeLibrary": "Per library",
     "playerScopeTitle": "Per show or movie",
-    "exportDialogTitle": "Export Plezy settings"
+    "exportDialogTitle": "Export Plezy settings",
+    "linuxVideoRenderMode": "Video rendering mode",
+    "linuxVideoRenderModeDescription": "Automatic prefers the native Wayland plane (HDR-capable); Texture forces the SDR fallback path.",
+    "linuxVideoRenderModeAuto": "Automatic",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Search movies, shows, music...",

--- a/lib/i18n/es.i18n.json
+++ b/lib/i18n/es.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "En todas partes",
     "playerScopeLibrary": "Por biblioteca",
     "playerScopeTitle": "Por serie o película",
-    "exportDialogTitle": "Exportar ajustes de Plezy"
+    "exportDialogTitle": "Exportar ajustes de Plezy",
+    "linuxVideoRenderMode": "Modo de renderizado de vídeo",
+    "linuxVideoRenderModeDescription": "Automático prefiere el plano Wayland nativo (compatible con HDR); Texture fuerza la ruta de reserva SDR.",
+    "linuxVideoRenderModeAuto": "Automático",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Buscar películas, series, música...",

--- a/lib/i18n/fr.i18n.json
+++ b/lib/i18n/fr.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Partout",
     "playerScopeLibrary": "Par bibliothèque",
     "playerScopeTitle": "Par série ou film",
-    "exportDialogTitle": "Exporter les paramètres de Plezy"
+    "exportDialogTitle": "Exporter les paramètres de Plezy",
+    "linuxVideoRenderMode": "Mode de rendu vidéo",
+    "linuxVideoRenderModeDescription": "Automatique préfère le plan Wayland natif (compatible HDR) ; Texture force le chemin de repli SDR.",
+    "linuxVideoRenderModeAuto": "Automatique",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Rechercher des films, des séries, de la musique...",

--- a/lib/i18n/hu.i18n.json
+++ b/lib/i18n/hu.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Mindenhol",
     "playerScopeLibrary": "Könyvtáronként",
     "playerScopeTitle": "Sorozatonként vagy filmenként",
-    "exportDialogTitle": "Plezy-beállítások exportálása"
+    "exportDialogTitle": "Plezy-beállítások exportálása",
+    "linuxVideoRenderMode": "Videó megjelenítési mód",
+    "linuxVideoRenderModeDescription": "Az Automatikus a natív Wayland síkot részesíti előnyben (HDR-képes); a Texture az SDR tartalék utat kényszeríti ki.",
+    "linuxVideoRenderModeAuto": "Automatikus",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Keresés filmek, sorozatok és zenék között...",

--- a/lib/i18n/it.i18n.json
+++ b/lib/i18n/it.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Ovunque",
     "playerScopeLibrary": "Per libreria",
     "playerScopeTitle": "Per serie o film",
-    "exportDialogTitle": "Esporta le impostazioni di Plezy"
+    "exportDialogTitle": "Esporta le impostazioni di Plezy",
+    "linuxVideoRenderMode": "Modalità di rendering video",
+    "linuxVideoRenderModeDescription": "Automatico preferisce il piano Wayland nativo (compatibile HDR); Texture forza il percorso di riserva SDR.",
+    "linuxVideoRenderModeAuto": "Automatico",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Cerca film, serie TV e musica...",

--- a/lib/i18n/ja.i18n.json
+++ b/lib/i18n/ja.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "すべて",
     "playerScopeLibrary": "ライブラリごと",
     "playerScopeTitle": "作品ごと",
-    "exportDialogTitle": "Plezyの設定をエクスポート"
+    "exportDialogTitle": "Plezyの設定をエクスポート",
+    "linuxVideoRenderMode": "動画レンダリングモード",
+    "linuxVideoRenderModeDescription": "自動はネイティブの Wayland プレーン（HDR 対応）を優先し、Texture は SDR フォールバック経路を強制します。",
+    "linuxVideoRenderModeAuto": "自動",
+    "linuxVideoRenderModeTexture": "Texture（SDR）"
   },
   "search": {
     "hint": "映画、番組、音楽を検索…",

--- a/lib/i18n/kk.i18n.json
+++ b/lib/i18n/kk.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Барлық жерде",
     "playerScopeLibrary": "Кітапхана бойынша",
     "playerScopeTitle": "Сериал немесе фильм бойынша",
-    "exportDialogTitle": "Plezy параметрлерін экспорттау"
+    "exportDialogTitle": "Plezy параметрлерін экспорттау",
+    "linuxVideoRenderMode": "Бейнені көрсету режимі",
+    "linuxVideoRenderModeDescription": "Автоматты режим жергілікті Wayland жазықтығын қалайды (HDR қолдайды); Texture SDR резервтік жолды мәжбүрлейді.",
+    "linuxVideoRenderModeAuto": "Автоматты",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Фильмдер, сериалдар, музыка іздеу...",

--- a/lib/i18n/ko.i18n.json
+++ b/lib/i18n/ko.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "모든 곳",
     "playerScopeLibrary": "라이브러리별",
     "playerScopeTitle": "시리즈 또는 영화별",
-    "exportDialogTitle": "Plezy 설정 내보내기"
+    "exportDialogTitle": "Plezy 설정 내보내기",
+    "linuxVideoRenderMode": "동영상 렌더링 모드",
+    "linuxVideoRenderModeDescription": "자동은 네이티브 Wayland 평면(HDR 지원)을 선호하고, Texture는 SDR 대체 경로를 강제합니다.",
+    "linuxVideoRenderModeAuto": "자동",
+    "linuxVideoRenderModeTexture": "Texture(SDR)"
   },
   "search": {
     "hint": "영화, 시리즈, 음악 등을 검색하세요...",

--- a/lib/i18n/nb.i18n.json
+++ b/lib/i18n/nb.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Overalt",
     "playerScopeLibrary": "Per bibliotek",
     "playerScopeTitle": "Per serie eller film",
-    "exportDialogTitle": "Eksporter Plezy-innstillinger"
+    "exportDialogTitle": "Eksporter Plezy-innstillinger",
+    "linuxVideoRenderMode": "Video-gjengivelsesmodus",
+    "linuxVideoRenderModeDescription": "Automatisk foretrekker det native Wayland-planet (HDR-kompatibelt); Texture tvinger SDR-fallback-stien.",
+    "linuxVideoRenderModeAuto": "Automatisk",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Søk i filmer, serier, musikk...",

--- a/lib/i18n/nl.i18n.json
+++ b/lib/i18n/nl.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Overal",
     "playerScopeLibrary": "Per bibliotheek",
     "playerScopeTitle": "Per serie of film",
-    "exportDialogTitle": "Plezy-instellingen exporteren"
+    "exportDialogTitle": "Plezy-instellingen exporteren",
+    "linuxVideoRenderMode": "Videoweergavemodus",
+    "linuxVideoRenderModeDescription": "Automatisch geeft de voorkeur aan het native Wayland-vlak (HDR-compatibel); Texture dwingt het SDR-reservepad af.",
+    "linuxVideoRenderModeAuto": "Automatisch",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Zoek films, series, muziek...",

--- a/lib/i18n/pl.i18n.json
+++ b/lib/i18n/pl.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Wszędzie",
     "playerScopeLibrary": "Na bibliotekę",
     "playerScopeTitle": "Na serial lub film",
-    "exportDialogTitle": "Eksport ustawień Plezy"
+    "exportDialogTitle": "Eksport ustawień Plezy",
+    "linuxVideoRenderMode": "Tryb renderowania wideo",
+    "linuxVideoRenderModeDescription": "Automatyczny preferuje natywną płaszczyznę Wayland (zgodną z HDR); Texture wymusza ścieżkę zapasową SDR.",
+    "linuxVideoRenderModeAuto": "Automatyczny",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Szukaj filmów, seriali, muzyki...",

--- a/lib/i18n/pt.i18n.json
+++ b/lib/i18n/pt.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Em todos os lugares",
     "playerScopeLibrary": "Por biblioteca",
     "playerScopeTitle": "Por série ou filme",
-    "exportDialogTitle": "Exportar configurações do Plezy"
+    "exportDialogTitle": "Exportar configurações do Plezy",
+    "linuxVideoRenderMode": "Modo de renderização de vídeo",
+    "linuxVideoRenderModeDescription": "Automático prefere o plano Wayland nativo (compatível com HDR); Texture força o caminho de reserva SDR.",
+    "linuxVideoRenderModeAuto": "Automático",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Buscar filmes, séries, músicas...",

--- a/lib/i18n/ru.i18n.json
+++ b/lib/i18n/ru.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Везде",
     "playerScopeLibrary": "Для библиотеки",
     "playerScopeTitle": "Для сериала или фильма",
-    "exportDialogTitle": "Экспорт настроек Plezy"
+    "exportDialogTitle": "Экспорт настроек Plezy",
+    "linuxVideoRenderMode": "Режим рендеринга видео",
+    "linuxVideoRenderModeDescription": "Автоматический режим предпочитает нативную плоскость Wayland (поддержка HDR); Texture принудительно использует запасной путь SDR.",
+    "linuxVideoRenderModeAuto": "Автоматически",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Поиск фильмов, сериалов, музыки...",

--- a/lib/i18n/strings.g.dart
+++ b/lib/i18n/strings.g.dart
@@ -4,7 +4,7 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 22
-/// Strings: 43755 (1988 per locale)
+/// Strings: 43843 (1992 per locale)
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/i18n/strings_az.g.dart
+++ b/lib/i18n/strings_az.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$az extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Kitabxana üzrə';
 	@override String get playerScopeTitle => 'Serial və ya film üzrə';
 	@override String get exportDialogTitle => 'Plezy tənzimləmələrini ixrac et';
+	@override String get linuxVideoRenderMode => 'Video göstərmə rejimi';
+	@override String get linuxVideoRenderModeDescription => 'Avtomatik yerli Wayland müstəvisinə üstünlük verir (HDR dəstəkləyir); Texture SDR ehtiyat yolunu məcbur edir.';
+	@override String get linuxVideoRenderModeAuto => 'Avtomatik';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsAz {
 			'settings.playerScopeLibrary' => 'Kitabxana üzrə',
 			'settings.playerScopeTitle' => 'Serial və ya film üzrə',
 			'settings.exportDialogTitle' => 'Plezy tənzimləmələrini ixrac et',
+			'settings.linuxVideoRenderMode' => 'Video göstərmə rejimi',
+			'settings.linuxVideoRenderModeDescription' => 'Avtomatik yerli Wayland müstəvisinə üstünlük verir (HDR dəstəkləyir); Texture SDR ehtiyat yolunu məcbur edir.',
+			'settings.linuxVideoRenderModeAuto' => 'Avtomatik',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Kino, serial, musiqi axtar...',
 			'search.tryDifferentTerm' => 'Fərqli axtarış sözü cəhd edin',
 			'search.searchYourMedia' => 'Mediyanızda axtarın',
@@ -3504,6 +3512,8 @@ extension on TranslationsAz {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy bunun hansı faylları siləcəyini yoxlaya bilmədi, ona görə də yuxarıda adı çəkilən elementdən daha çoxunu silə bilər. Ləğv edib təzədən cəhd edin və ya yenə də silin.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Serveriniz bu element üçün fayl təfərrüatlarını təqdim etmədi, ona görə Plezy bunun hansı faylları siləcəyini yoxlaya bilmir. Yuxarıda adı çəkilən elementdən daha çoxunu silə bilər.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media elementi uğurla silindi',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Media elementi silinə bilmədi',
 			'mediaMenu.rate' => 'Qiymətləndir',
 			'mediaMenu.playFromBeginning' => 'Əvvəldən oynat',
@@ -4072,6 +4082,8 @@ extension on TranslationsAz {
 			'explore.watchlistNoMatch' => 'Bu elementi heç bir baxış siyahısı ilə uyğunlaşdırmaq olmadı',
 			'explore.notInLibrary' => 'Kitabxananızda yoxdur',
 			'explore.inTheseLibraries' => 'Bu kitabxanalarda var',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kitabxananız yoxlanılır...',
 			'explore.emptyTitle' => 'Hələlik burada heç nə yoxdur',
 			'explore.emptyMessage' => ({required Object source}) => '${source} mənbəsindən olan sətirlər burada görünəcək.',
@@ -4608,6 +4620,8 @@ extension on TranslationsAz {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Heç bir ünvana qoşuluna bilmədi',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} cəhddən sonra əlaqə kəsildi',
 			'companionRemote.errors.connectionLost' => 'Əlaqə kəsildi',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Bağlantı autentifikasiyadan əvvəl bağlandı',
 			'videoSettings.playbackSpeed' => 'Oynatma sürəti',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_az.g.dart
+++ b/lib/i18n/strings_az.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsAz {
 			'fileInfo.filePresent' => 'Fayl mövcuddur',
 			'fileInfo.fileReadable' => 'Server tərəfindən oxuna bilir',
 			'fileInfo.streamPath' => 'Axın yolu',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Yayım üçün optimallaşdırılıb',
 			'fileInfo.has64bitOffsets' => '64-bit ofsetlər',
 			'fileInfo.protocol' => 'Protokol',
 			'fileInfo.mediaType' => 'Media növü',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Mənbə növü',
 			'fileInfo.optimizedVersion' => 'Optimallaşdırılmış versiya',
 			'fileInfo.optimizationTarget' => 'Optimallaşdırma hədəfi',
@@ -3512,8 +3512,6 @@ extension on TranslationsAz {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy bunun hansı faylları siləcəyini yoxlaya bilmədi, ona görə də yuxarıda adı çəkilən elementdən daha çoxunu silə bilər. Ləğv edib təzədən cəhd edin və ya yenə də silin.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Serveriniz bu element üçün fayl təfərrüatlarını təqdim etmədi, ona görə Plezy bunun hansı faylları siləcəyini yoxlaya bilmir. Yuxarıda adı çəkilən elementdən daha çoxunu silə bilər.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media elementi uğurla silindi',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Media elementi silinə bilmədi',
 			'mediaMenu.rate' => 'Qiymətləndir',
 			'mediaMenu.playFromBeginning' => 'Əvvəldən oynat',
@@ -3969,12 +3967,12 @@ extension on TranslationsAz {
 			'libraries.groupings.tracks' => 'Mahnılar',
 			'libraries.groupings.folders' => 'Qovluqlar',
 			'libraries.filterCategories.genre' => 'Janr',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'İl',
 			'libraries.filterCategories.contentRating' => 'Məzmun reytinqi',
 			'libraries.filterCategories.tag' => 'Teq',
 			'libraries.filterCategories.unwatched' => 'Baxılmayıb',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Oynadılmayıb',
 			'libraries.filterCategories.favorites' => 'Sevimlilər',
 			'libraries.sortLabels.title' => 'Ad',
@@ -4082,8 +4080,6 @@ extension on TranslationsAz {
 			'explore.watchlistNoMatch' => 'Bu elementi heç bir baxış siyahısı ilə uyğunlaşdırmaq olmadı',
 			'explore.notInLibrary' => 'Kitabxananızda yoxdur',
 			'explore.inTheseLibraries' => 'Bu kitabxanalarda var',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kitabxananız yoxlanılır...',
 			'explore.emptyTitle' => 'Hələlik burada heç nə yoxdur',
 			'explore.emptyMessage' => ({required Object source}) => '${source} mənbəsindən olan sətirlər burada görünəcək.',
@@ -4485,12 +4481,12 @@ extension on TranslationsAz {
 			'downloads.syncRuleUpdated' => 'Eyniləşdirmə qaydası yeniləndi',
 			'downloads.syncRuleRemoved' => 'Eyniləşdirmə qaydası silindi',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Eyniləşdirmə qaydası və əlaqəli yükləmələr silindi',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Eyniləşdirmə qaydaları hazırda yenilənir. Bir azdan təzədən cəhd edin.',
 			'downloads.syncRuleCleanupUnavailable' => 'Əlaqəli yükləmələr təhlükəsiz şəkildə müəyyən edilə bilmədi. Serverə yenidən qoşulub cəhd edin və ya qaydanı yükləmələri silmədən silin.',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '${title} üçün ${count} yeni seriya eyniləşdirildi',
 			'downloads.activeSyncRules' => 'Eyniləşdirmə qaydaları',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Eyniləşdirmə qaydası yoxdur',
 			'downloads.manageSyncRule' => 'Eyniləşdirməni idarə et',
 			'downloads.editEpisodeCount' => 'Seriya sayı',
@@ -4620,8 +4616,6 @@ extension on TranslationsAz {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Heç bir ünvana qoşuluna bilmədi',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} cəhddən sonra əlaqə kəsildi',
 			'companionRemote.errors.connectionLost' => 'Əlaqə kəsildi',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Bağlantı autentifikasiyadan əvvəl bağlandı',
 			'videoSettings.playbackSpeed' => 'Oynatma sürəti',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_bg.g.dart
+++ b/lib/i18n/strings_bg.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$bg extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'По библиотека';
 	@override String get playerScopeTitle => 'По сериал или филм';
 	@override String get exportDialogTitle => 'Експортиране на настройките на Plezy';
+	@override String get linuxVideoRenderMode => 'Режим на видеото';
+	@override String get linuxVideoRenderModeDescription => 'Автоматично предпочита родната Wayland равнина (HDR-съвместима); Texture принуждава SDR резервния път.';
+	@override String get linuxVideoRenderModeAuto => 'Автоматично';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsBg {
 			'settings.playerScopeLibrary' => 'По библиотека',
 			'settings.playerScopeTitle' => 'По сериал или филм',
 			'settings.exportDialogTitle' => 'Експортиране на настройките на Plezy',
+			'settings.linuxVideoRenderMode' => 'Режим на видеото',
+			'settings.linuxVideoRenderModeDescription' => 'Автоматично предпочита родната Wayland равнина (HDR-съвместима); Texture принуждава SDR резервния път.',
+			'settings.linuxVideoRenderModeAuto' => 'Автоматично',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Търсене на филми, сериали, музика...',
 			'search.tryDifferentTerm' => 'Опитайте с различна дума за търсене',
 			'search.searchYourMedia' => 'Търсете в медийното си съдържание',
@@ -3504,6 +3512,8 @@ extension on TranslationsBg {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy не успя да провери кои файлове ще бъдат премахнати, така че може да изтрие повече от посочения по-горе елемент. Откажете и опитайте отново, или изтрийте въпреки това.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Сървърът ви не предостави данни за файловете на този елемент, така че Plezy не може да провери кои файлове ще бъдат премахнати. Може да изтрие повече от посочения по-горе елемент.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Елементът е изтрит успешно',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Неуспешно изтриване на елемента',
 			'mediaMenu.rate' => 'Оцени',
 			'mediaMenu.playFromBeginning' => 'Пусни от началото',
@@ -4072,6 +4082,8 @@ extension on TranslationsBg {
 			'explore.watchlistNoMatch' => 'Този елемент не можа да бъде съпоставен със списък за гледане',
 			'explore.notInLibrary' => 'Не е в твоята библиотека',
 			'explore.inTheseLibraries' => 'В тези библиотеки',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Проверка на твоята библиотека...',
 			'explore.emptyTitle' => 'Тук все още няма нищо',
 			'explore.emptyMessage' => ({required Object source}) => 'Редовете от ${source} ще се появят тук, когато има съдържание.',
@@ -4608,6 +4620,8 @@ extension on TranslationsBg {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Неуспешно свързване към който и да е адрес',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Връзката е загубена след ${attempts} опита',
 			'companionRemote.errors.connectionLost' => 'Връзката е загубена',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Връзката беше затворена преди удостоверяването',
 			'videoSettings.playbackSpeed' => 'Скорост на възпроизвеждане',
 			'videoSettings.normalSpeed' => 'Нормална',

--- a/lib/i18n/strings_bg.g.dart
+++ b/lib/i18n/strings_bg.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsBg {
 			'fileInfo.filePresent' => 'Файлът е наличен',
 			'fileInfo.fileReadable' => 'Четим от сървъра',
 			'fileInfo.streamPath' => 'Път на потока',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Оптимизирано за стрийминг',
 			'fileInfo.has64bitOffsets' => '64-битови отмествания',
 			'fileInfo.protocol' => 'Протокол',
 			'fileInfo.mediaType' => 'Тип медия',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Вид източник',
 			'fileInfo.optimizedVersion' => 'Оптимизирана версия',
 			'fileInfo.optimizationTarget' => 'Цел на оптимизацията',
@@ -3512,8 +3512,6 @@ extension on TranslationsBg {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy не успя да провери кои файлове ще бъдат премахнати, така че може да изтрие повече от посочения по-горе елемент. Откажете и опитайте отново, или изтрийте въпреки това.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Сървърът ви не предостави данни за файловете на този елемент, така че Plezy не може да провери кои файлове ще бъдат премахнати. Може да изтрие повече от посочения по-горе елемент.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Елементът е изтрит успешно',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Неуспешно изтриване на елемента',
 			'mediaMenu.rate' => 'Оцени',
 			'mediaMenu.playFromBeginning' => 'Пусни от началото',
@@ -3969,12 +3967,12 @@ extension on TranslationsBg {
 			'libraries.groupings.tracks' => 'Песни',
 			'libraries.groupings.folders' => 'Папки',
 			'libraries.filterCategories.genre' => 'Жанр',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Година',
 			'libraries.filterCategories.contentRating' => 'Възрастов рейтинг',
 			'libraries.filterCategories.tag' => 'Таг',
 			'libraries.filterCategories.unwatched' => 'Негледани',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Непускани',
 			'libraries.filterCategories.favorites' => 'Любими',
 			'libraries.sortLabels.title' => 'Заглавие',
@@ -4082,8 +4080,6 @@ extension on TranslationsBg {
 			'explore.watchlistNoMatch' => 'Този елемент не можа да бъде съпоставен със списък за гледане',
 			'explore.notInLibrary' => 'Не е в твоята библиотека',
 			'explore.inTheseLibraries' => 'В тези библиотеки',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Проверка на твоята библиотека...',
 			'explore.emptyTitle' => 'Тук все още няма нищо',
 			'explore.emptyMessage' => ({required Object source}) => 'Редовете от ${source} ще се появят тук, когато има съдържание.',
@@ -4485,12 +4481,12 @@ extension on TranslationsBg {
 			'downloads.syncRuleUpdated' => 'Правилото за синхронизация е обновено',
 			'downloads.syncRuleRemoved' => 'Правилото за синхронизация е премахнато',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Правилото за синхронизация и свързаните изтегляния са премахнати',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Правилата за синхронизация в момента се обновяват. Опитайте отново след малко.',
 			'downloads.syncRuleCleanupUnavailable' => 'Свързаните изтегляния не можаха да бъдат идентифицирани безопасно. Свържете се отново със сървъра и опитайте отново, или премахнете правилото, без да изтривате изтеглянията.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => 'Синхронизирани са ${count} нови епизода за ${title}',
 			'downloads.activeSyncRules' => 'Правила за синхронизация',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Няма правила за синхронизация',
 			'downloads.manageSyncRule' => 'Управление на синхронизацията',
 			'downloads.editEpisodeCount' => 'Брой епизоди',
@@ -4620,8 +4616,6 @@ extension on TranslationsBg {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Неуспешно свързване към който и да е адрес',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Връзката е загубена след ${attempts} опита',
 			'companionRemote.errors.connectionLost' => 'Връзката е загубена',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Връзката беше затворена преди удостоверяването',
 			'videoSettings.playbackSpeed' => 'Скорост на възпроизвеждане',
 			'videoSettings.normalSpeed' => 'Нормална',

--- a/lib/i18n/strings_da.g.dart
+++ b/lib/i18n/strings_da.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsDa {
 			'fileInfo.filePresent' => 'Fil til stede',
 			'fileInfo.fileReadable' => 'Læsbar af serveren',
 			'fileInfo.streamPath' => 'Strømsti',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Optimeret til streaming',
 			'fileInfo.has64bitOffsets' => '64-bit-forskydninger',
 			'fileInfo.protocol' => 'Protokol',
 			'fileInfo.mediaType' => 'Medietype',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Kildetype',
 			'fileInfo.optimizedVersion' => 'Optimeret version',
 			'fileInfo.optimizationTarget' => 'Optimeringsmål',
@@ -3512,8 +3512,6 @@ extension on TranslationsDa {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kunne ikke kontrollere, hvilke filer dette vil fjerne, så det kan slette mere end det ovennævnte emne. Annuller og prøv igen, eller slet alligevel.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Din server leverede ikke filoplysninger for dette emne, så Plezy kan ikke kontrollere, hvilke filer dette vil fjerne. Det kan slette mere end det ovennævnte emne.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Mediet blev slettet',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Mediet kunne ikke slettes',
 			'mediaMenu.rate' => 'Bedøm',
 			'mediaMenu.playFromBeginning' => 'Afspil fra begyndelsen',
@@ -3969,12 +3967,12 @@ extension on TranslationsDa {
 			'libraries.groupings.tracks' => 'Numre',
 			'libraries.groupings.folders' => 'Mapper',
 			'libraries.filterCategories.genre' => 'Genre',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'År',
 			'libraries.filterCategories.contentRating' => 'Aldersvurdering',
 			'libraries.filterCategories.tag' => 'Tag',
 			'libraries.filterCategories.unwatched' => 'Usete',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Ikke afspillet',
 			'libraries.filterCategories.favorites' => 'Favoritter',
 			'libraries.sortLabels.title' => 'Titel',
@@ -4082,8 +4080,6 @@ extension on TranslationsDa {
 			'explore.watchlistNoMatch' => 'Kunne ikke knytte dette element til en overvågningsliste',
 			'explore.notInLibrary' => 'Ikke i dit bibliotek',
 			'explore.inTheseLibraries' => 'I disse biblioteker',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Tjekker dit bibliotek...',
 			'explore.emptyTitle' => 'Der er ikke noget her endnu',
 			'explore.emptyMessage' => ({required Object source}) => 'Indholdsrækker fra ${source} vises her, når de har indhold.',
@@ -4485,12 +4481,12 @@ extension on TranslationsDa {
 			'downloads.syncRuleUpdated' => 'Synkroniseringsregel opdateret',
 			'downloads.syncRuleRemoved' => 'Synkroniseringsregel fjernet',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Synkroniseringsregel og tilknyttede downloads fjernet',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Synkroniseringsregler opdateres lige nu. Prøv igen om et øjeblik.',
 			'downloads.syncRuleCleanupUnavailable' => 'Tilknyttede downloads kunne ikke identificeres sikkert. Genopret forbindelse til serveren og prøv igen, eller fjern reglen uden at slette downloads.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => 'Synkroniserede ${count} nye episoder for ${title}',
 			'downloads.activeSyncRules' => 'Synkroniseringsregler',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Ingen synkroniseringsregler',
 			'downloads.manageSyncRule' => 'Administrer synkronisering',
 			'downloads.editEpisodeCount' => 'Antal episoder',
@@ -4620,8 +4616,6 @@ extension on TranslationsDa {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Kunne ikke oprette forbindelse til nogen adresse',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Forbindelse mistet efter ${attempts} forsøg',
 			'companionRemote.errors.connectionLost' => 'Forbindelse mistet',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Forbindelsen blev lukket før godkendelsen',
 			'videoSettings.playbackSpeed' => 'Afspilningshastighed',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_da.g.dart
+++ b/lib/i18n/strings_da.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$da extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Pr. bibliotek';
 	@override String get playerScopeTitle => 'Pr. serie eller film';
 	@override String get exportDialogTitle => 'Eksportér Plezy-indstillinger';
+	@override String get linuxVideoRenderMode => 'Video-gengivelsestilstand';
+	@override String get linuxVideoRenderModeDescription => 'Automatisk foretrækker det native Wayland-plan (HDR-kompatibelt); Texture tvinger SDR-fallback-stien.';
+	@override String get linuxVideoRenderModeAuto => 'Automatisk';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsDa {
 			'settings.playerScopeLibrary' => 'Pr. bibliotek',
 			'settings.playerScopeTitle' => 'Pr. serie eller film',
 			'settings.exportDialogTitle' => 'Eksportér Plezy-indstillinger',
+			'settings.linuxVideoRenderMode' => 'Video-gengivelsestilstand',
+			'settings.linuxVideoRenderModeDescription' => 'Automatisk foretrækker det native Wayland-plan (HDR-kompatibelt); Texture tvinger SDR-fallback-stien.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatisk',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Søg film, serier, musik...',
 			'search.tryDifferentTerm' => 'Prøv en anden søgning',
 			'search.searchYourMedia' => 'Søg i dine medier',
@@ -3504,6 +3512,8 @@ extension on TranslationsDa {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kunne ikke kontrollere, hvilke filer dette vil fjerne, så det kan slette mere end det ovennævnte emne. Annuller og prøv igen, eller slet alligevel.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Din server leverede ikke filoplysninger for dette emne, så Plezy kan ikke kontrollere, hvilke filer dette vil fjerne. Det kan slette mere end det ovennævnte emne.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Mediet blev slettet',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Mediet kunne ikke slettes',
 			'mediaMenu.rate' => 'Bedøm',
 			'mediaMenu.playFromBeginning' => 'Afspil fra begyndelsen',
@@ -4072,6 +4082,8 @@ extension on TranslationsDa {
 			'explore.watchlistNoMatch' => 'Kunne ikke knytte dette element til en overvågningsliste',
 			'explore.notInLibrary' => 'Ikke i dit bibliotek',
 			'explore.inTheseLibraries' => 'I disse biblioteker',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Tjekker dit bibliotek...',
 			'explore.emptyTitle' => 'Der er ikke noget her endnu',
 			'explore.emptyMessage' => ({required Object source}) => 'Indholdsrækker fra ${source} vises her, når de har indhold.',
@@ -4608,6 +4620,8 @@ extension on TranslationsDa {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Kunne ikke oprette forbindelse til nogen adresse',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Forbindelse mistet efter ${attempts} forsøg',
 			'companionRemote.errors.connectionLost' => 'Forbindelse mistet',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Forbindelsen blev lukket før godkendelsen',
 			'videoSettings.playbackSpeed' => 'Afspilningshastighed',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsDe {
 			'fileInfo.filePresent' => 'Datei vorhanden',
 			'fileInfo.fileReadable' => 'Vom Server lesbar',
 			'fileInfo.streamPath' => 'Stream-Pfad',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Für Streaming optimiert',
 			'fileInfo.has64bitOffsets' => '64-Bit-Offsets',
 			'fileInfo.protocol' => 'Protokoll',
 			'fileInfo.mediaType' => 'Medientyp',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Quellenart',
 			'fileInfo.optimizedVersion' => 'Optimierte Version',
 			'fileInfo.optimizationTarget' => 'Optimierungsziel',
@@ -3512,8 +3512,6 @@ extension on TranslationsDe {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy konnte nicht prüfen, welche Dateien dadurch entfernt werden. Es könnte also mehr gelöscht werden als das oben genannte Element. Brich ab und versuche es erneut, oder lösche trotzdem.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Dein Server hat für dieses Element keine Dateidetails bereitgestellt, daher kann Plezy nicht prüfen, welche Dateien entfernt werden. Es könnte mehr gelöscht werden als das oben genannte Element.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medienelement gelöscht',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Medienelement konnte nicht gelöscht werden',
 			'mediaMenu.rate' => 'Bewerten',
 			'mediaMenu.playFromBeginning' => 'Von Anfang an abspielen',
@@ -3969,12 +3967,12 @@ extension on TranslationsDe {
 			'libraries.groupings.tracks' => 'Titel',
 			'libraries.groupings.folders' => 'Ordner',
 			'libraries.filterCategories.genre' => 'Genre',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Jahr',
 			'libraries.filterCategories.contentRating' => 'Altersfreigabe',
 			'libraries.filterCategories.tag' => 'Tag',
 			'libraries.filterCategories.unwatched' => 'Ungesehene',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Nicht abgespielt',
 			'libraries.filterCategories.favorites' => 'Favoriten',
 			'libraries.sortLabels.title' => 'Titel',
@@ -4082,8 +4080,6 @@ extension on TranslationsDe {
 			'explore.watchlistNoMatch' => 'Dieser Eintrag konnte keiner Watchlist zugeordnet werden',
 			'explore.notInLibrary' => 'Nicht in deiner Mediathek',
 			'explore.inTheseLibraries' => 'In diesen Mediatheken',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Deine Mediathek wird überprüft …',
 			'explore.emptyTitle' => 'Hier ist noch nichts',
 			'explore.emptyMessage' => ({required Object source}) => 'Zeilen aus ${source} erscheinen hier, sobald sie Inhalte enthalten.',
@@ -4485,12 +4481,12 @@ extension on TranslationsDe {
 			'downloads.syncRuleUpdated' => 'Synchronisierungsregel aktualisiert',
 			'downloads.syncRuleRemoved' => 'Synchronisierungsregel entfernt',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Synchronisierungsregel und zugehörige Downloads entfernt',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Synchronisierungsregeln werden gerade aktualisiert. Versuche es gleich noch einmal.',
 			'downloads.syncRuleCleanupUnavailable' => 'Zugehörige Downloads konnten nicht sicher ermittelt werden. Verbinde den Server erneut und versuche es noch einmal, oder entferne die Regel, ohne die Downloads zu löschen.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} neue Episoden für ${title} synchronisiert',
 			'downloads.activeSyncRules' => 'Synchronisierungsregeln',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Keine Synchronisierungsregeln',
 			'downloads.manageSyncRule' => 'Synchronisierung verwalten',
 			'downloads.editEpisodeCount' => 'Episodenanzahl',
@@ -4620,8 +4616,6 @@ extension on TranslationsDe {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Keine Verbindung zu einer Adresse möglich',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Verbindung nach ${attempts} Versuchen verloren',
 			'companionRemote.errors.connectionLost' => 'Verbindung verloren',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Die Verbindung wurde vor der Authentifizierung geschlossen',
 			'videoSettings.playbackSpeed' => 'Wiedergabegeschwindigkeit',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_de.g.dart
+++ b/lib/i18n/strings_de.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$de extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Pro Bibliothek';
 	@override String get playerScopeTitle => 'Pro Serie oder Film';
 	@override String get exportDialogTitle => 'Plezy-Einstellungen exportieren';
+	@override String get linuxVideoRenderMode => 'Video-Rendermodus';
+	@override String get linuxVideoRenderModeDescription => 'Automatisch bevorzugt die native Wayland-Ebene (HDR-fähig); Texture erzwingt den SDR-Fallback-Pfad.';
+	@override String get linuxVideoRenderModeAuto => 'Automatisch';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsDe {
 			'settings.playerScopeLibrary' => 'Pro Bibliothek',
 			'settings.playerScopeTitle' => 'Pro Serie oder Film',
 			'settings.exportDialogTitle' => 'Plezy-Einstellungen exportieren',
+			'settings.linuxVideoRenderMode' => 'Video-Rendermodus',
+			'settings.linuxVideoRenderModeDescription' => 'Automatisch bevorzugt die native Wayland-Ebene (HDR-fähig); Texture erzwingt den SDR-Fallback-Pfad.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatisch',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Filme, Serien und Musik suchen …',
 			'search.tryDifferentTerm' => 'Anderen Suchbegriff versuchen',
 			'search.searchYourMedia' => 'In den eigenen Medien suchen',
@@ -3504,6 +3512,8 @@ extension on TranslationsDe {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy konnte nicht prüfen, welche Dateien dadurch entfernt werden. Es könnte also mehr gelöscht werden als das oben genannte Element. Brich ab und versuche es erneut, oder lösche trotzdem.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Dein Server hat für dieses Element keine Dateidetails bereitgestellt, daher kann Plezy nicht prüfen, welche Dateien entfernt werden. Es könnte mehr gelöscht werden als das oben genannte Element.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medienelement gelöscht',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Medienelement konnte nicht gelöscht werden',
 			'mediaMenu.rate' => 'Bewerten',
 			'mediaMenu.playFromBeginning' => 'Von Anfang an abspielen',
@@ -4072,6 +4082,8 @@ extension on TranslationsDe {
 			'explore.watchlistNoMatch' => 'Dieser Eintrag konnte keiner Watchlist zugeordnet werden',
 			'explore.notInLibrary' => 'Nicht in deiner Mediathek',
 			'explore.inTheseLibraries' => 'In diesen Mediatheken',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Deine Mediathek wird überprüft …',
 			'explore.emptyTitle' => 'Hier ist noch nichts',
 			'explore.emptyMessage' => ({required Object source}) => 'Zeilen aus ${source} erscheinen hier, sobald sie Inhalte enthalten.',
@@ -4608,6 +4620,8 @@ extension on TranslationsDe {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Keine Verbindung zu einer Adresse möglich',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Verbindung nach ${attempts} Versuchen verloren',
 			'companionRemote.errors.connectionLost' => 'Verbindung verloren',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Die Verbindung wurde vor der Authentifizierung geschlossen',
 			'videoSettings.playbackSpeed' => 'Wiedergabegeschwindigkeit',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -7495,12 +7495,12 @@ extension on Translations {
 			'fileInfo.duration' => 'Duration',
 			'fileInfo.previewThumbnails' => 'Preview Thumbnails',
 			'fileInfo.previewIndex' => 'Preview Index',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.packetLength' => 'Packet Length',
 			'fileInfo.filePresent' => 'File Present',
 			'fileInfo.fileReadable' => 'Readable by Server',
 			'fileInfo.streamPath' => 'Stream Path',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Optimized for Streaming',
 			'fileInfo.has64bitOffsets' => '64-bit Offsets',
 			'fileInfo.protocol' => 'Protocol',
@@ -7558,8 +7558,6 @@ extension on Translations {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy could not check which files this will remove, so it may delete more than the item named above. Cancel and try again, or delete anyway.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Your server did not provide file details for this item, so Plezy cannot check which files this will remove. It may delete more than the item named above.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media item deleted successfully',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Failed to delete media item',
 			'mediaMenu.rate' => 'Rate',
 			'mediaMenu.playFromBeginning' => 'Play from Beginning',
@@ -8011,12 +8009,12 @@ extension on Translations {
 			'libraries.groupings.all' => 'All',
 			'libraries.groupings.movies' => 'Movies',
 			'libraries.groupings.shows' => 'TV Shows',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.groupings.seasons' => 'Seasons',
 			'libraries.groupings.episodes' => 'Episodes',
 			'libraries.groupings.artists' => 'Artists',
 			'libraries.groupings.albums' => 'Albums',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.groupings.tracks' => 'Tracks',
 			'libraries.groupings.folders' => 'Folders',
 			'libraries.filterCategories.genre' => 'Genre',
@@ -8131,8 +8129,6 @@ extension on Translations {
 			'explore.watchlistNoMatch' => 'Couldn\'t match this item to a watchlist',
 			'explore.notInLibrary' => 'Not in your library',
 			'explore.inTheseLibraries' => 'In these libraries',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Checking your library...',
 			'explore.emptyTitle' => 'Nothing here yet',
 			'explore.emptyMessage' => ({required Object source}) => 'Rows from ${source} will appear here once they have content.',
@@ -8527,12 +8523,12 @@ extension on Translations {
 			'downloads.nextNUnwatched' => ({required Object count}) => 'Next ${count} unwatched',
 			'downloads.customAmount' => 'Custom amount...',
 			'downloads.includeSpecials' => 'Include Specials',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.howManyEpisodes' => 'How many episodes?',
 			'downloads.invalidEpisodeCount' => 'Enter a valid episode count.',
 			'downloads.keepSynced' => 'Keep synced',
 			'downloads.downloadOnce' => 'Download once',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.keepNUnwatched' => ({required Object count}) => 'Keep ${count} unwatched',
 			'downloads.editSyncRule' => 'Edit sync rule',
 			'downloads.removeSyncRule' => 'Remove sync rule',
@@ -8677,8 +8673,6 @@ extension on Translations {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Failed to connect to any address',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Connection lost after ${attempts} attempts',
 			'companionRemote.errors.connectionLost' => 'Connection lost',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'The connection closed before authentication',
 			'videoSettings.playbackSpeed' => 'Playback Speed',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_en.g.dart
+++ b/lib/i18n/strings_en.g.dart
@@ -1250,6 +1250,18 @@ class Translations$settings$en {
 
 	/// en: 'Export Plezy settings'
 	String get exportDialogTitle => 'Export Plezy settings';
+
+	/// en: 'Video rendering mode'
+	String get linuxVideoRenderMode => 'Video rendering mode';
+
+	/// en: 'Automatic prefers the native Wayland plane (HDR-capable); Texture forces the SDR fallback path.'
+	String get linuxVideoRenderModeDescription => 'Automatic prefers the native Wayland plane (HDR-capable); Texture forces the SDR fallback path.';
+
+	/// en: 'Automatic'
+	String get linuxVideoRenderModeAuto => 'Automatic';
+
+	/// en: 'Texture (SDR)'
+	String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -7361,6 +7373,10 @@ extension on Translations {
 			'settings.playerScopeLibrary' => 'Per library',
 			'settings.playerScopeTitle' => 'Per show or movie',
 			'settings.exportDialogTitle' => 'Export Plezy settings',
+			'settings.linuxVideoRenderMode' => 'Video rendering mode',
+			'settings.linuxVideoRenderModeDescription' => 'Automatic prefers the native Wayland plane (HDR-capable); Texture forces the SDR fallback path.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatic',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Search movies, shows, music...',
 			'search.tryDifferentTerm' => 'Try a different search term',
 			'search.searchYourMedia' => 'Search your media',
@@ -7542,6 +7558,8 @@ extension on Translations {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy could not check which files this will remove, so it may delete more than the item named above. Cancel and try again, or delete anyway.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Your server did not provide file details for this item, so Plezy cannot check which files this will remove. It may delete more than the item named above.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media item deleted successfully',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Failed to delete media item',
 			'mediaMenu.rate' => 'Rate',
 			'mediaMenu.playFromBeginning' => 'Play from Beginning',
@@ -8113,6 +8131,8 @@ extension on Translations {
 			'explore.watchlistNoMatch' => 'Couldn\'t match this item to a watchlist',
 			'explore.notInLibrary' => 'Not in your library',
 			'explore.inTheseLibraries' => 'In these libraries',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Checking your library...',
 			'explore.emptyTitle' => 'Nothing here yet',
 			'explore.emptyMessage' => ({required Object source}) => 'Rows from ${source} will appear here once they have content.',
@@ -8657,6 +8677,8 @@ extension on Translations {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Failed to connect to any address',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Connection lost after ${attempts} attempts',
 			'companionRemote.errors.connectionLost' => 'Connection lost',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'The connection closed before authentication',
 			'videoSettings.playbackSpeed' => 'Playback Speed',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_es.g.dart
+++ b/lib/i18n/strings_es.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsEs {
 			'fileInfo.filePresent' => 'Archivo presente',
 			'fileInfo.fileReadable' => 'Legible por el servidor',
 			'fileInfo.streamPath' => 'Ruta del flujo',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Optimizado para transmisión',
 			'fileInfo.has64bitOffsets' => 'Desplazamientos de 64 bits',
 			'fileInfo.protocol' => 'Protocolo',
 			'fileInfo.mediaType' => 'Tipo de medio',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Tipo de origen',
 			'fileInfo.optimizedVersion' => 'Versión optimizada',
 			'fileInfo.optimizationTarget' => 'Destino de optimización',
@@ -3512,8 +3512,6 @@ extension on TranslationsEs {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy no pudo comprobar qué archivos se eliminarán, por lo que podría borrar más de lo indicado arriba. Cancela y vuelve a intentarlo, o elimina de todos modos.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Tu servidor no proporcionó los detalles del archivo de este elemento, por lo que Plezy no puede comprobar qué archivos se eliminarán. Podría borrar más de lo indicado arriba.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Elemento multimedia eliminado con éxito',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Error al eliminar el elemento multimedia',
 			'mediaMenu.rate' => 'Calificar',
 			'mediaMenu.playFromBeginning' => 'Reproducir desde el inicio',
@@ -3969,12 +3967,12 @@ extension on TranslationsEs {
 			'libraries.groupings.tracks' => 'Canciones',
 			'libraries.groupings.folders' => 'Carpetas',
 			'libraries.filterCategories.genre' => 'Género',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Año',
 			'libraries.filterCategories.contentRating' => 'Clasificación por edad',
 			'libraries.filterCategories.tag' => 'Etiqueta',
 			'libraries.filterCategories.unwatched' => 'No vistos',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'No reproducidos',
 			'libraries.filterCategories.favorites' => 'Favoritos',
 			'libraries.sortLabels.title' => 'Título',
@@ -4082,8 +4080,6 @@ extension on TranslationsEs {
 			'explore.watchlistNoMatch' => 'No se pudo asociar este elemento con una lista de seguimiento',
 			'explore.notInLibrary' => 'No está en tu biblioteca',
 			'explore.inTheseLibraries' => 'En estas bibliotecas',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Comprobando tu biblioteca...',
 			'explore.emptyTitle' => 'Aquí no hay nada todavía',
 			'explore.emptyMessage' => ({required Object source}) => 'Las filas de ${source} aparecerán aquí cuando tengan contenido.',
@@ -4485,12 +4481,12 @@ extension on TranslationsEs {
 			'downloads.syncRuleUpdated' => 'Regla de sincronización actualizada',
 			'downloads.syncRuleRemoved' => 'Regla de sincronización eliminada',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Regla de sincronización y descargas asociadas eliminadas',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Las reglas de sincronización se están actualizando. Inténtalo de nuevo en un momento.',
 			'downloads.syncRuleCleanupUnavailable' => 'No se pudieron identificar las descargas asociadas de forma segura. Vuelve a conectar el servidor e inténtalo de nuevo, o elimina la regla sin borrar las descargas.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} nuevos episodios sincronizados para ${title}',
 			'downloads.activeSyncRules' => 'Reglas de sincronización',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Sin reglas de sincronización',
 			'downloads.manageSyncRule' => 'Gestionar sincronización',
 			'downloads.editEpisodeCount' => 'Número de episodios',
@@ -4620,8 +4616,6 @@ extension on TranslationsEs {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'No se pudo conectar a ninguna dirección',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Conexión perdida tras ${attempts} intentos',
 			'companionRemote.errors.connectionLost' => 'Conexión perdida',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'La conexión se cerró antes de la autenticación',
 			'videoSettings.playbackSpeed' => 'Velocidad de reproducción',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_es.g.dart
+++ b/lib/i18n/strings_es.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$es extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Por biblioteca';
 	@override String get playerScopeTitle => 'Por serie o película';
 	@override String get exportDialogTitle => 'Exportar ajustes de Plezy';
+	@override String get linuxVideoRenderMode => 'Modo de renderizado de vídeo';
+	@override String get linuxVideoRenderModeDescription => 'Automático prefiere el plano Wayland nativo (compatible con HDR); Texture fuerza la ruta de reserva SDR.';
+	@override String get linuxVideoRenderModeAuto => 'Automático';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsEs {
 			'settings.playerScopeLibrary' => 'Por biblioteca',
 			'settings.playerScopeTitle' => 'Por serie o película',
 			'settings.exportDialogTitle' => 'Exportar ajustes de Plezy',
+			'settings.linuxVideoRenderMode' => 'Modo de renderizado de vídeo',
+			'settings.linuxVideoRenderModeDescription' => 'Automático prefiere el plano Wayland nativo (compatible con HDR); Texture fuerza la ruta de reserva SDR.',
+			'settings.linuxVideoRenderModeAuto' => 'Automático',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Buscar películas, series, música...',
 			'search.tryDifferentTerm' => 'Prueba con un término de búsqueda diferente',
 			'search.searchYourMedia' => 'Busca en tu contenido',
@@ -3504,6 +3512,8 @@ extension on TranslationsEs {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy no pudo comprobar qué archivos se eliminarán, por lo que podría borrar más de lo indicado arriba. Cancela y vuelve a intentarlo, o elimina de todos modos.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Tu servidor no proporcionó los detalles del archivo de este elemento, por lo que Plezy no puede comprobar qué archivos se eliminarán. Podría borrar más de lo indicado arriba.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Elemento multimedia eliminado con éxito',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Error al eliminar el elemento multimedia',
 			'mediaMenu.rate' => 'Calificar',
 			'mediaMenu.playFromBeginning' => 'Reproducir desde el inicio',
@@ -4072,6 +4082,8 @@ extension on TranslationsEs {
 			'explore.watchlistNoMatch' => 'No se pudo asociar este elemento con una lista de seguimiento',
 			'explore.notInLibrary' => 'No está en tu biblioteca',
 			'explore.inTheseLibraries' => 'En estas bibliotecas',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Comprobando tu biblioteca...',
 			'explore.emptyTitle' => 'Aquí no hay nada todavía',
 			'explore.emptyMessage' => ({required Object source}) => 'Las filas de ${source} aparecerán aquí cuando tengan contenido.',
@@ -4608,6 +4620,8 @@ extension on TranslationsEs {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'No se pudo conectar a ninguna dirección',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Conexión perdida tras ${attempts} intentos',
 			'companionRemote.errors.connectionLost' => 'Conexión perdida',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'La conexión se cerró antes de la autenticación',
 			'videoSettings.playbackSpeed' => 'Velocidad de reproducción',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_fr.g.dart
+++ b/lib/i18n/strings_fr.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsFr {
 			'fileInfo.filePresent' => 'Fichier présent',
 			'fileInfo.fileReadable' => 'Lisible par le serveur',
 			'fileInfo.streamPath' => 'Chemin du flux',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Optimisé pour le streaming',
 			'fileInfo.has64bitOffsets' => 'Décalages 64 bits',
 			'fileInfo.protocol' => 'Protocole',
 			'fileInfo.mediaType' => 'Type de média',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Type de source',
 			'fileInfo.optimizedVersion' => 'Version optimisée',
 			'fileInfo.optimizationTarget' => 'Cible d\'optimisation',
@@ -3512,8 +3512,6 @@ extension on TranslationsFr {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy n\'a pas pu vérifier quels fichiers seront supprimés ; il risque donc d\'en supprimer plus que l\'élément nommé ci-dessus. Annulez et réessayez, ou supprimez quand même.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Votre serveur n\'a pas fourni les détails du fichier pour cet élément, Plezy ne peut donc pas vérifier quels fichiers seront supprimés. Il risque d\'en supprimer plus que l\'élément nommé ci-dessus.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Élément média supprimé avec succès',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Échec de la suppression de l\'élément média',
 			'mediaMenu.rate' => 'Noter',
 			'mediaMenu.playFromBeginning' => 'Lire depuis le début',
@@ -3969,12 +3967,12 @@ extension on TranslationsFr {
 			'libraries.groupings.tracks' => 'Titres',
 			'libraries.groupings.folders' => 'Dossiers',
 			'libraries.filterCategories.genre' => 'Genre',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Année',
 			'libraries.filterCategories.contentRating' => 'Classification',
 			'libraries.filterCategories.tag' => 'Étiquette',
 			'libraries.filterCategories.unwatched' => 'Non vus',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Non lus',
 			'libraries.filterCategories.favorites' => 'Favoris',
 			'libraries.sortLabels.title' => 'Titre',
@@ -4082,8 +4080,6 @@ extension on TranslationsFr {
 			'explore.watchlistNoMatch' => 'Impossible d’associer cet élément à une liste de suivi',
 			'explore.notInLibrary' => 'Absent de votre bibliothèque',
 			'explore.inTheseLibraries' => 'Dans ces bibliothèques',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Vérification de votre bibliothèque...',
 			'explore.emptyTitle' => 'Rien ici pour l\'instant',
 			'explore.emptyMessage' => ({required Object source}) => 'Les lignes de ${source} apparaîtront ici dès qu’elles contiendront des éléments.',
@@ -4485,12 +4481,12 @@ extension on TranslationsFr {
 			'downloads.syncRuleUpdated' => 'Règle de synchronisation mise à jour',
 			'downloads.syncRuleRemoved' => 'Règle de synchronisation supprimée',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Règle de synchronisation et téléchargements associés supprimés',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Les règles de synchronisation sont en cours de mise à jour. Réessayez dans un instant.',
 			'downloads.syncRuleCleanupUnavailable' => 'Les téléchargements associés n\'ont pas pu être identifiés en toute sécurité. Reconnectez le serveur et réessayez, ou retirez la règle sans supprimer les téléchargements.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} nouveaux épisodes synchronisés pour ${title}',
 			'downloads.activeSyncRules' => 'Règles de synchronisation',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Aucune règle de synchronisation',
 			'downloads.manageSyncRule' => 'Gérer la synchronisation',
 			'downloads.editEpisodeCount' => 'Nombre d’épisodes',
@@ -4620,8 +4616,6 @@ extension on TranslationsFr {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Impossible de se connecter à une adresse',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Connexion perdue après ${attempts} tentatives',
 			'companionRemote.errors.connectionLost' => 'Connexion perdue',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'La connexion a été fermée avant l’authentification',
 			'videoSettings.playbackSpeed' => 'Vitesse de lecture',
 			'videoSettings.normalSpeed' => 'Normale',

--- a/lib/i18n/strings_fr.g.dart
+++ b/lib/i18n/strings_fr.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$fr extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Par bibliothèque';
 	@override String get playerScopeTitle => 'Par série ou film';
 	@override String get exportDialogTitle => 'Exporter les paramètres de Plezy';
+	@override String get linuxVideoRenderMode => 'Mode de rendu vidéo';
+	@override String get linuxVideoRenderModeDescription => 'Automatique préfère le plan Wayland natif (compatible HDR) ; Texture force le chemin de repli SDR.';
+	@override String get linuxVideoRenderModeAuto => 'Automatique';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsFr {
 			'settings.playerScopeLibrary' => 'Par bibliothèque',
 			'settings.playerScopeTitle' => 'Par série ou film',
 			'settings.exportDialogTitle' => 'Exporter les paramètres de Plezy',
+			'settings.linuxVideoRenderMode' => 'Mode de rendu vidéo',
+			'settings.linuxVideoRenderModeDescription' => 'Automatique préfère le plan Wayland natif (compatible HDR) ; Texture force le chemin de repli SDR.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatique',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Rechercher des films, des séries, de la musique...',
 			'search.tryDifferentTerm' => 'Essayez un autre terme de recherche',
 			'search.searchYourMedia' => 'Rechercher dans vos médias',
@@ -3504,6 +3512,8 @@ extension on TranslationsFr {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy n\'a pas pu vérifier quels fichiers seront supprimés ; il risque donc d\'en supprimer plus que l\'élément nommé ci-dessus. Annulez et réessayez, ou supprimez quand même.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Votre serveur n\'a pas fourni les détails du fichier pour cet élément, Plezy ne peut donc pas vérifier quels fichiers seront supprimés. Il risque d\'en supprimer plus que l\'élément nommé ci-dessus.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Élément média supprimé avec succès',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Échec de la suppression de l\'élément média',
 			'mediaMenu.rate' => 'Noter',
 			'mediaMenu.playFromBeginning' => 'Lire depuis le début',
@@ -4072,6 +4082,8 @@ extension on TranslationsFr {
 			'explore.watchlistNoMatch' => 'Impossible d’associer cet élément à une liste de suivi',
 			'explore.notInLibrary' => 'Absent de votre bibliothèque',
 			'explore.inTheseLibraries' => 'Dans ces bibliothèques',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Vérification de votre bibliothèque...',
 			'explore.emptyTitle' => 'Rien ici pour l\'instant',
 			'explore.emptyMessage' => ({required Object source}) => 'Les lignes de ${source} apparaîtront ici dès qu’elles contiendront des éléments.',
@@ -4608,6 +4620,8 @@ extension on TranslationsFr {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Impossible de se connecter à une adresse',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Connexion perdue après ${attempts} tentatives',
 			'companionRemote.errors.connectionLost' => 'Connexion perdue',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'La connexion a été fermée avant l’authentification',
 			'videoSettings.playbackSpeed' => 'Vitesse de lecture',
 			'videoSettings.normalSpeed' => 'Normale',

--- a/lib/i18n/strings_hu.g.dart
+++ b/lib/i18n/strings_hu.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$hu extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Könyvtáronként';
 	@override String get playerScopeTitle => 'Sorozatonként vagy filmenként';
 	@override String get exportDialogTitle => 'Plezy-beállítások exportálása';
+	@override String get linuxVideoRenderMode => 'Videó megjelenítési mód';
+	@override String get linuxVideoRenderModeDescription => 'Az Automatikus a natív Wayland síkot részesíti előnyben (HDR-képes); a Texture az SDR tartalék utat kényszeríti ki.';
+	@override String get linuxVideoRenderModeAuto => 'Automatikus';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsHu {
 			'settings.playerScopeLibrary' => 'Könyvtáronként',
 			'settings.playerScopeTitle' => 'Sorozatonként vagy filmenként',
 			'settings.exportDialogTitle' => 'Plezy-beállítások exportálása',
+			'settings.linuxVideoRenderMode' => 'Videó megjelenítési mód',
+			'settings.linuxVideoRenderModeDescription' => 'Az Automatikus a natív Wayland síkot részesíti előnyben (HDR-képes); a Texture az SDR tartalék utat kényszeríti ki.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatikus',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Keresés filmek, sorozatok és zenék között...',
 			'search.tryDifferentTerm' => 'Próbálj másik keresési kifejezést',
 			'search.searchYourMedia' => 'Keresés a saját médiatartalmak között',
@@ -3504,6 +3512,8 @@ extension on TranslationsHu {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'A Plezy nem tudta ellenőrizni, mely fájlokat távolítja el ez, ezért a fent nevezett elemnél többet is törölhet. Szakítsa meg és próbálja újra, vagy töröljön mindenképp.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'A szerver nem szolgáltatott fájladatokat ehhez az elemhez, ezért a Plezy nem tudja ellenőrizni, mely fájlokat távolít el. A fent nevezett elemnél többet is törölhet.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Médiaelem sikeresen törölve',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Nem sikerült a médiaelem törlése',
 			'mediaMenu.rate' => 'Értékelés',
 			'mediaMenu.playFromBeginning' => 'Lejátszás az elejétől',
@@ -4072,6 +4082,8 @@ extension on TranslationsHu {
 			'explore.watchlistNoMatch' => 'Nem sikerült ezt az elemet figyelőlistához társítani',
 			'explore.notInLibrary' => 'Nincs a könyvtáradban',
 			'explore.inTheseLibraries' => 'Ezekben a könyvtárakban',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Könyvtár ellenőrzése...',
 			'explore.emptyTitle' => 'Még nincs itt semmi',
 			'explore.emptyMessage' => ({required Object source}) => 'A(z) ${source} forrásból származó sorok itt fognak megjelenni, amint van tartalmuk.',
@@ -4608,6 +4620,8 @@ extension on TranslationsHu {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Egyetlen címhez sem sikerült csatlakozni',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'A kapcsolat megszakadt ${attempts} próbálkozás után',
 			'companionRemote.errors.connectionLost' => 'A kapcsolat megszakadt',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'A kapcsolat a hitelesítés előtt megszakadt',
 			'videoSettings.playbackSpeed' => 'Lejátszási sebesség',
 			'videoSettings.normalSpeed' => 'Normál',

--- a/lib/i18n/strings_hu.g.dart
+++ b/lib/i18n/strings_hu.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsHu {
 			'fileInfo.filePresent' => 'Fájl jelen van',
 			'fileInfo.fileReadable' => 'A szerver számára olvasható',
 			'fileInfo.streamPath' => 'Adatfolyam útvonala',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Adatfolyam-továbbításra optimalizálva',
 			'fileInfo.has64bitOffsets' => '64 bites eltolások',
 			'fileInfo.protocol' => 'Protokoll',
 			'fileInfo.mediaType' => 'Médiatípus',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Forrás típusa',
 			'fileInfo.optimizedVersion' => 'Optimalizált verzió',
 			'fileInfo.optimizationTarget' => 'Optimalizálási cél',
@@ -3512,8 +3512,6 @@ extension on TranslationsHu {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'A Plezy nem tudta ellenőrizni, mely fájlokat távolítja el ez, ezért a fent nevezett elemnél többet is törölhet. Szakítsa meg és próbálja újra, vagy töröljön mindenképp.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'A szerver nem szolgáltatott fájladatokat ehhez az elemhez, ezért a Plezy nem tudja ellenőrizni, mely fájlokat távolít el. A fent nevezett elemnél többet is törölhet.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Médiaelem sikeresen törölve',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Nem sikerült a médiaelem törlése',
 			'mediaMenu.rate' => 'Értékelés',
 			'mediaMenu.playFromBeginning' => 'Lejátszás az elejétől',
@@ -3969,12 +3967,12 @@ extension on TranslationsHu {
 			'libraries.groupings.tracks' => 'Zeneszámok',
 			'libraries.groupings.folders' => 'Mappák',
 			'libraries.filterCategories.genre' => 'Műfaj',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Év',
 			'libraries.filterCategories.contentRating' => 'Korhatár-besorolás',
 			'libraries.filterCategories.tag' => 'Címke',
 			'libraries.filterCategories.unwatched' => 'Nem látott',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Nem lejátszott',
 			'libraries.filterCategories.favorites' => 'Kedvencek',
 			'libraries.sortLabels.title' => 'Cím',
@@ -4082,8 +4080,6 @@ extension on TranslationsHu {
 			'explore.watchlistNoMatch' => 'Nem sikerült ezt az elemet figyelőlistához társítani',
 			'explore.notInLibrary' => 'Nincs a könyvtáradban',
 			'explore.inTheseLibraries' => 'Ezekben a könyvtárakban',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Könyvtár ellenőrzése...',
 			'explore.emptyTitle' => 'Még nincs itt semmi',
 			'explore.emptyMessage' => ({required Object source}) => 'A(z) ${source} forrásból származó sorok itt fognak megjelenni, amint van tartalmuk.',
@@ -4485,12 +4481,12 @@ extension on TranslationsHu {
 			'downloads.syncRuleUpdated' => 'Szinkronizálási szabály frissítve',
 			'downloads.syncRuleRemoved' => 'Szinkronizálási szabály eltávolítva',
 			'downloads.syncRuleAndDownloadsRemoved' => 'A szinkronszabály és a kapcsolódó letöltések eltávolítva',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'A szinkronszabályok éppen frissülnek. Próbálja újra egy pillanat múlva.',
 			'downloads.syncRuleCleanupUnavailable' => 'A kapcsolódó letöltések nem azonosíthatók biztonságosan. Csatlakoztassa újra a szervert, és próbálja újra, vagy távolítsa el a szabályt a letöltések törlése nélkül.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} új epizód szinkronizálva a következőhöz: ${title}',
 			'downloads.activeSyncRules' => 'Szinkronizálási szabályok',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Nincsenek szinkronizálási szabályok',
 			'downloads.manageSyncRule' => 'Szinkronizálás kezelése',
 			'downloads.editEpisodeCount' => 'Epizódszám',
@@ -4620,8 +4616,6 @@ extension on TranslationsHu {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Egyetlen címhez sem sikerült csatlakozni',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'A kapcsolat megszakadt ${attempts} próbálkozás után',
 			'companionRemote.errors.connectionLost' => 'A kapcsolat megszakadt',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'A kapcsolat a hitelesítés előtt megszakadt',
 			'videoSettings.playbackSpeed' => 'Lejátszási sebesség',
 			'videoSettings.normalSpeed' => 'Normál',

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsIt {
 			'fileInfo.filePresent' => 'File presente',
 			'fileInfo.fileReadable' => 'Leggibile dal server',
 			'fileInfo.streamPath' => 'Percorso flusso',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Ottimizzato per lo streaming',
 			'fileInfo.has64bitOffsets' => 'Offset a 64 bit',
 			'fileInfo.protocol' => 'Protocollo',
 			'fileInfo.mediaType' => 'Tipo di supporto',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Tipo di origine',
 			'fileInfo.optimizedVersion' => 'Versione ottimizzata',
 			'fileInfo.optimizationTarget' => 'Obiettivo ottimizzazione',
@@ -3512,8 +3512,6 @@ extension on TranslationsIt {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy non ha potuto verificare quali file rimuoverà, quindi potrebbe eliminare più di quanto indicato sopra. Annulla e riprova, oppure elimina comunque.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Il tuo server non ha fornito i dettagli del file per questo elemento, quindi Plezy non può verificare quali file rimuoverà. Potrebbe eliminare più di quanto indicato sopra.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Elemento multimediale eliminato correttamente',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Impossibile eliminare l\'elemento multimediale',
 			'mediaMenu.rate' => 'Valuta',
 			'mediaMenu.playFromBeginning' => 'Riproduci dall\'inizio',
@@ -3969,12 +3967,12 @@ extension on TranslationsIt {
 			'libraries.groupings.tracks' => 'Brani',
 			'libraries.groupings.folders' => 'Cartelle',
 			'libraries.filterCategories.genre' => 'Genere',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Anno',
 			'libraries.filterCategories.contentRating' => 'Classificazione per età',
 			'libraries.filterCategories.tag' => 'Tag',
 			'libraries.filterCategories.unwatched' => 'Non visti',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Non riprodotti',
 			'libraries.filterCategories.favorites' => 'Preferiti',
 			'libraries.sortLabels.title' => 'Titolo',
@@ -4082,8 +4080,6 @@ extension on TranslationsIt {
 			'explore.watchlistNoMatch' => 'Impossibile associare questo elemento a una lista titoli',
 			'explore.notInLibrary' => 'Non è nella tua libreria',
 			'explore.inTheseLibraries' => 'In queste librerie',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Ricerca nella tua libreria...',
 			'explore.emptyTitle' => 'Ancora niente qui',
 			'explore.emptyMessage' => ({required Object source}) => 'Le sezioni di ${source} appariranno qui quando saranno disponibili dei contenuti.',
@@ -4485,12 +4481,12 @@ extension on TranslationsIt {
 			'downloads.syncRuleUpdated' => 'Regola di sincronizzazione aggiornata',
 			'downloads.syncRuleRemoved' => 'Regola di sincronizzazione rimossa',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Regola di sincronizzazione e download associati rimossi',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Le regole di sincronizzazione sono in fase di aggiornamento. Riprova tra un momento.',
 			'downloads.syncRuleCleanupUnavailable' => 'Non è stato possibile identificare in sicurezza i download associati. Riconnetti il server e riprova, oppure rimuovi la regola senza eliminare i download.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} nuovi episodi sincronizzati per ${title}',
 			'downloads.activeSyncRules' => 'Regole di sincronizzazione',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Nessuna regola di sincronizzazione',
 			'downloads.manageSyncRule' => 'Gestisci sincronizzazione',
 			'downloads.editEpisodeCount' => 'Numero di episodi',
@@ -4620,8 +4616,6 @@ extension on TranslationsIt {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Impossibile connettersi a qualsiasi indirizzo',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Connessione persa dopo ${attempts} tentativi',
 			'companionRemote.errors.connectionLost' => 'Connessione persa',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'La connessione si è chiusa prima dell\'autenticazione',
 			'videoSettings.playbackSpeed' => 'Velocità di riproduzione',
 			'videoSettings.normalSpeed' => 'Normale',

--- a/lib/i18n/strings_it.g.dart
+++ b/lib/i18n/strings_it.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$it extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Per libreria';
 	@override String get playerScopeTitle => 'Per serie o film';
 	@override String get exportDialogTitle => 'Esporta le impostazioni di Plezy';
+	@override String get linuxVideoRenderMode => 'Modalità di rendering video';
+	@override String get linuxVideoRenderModeDescription => 'Automatico preferisce il piano Wayland nativo (compatibile HDR); Texture forza il percorso di riserva SDR.';
+	@override String get linuxVideoRenderModeAuto => 'Automatico';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsIt {
 			'settings.playerScopeLibrary' => 'Per libreria',
 			'settings.playerScopeTitle' => 'Per serie o film',
 			'settings.exportDialogTitle' => 'Esporta le impostazioni di Plezy',
+			'settings.linuxVideoRenderMode' => 'Modalità di rendering video',
+			'settings.linuxVideoRenderModeDescription' => 'Automatico preferisce il piano Wayland nativo (compatibile HDR); Texture forza il percorso di riserva SDR.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatico',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Cerca film, serie TV e musica...',
 			'search.tryDifferentTerm' => 'Prova altri termini di ricerca',
 			'search.searchYourMedia' => 'Cerca nei tuoi media',
@@ -3504,6 +3512,8 @@ extension on TranslationsIt {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy non ha potuto verificare quali file rimuoverà, quindi potrebbe eliminare più di quanto indicato sopra. Annulla e riprova, oppure elimina comunque.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Il tuo server non ha fornito i dettagli del file per questo elemento, quindi Plezy non può verificare quali file rimuoverà. Potrebbe eliminare più di quanto indicato sopra.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Elemento multimediale eliminato correttamente',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Impossibile eliminare l\'elemento multimediale',
 			'mediaMenu.rate' => 'Valuta',
 			'mediaMenu.playFromBeginning' => 'Riproduci dall\'inizio',
@@ -4072,6 +4082,8 @@ extension on TranslationsIt {
 			'explore.watchlistNoMatch' => 'Impossibile associare questo elemento a una lista titoli',
 			'explore.notInLibrary' => 'Non è nella tua libreria',
 			'explore.inTheseLibraries' => 'In queste librerie',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Ricerca nella tua libreria...',
 			'explore.emptyTitle' => 'Ancora niente qui',
 			'explore.emptyMessage' => ({required Object source}) => 'Le sezioni di ${source} appariranno qui quando saranno disponibili dei contenuti.',
@@ -4608,6 +4620,8 @@ extension on TranslationsIt {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Impossibile connettersi a qualsiasi indirizzo',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Connessione persa dopo ${attempts} tentativi',
 			'companionRemote.errors.connectionLost' => 'Connessione persa',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'La connessione si è chiusa prima dell\'autenticazione',
 			'videoSettings.playbackSpeed' => 'Velocità di riproduzione',
 			'videoSettings.normalSpeed' => 'Normale',

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -3443,12 +3443,12 @@ extension on TranslationsJa {
 			'fileInfo.filePresent' => 'ファイルあり',
 			'fileInfo.fileReadable' => 'サーバーから読み取り可能',
 			'fileInfo.streamPath' => 'ストリームパス',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'ストリーミング最適化',
 			'fileInfo.has64bitOffsets' => '64ビットオフセット',
 			'fileInfo.protocol' => 'プロトコル',
 			'fileInfo.mediaType' => 'メディアタイプ',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'ソース種別',
 			'fileInfo.optimizedVersion' => '最適化バージョン',
 			'fileInfo.optimizationTarget' => '最適化ターゲット',
@@ -3502,8 +3502,6 @@ extension on TranslationsJa {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezyは削除対象のファイルを確認できなかったため、上記のアイテム以上に削除される可能性があります。キャンセルして再試行するか、それでも削除してください。',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'サーバーがこのアイテムのファイル情報を提供しなかったため、Plezyは削除対象のファイルを確認できません。上記のアイテム以上に削除される可能性があります。',
 			'mediaMenu.mediaDeletedSuccessfully' => 'メディアアイテムを正常に削除しました',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'メディアアイテムの削除に失敗しました',
 			'mediaMenu.rate' => '評価',
 			'mediaMenu.playFromBeginning' => '最初から再生',
@@ -3959,12 +3957,12 @@ extension on TranslationsJa {
 			'libraries.groupings.tracks' => '曲',
 			'libraries.groupings.folders' => 'フォルダ',
 			'libraries.filterCategories.genre' => 'ジャンル',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => '年',
 			'libraries.filterCategories.contentRating' => '視聴年齢区分',
 			'libraries.filterCategories.tag' => 'タグ',
 			'libraries.filterCategories.unwatched' => '未視聴',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => '未再生',
 			'libraries.filterCategories.favorites' => 'お気に入り',
 			'libraries.sortLabels.title' => 'タイトル',
@@ -4072,8 +4070,6 @@ extension on TranslationsJa {
 			'explore.watchlistNoMatch' => 'このアイテムに一致するウォッチリスト項目が見つかりませんでした',
 			'explore.notInLibrary' => 'ライブラリにありません',
 			'explore.inTheseLibraries' => 'これらのライブラリにあります',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'ライブラリを確認中…',
 			'explore.emptyTitle' => 'まだ何もありません',
 			'explore.emptyMessage' => ({required Object source}) => '${source}にコンテンツが追加されると、ここに表示されます。',
@@ -4475,12 +4471,12 @@ extension on TranslationsJa {
 			'downloads.syncRuleUpdated' => '同期ルールを更新しました',
 			'downloads.syncRuleRemoved' => '同期ルールを削除しました',
 			'downloads.syncRuleAndDownloadsRemoved' => '同期ルールと関連するダウンロードを削除しました',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => '同期ルールが更新中です。しばらくしてからもう一度お試しください。',
 			'downloads.syncRuleCleanupUnavailable' => '関連するダウンロードを安全に特定できませんでした。サーバーに再接続して再試行するか、ダウンロードを削除せずにルールを削除してください。',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '${title}の新しいエピソードを${count}件同期しました',
 			'downloads.activeSyncRules' => '同期ルール',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => '同期ルールなし',
 			'downloads.manageSyncRule' => '同期を管理',
 			'downloads.editEpisodeCount' => 'エピソード数',
@@ -4610,8 +4606,6 @@ extension on TranslationsJa {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'どのアドレスにも接続できませんでした',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts}回試行後に接続が切断されました',
 			'companionRemote.errors.connectionLost' => '接続が切断されました',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '認証前に接続が切断されました',
 			'videoSettings.playbackSpeed' => '再生速度',
 			'videoSettings.normalSpeed' => '標準',

--- a/lib/i18n/strings_ja.g.dart
+++ b/lib/i18n/strings_ja.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$ja extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'ライブラリごと';
 	@override String get playerScopeTitle => '作品ごと';
 	@override String get exportDialogTitle => 'Plezyの設定をエクスポート';
+	@override String get linuxVideoRenderMode => '動画レンダリングモード';
+	@override String get linuxVideoRenderModeDescription => '自動はネイティブの Wayland プレーン（HDR 対応）を優先し、Texture は SDR フォールバック経路を強制します。';
+	@override String get linuxVideoRenderModeAuto => '自動';
+	@override String get linuxVideoRenderModeTexture => 'Texture（SDR）';
 }
 
 // Path: search
@@ -3313,6 +3317,10 @@ extension on TranslationsJa {
 			'settings.playerScopeLibrary' => 'ライブラリごと',
 			'settings.playerScopeTitle' => '作品ごと',
 			'settings.exportDialogTitle' => 'Plezyの設定をエクスポート',
+			'settings.linuxVideoRenderMode' => '動画レンダリングモード',
+			'settings.linuxVideoRenderModeDescription' => '自動はネイティブの Wayland プレーン（HDR 対応）を優先し、Texture は SDR フォールバック経路を強制します。',
+			'settings.linuxVideoRenderModeAuto' => '自動',
+			'settings.linuxVideoRenderModeTexture' => 'Texture（SDR）',
 			'search.hint' => '映画、番組、音楽を検索…',
 			'search.tryDifferentTerm' => '別の検索語をお試しください',
 			'search.searchYourMedia' => 'メディアを検索',
@@ -3494,6 +3502,8 @@ extension on TranslationsJa {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezyは削除対象のファイルを確認できなかったため、上記のアイテム以上に削除される可能性があります。キャンセルして再試行するか、それでも削除してください。',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'サーバーがこのアイテムのファイル情報を提供しなかったため、Plezyは削除対象のファイルを確認できません。上記のアイテム以上に削除される可能性があります。',
 			'mediaMenu.mediaDeletedSuccessfully' => 'メディアアイテムを正常に削除しました',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'メディアアイテムの削除に失敗しました',
 			'mediaMenu.rate' => '評価',
 			'mediaMenu.playFromBeginning' => '最初から再生',
@@ -4062,6 +4072,8 @@ extension on TranslationsJa {
 			'explore.watchlistNoMatch' => 'このアイテムに一致するウォッチリスト項目が見つかりませんでした',
 			'explore.notInLibrary' => 'ライブラリにありません',
 			'explore.inTheseLibraries' => 'これらのライブラリにあります',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'ライブラリを確認中…',
 			'explore.emptyTitle' => 'まだ何もありません',
 			'explore.emptyMessage' => ({required Object source}) => '${source}にコンテンツが追加されると、ここに表示されます。',
@@ -4598,6 +4610,8 @@ extension on TranslationsJa {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'どのアドレスにも接続できませんでした',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts}回試行後に接続が切断されました',
 			'companionRemote.errors.connectionLost' => '接続が切断されました',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '認証前に接続が切断されました',
 			'videoSettings.playbackSpeed' => '再生速度',
 			'videoSettings.normalSpeed' => '標準',

--- a/lib/i18n/strings_kk.g.dart
+++ b/lib/i18n/strings_kk.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$kk extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Кітапхана бойынша';
 	@override String get playerScopeTitle => 'Сериал немесе фильм бойынша';
 	@override String get exportDialogTitle => 'Plezy параметрлерін экспорттау';
+	@override String get linuxVideoRenderMode => 'Бейнені көрсету режимі';
+	@override String get linuxVideoRenderModeDescription => 'Автоматты режим жергілікті Wayland жазықтығын қалайды (HDR қолдайды); Texture SDR резервтік жолды мәжбүрлейді.';
+	@override String get linuxVideoRenderModeAuto => 'Автоматты';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsKk {
 			'settings.playerScopeLibrary' => 'Кітапхана бойынша',
 			'settings.playerScopeTitle' => 'Сериал немесе фильм бойынша',
 			'settings.exportDialogTitle' => 'Plezy параметрлерін экспорттау',
+			'settings.linuxVideoRenderMode' => 'Бейнені көрсету режимі',
+			'settings.linuxVideoRenderModeDescription' => 'Автоматты режим жергілікті Wayland жазықтығын қалайды (HDR қолдайды); Texture SDR резервтік жолды мәжбүрлейді.',
+			'settings.linuxVideoRenderModeAuto' => 'Автоматты',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Фильмдер, сериалдар, музыка іздеу...',
 			'search.tryDifferentTerm' => 'Басқа іздеу сөзін байқап көріңіз',
 			'search.searchYourMedia' => 'Медиафайлдардан іздеу',
@@ -3504,6 +3512,8 @@ extension on TranslationsKk {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy қандай файлдар өшірілетінін тексере алмады, сондықтан ол жоғарыда аталған элементтен артық өшіруі мүмкін. Бас тартып, қайталап көріңіз немесе бәрібір өшіріңіз.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Серверіңіз бұл элемент үшін файл мәліметтерін ұсынбады, сондықтан Plezy қандай файлдар өшірілетінін тексере алмайды. Ол жоғарыда аталған элементтен артық өшіруі мүмкін.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Медиа элементі сәтті өшірілді',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Медиа элементін өшіру мүмкін болмады',
 			'mediaMenu.rate' => 'Бағалау',
 			'mediaMenu.playFromBeginning' => 'Басынан бастап ойнату',
@@ -4072,6 +4082,8 @@ extension on TranslationsKk {
 			'explore.watchlistNoMatch' => 'Бұл элементті көру тізімімен сәйкестендіру мүмкін болмады',
 			'explore.notInLibrary' => 'Кітапханаңызда жоқ',
 			'explore.inTheseLibraries' => 'Осы кітапханаларда бар',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Кітапхана тексерілуде...',
 			'explore.emptyTitle' => 'Әлі де мұнда ештеңе жоқ',
 			'explore.emptyMessage' => ({required Object source}) => '${source} дереккөзінен алынған қатарлар мұнда көрінеді.',
@@ -4608,6 +4620,8 @@ extension on TranslationsKk {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Ешбір мекенжайға қосылу мүмкін болмады',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} әрекеттен кейін байланыс үзілді',
 			'companionRemote.errors.connectionLost' => 'Байланыс үзілді',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Аутентификациядан бұрын байланыс жабылды',
 			'videoSettings.playbackSpeed' => 'Ойнату жылдамдығы',
 			'videoSettings.normalSpeed' => 'Қалыпты',

--- a/lib/i18n/strings_kk.g.dart
+++ b/lib/i18n/strings_kk.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsKk {
 			'fileInfo.filePresent' => 'Файл бар',
 			'fileInfo.fileReadable' => 'Сервер оқи алады',
 			'fileInfo.streamPath' => 'Ағын жолы',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Ағынды беру үшін оңтайландырылған',
 			'fileInfo.has64bitOffsets' => '64-биттік ығысулар',
 			'fileInfo.protocol' => 'Протокол',
 			'fileInfo.mediaType' => 'Медиа түрі',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Дереккөз түрі',
 			'fileInfo.optimizedVersion' => 'Оңтайландырылған нұсқа',
 			'fileInfo.optimizationTarget' => 'Оңтайландыру мақсаты',
@@ -3512,8 +3512,6 @@ extension on TranslationsKk {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy қандай файлдар өшірілетінін тексере алмады, сондықтан ол жоғарыда аталған элементтен артық өшіруі мүмкін. Бас тартып, қайталап көріңіз немесе бәрібір өшіріңіз.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Серверіңіз бұл элемент үшін файл мәліметтерін ұсынбады, сондықтан Plezy қандай файлдар өшірілетінін тексере алмайды. Ол жоғарыда аталған элементтен артық өшіруі мүмкін.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Медиа элементі сәтті өшірілді',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Медиа элементін өшіру мүмкін болмады',
 			'mediaMenu.rate' => 'Бағалау',
 			'mediaMenu.playFromBeginning' => 'Басынан бастап ойнату',
@@ -3969,12 +3967,12 @@ extension on TranslationsKk {
 			'libraries.groupings.tracks' => 'Әндер',
 			'libraries.groupings.folders' => 'Қапшықтар',
 			'libraries.filterCategories.genre' => 'Жанр',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Жыл',
 			'libraries.filterCategories.contentRating' => 'Мазмұн рейтингі',
 			'libraries.filterCategories.tag' => 'Тег',
 			'libraries.filterCategories.unwatched' => 'Көрілмеген',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Ойнатылмаған',
 			'libraries.filterCategories.favorites' => 'Таңдаулылар',
 			'libraries.sortLabels.title' => 'Атауы',
@@ -4082,8 +4080,6 @@ extension on TranslationsKk {
 			'explore.watchlistNoMatch' => 'Бұл элементті көру тізімімен сәйкестендіру мүмкін болмады',
 			'explore.notInLibrary' => 'Кітапханаңызда жоқ',
 			'explore.inTheseLibraries' => 'Осы кітапханаларда бар',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Кітапхана тексерілуде...',
 			'explore.emptyTitle' => 'Әлі де мұнда ештеңе жоқ',
 			'explore.emptyMessage' => ({required Object source}) => '${source} дереккөзінен алынған қатарлар мұнда көрінеді.',
@@ -4485,12 +4481,12 @@ extension on TranslationsKk {
 			'downloads.syncRuleUpdated' => 'Синхрондау ережесі жаңартылды',
 			'downloads.syncRuleRemoved' => 'Синхрондау ережесі өшірілді',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Синхрондау ережесі және байланысты жүктеулер өшірілді',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Синхрондау ережелері қазір жаңартылуда. Сәлден соң қайталап көріңіз.',
 			'downloads.syncRuleCleanupUnavailable' => 'Байланысты жүктеулерді қауіпсіз анықтау мүмкін болмады. Серверге қайта қосылып көріңіз немесе ережені жүктеулерді жоймай өшіріңіз.',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '${title} үшін ${count} жаңа бөлім синхрондалды',
 			'downloads.activeSyncRules' => 'Белсенді синхрондау ережелері',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Синхрондау ережелері жоқ',
 			'downloads.manageSyncRule' => 'Синхрондауды басқару',
 			'downloads.editEpisodeCount' => 'Бөлімдер саны',
@@ -4620,8 +4616,6 @@ extension on TranslationsKk {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Ешбір мекенжайға қосылу мүмкін болмады',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} әрекеттен кейін байланыс үзілді',
 			'companionRemote.errors.connectionLost' => 'Байланыс үзілді',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Аутентификациядан бұрын байланыс жабылды',
 			'videoSettings.playbackSpeed' => 'Ойнату жылдамдығы',
 			'videoSettings.normalSpeed' => 'Қалыпты',

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$ko extends Translations$settings$en {
 	@override String get playerScopeLibrary => '라이브러리별';
 	@override String get playerScopeTitle => '시리즈 또는 영화별';
 	@override String get exportDialogTitle => 'Plezy 설정 내보내기';
+	@override String get linuxVideoRenderMode => '동영상 렌더링 모드';
+	@override String get linuxVideoRenderModeDescription => '자동은 네이티브 Wayland 평면(HDR 지원)을 선호하고, Texture는 SDR 대체 경로를 강제합니다.';
+	@override String get linuxVideoRenderModeAuto => '자동';
+	@override String get linuxVideoRenderModeTexture => 'Texture(SDR)';
 }
 
 // Path: search
@@ -3313,6 +3317,10 @@ extension on TranslationsKo {
 			'settings.playerScopeLibrary' => '라이브러리별',
 			'settings.playerScopeTitle' => '시리즈 또는 영화별',
 			'settings.exportDialogTitle' => 'Plezy 설정 내보내기',
+			'settings.linuxVideoRenderMode' => '동영상 렌더링 모드',
+			'settings.linuxVideoRenderModeDescription' => '자동은 네이티브 Wayland 평면(HDR 지원)을 선호하고, Texture는 SDR 대체 경로를 강제합니다.',
+			'settings.linuxVideoRenderModeAuto' => '자동',
+			'settings.linuxVideoRenderModeTexture' => 'Texture(SDR)',
 			'search.hint' => '영화, 시리즈, 음악 등을 검색하세요...',
 			'search.tryDifferentTerm' => '다른 검색어를 시도해 보세요',
 			'search.searchYourMedia' => '미디어 검색',
@@ -3494,6 +3502,8 @@ extension on TranslationsKo {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy가 어떤 파일이 삭제될지 확인하지 못해 위 항목보다 더 많은 파일이 삭제될 수 있습니다. 취소하고 다시 시도하거나 그래도 삭제하세요.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => '서버가 이 항목의 파일 정보를 제공하지 않아 Plezy가 어떤 파일이 삭제될지 확인할 수 없습니다. 위 항목보다 더 많은 파일이 삭제될 수 있습니다.',
 			'mediaMenu.mediaDeletedSuccessfully' => '미디어 항목이 성공적으로 삭제되었습니다',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => '미디어 항목 삭제 실패',
 			'mediaMenu.rate' => '평가',
 			'mediaMenu.playFromBeginning' => '처음부터 재생',
@@ -4062,6 +4072,8 @@ extension on TranslationsKo {
 			'explore.watchlistNoMatch' => '이 항목을 관심 목록과 연결할 수 없습니다',
 			'explore.notInLibrary' => '라이브러리에 없음',
 			'explore.inTheseLibraries' => '이 라이브러리에 있음',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => '라이브러리 확인 중...',
 			'explore.emptyTitle' => '아직 아무것도 없습니다',
 			'explore.emptyMessage' => ({required Object source}) => '${source}에 콘텐츠가 추가되면 여기에 표시됩니다.',
@@ -4598,6 +4610,8 @@ extension on TranslationsKo {
 			'companionRemote.errors.failedToConnectAnyAddress' => '어떤 주소에도 연결하지 못했습니다',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts}회 시도 후 연결이 끊어졌습니다',
 			'companionRemote.errors.connectionLost' => '연결이 끊어졌습니다',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '인증 전에 연결이 종료되었습니다',
 			'videoSettings.playbackSpeed' => '재생 속도',
 			'videoSettings.normalSpeed' => '보통',

--- a/lib/i18n/strings_ko.g.dart
+++ b/lib/i18n/strings_ko.g.dart
@@ -3443,12 +3443,12 @@ extension on TranslationsKo {
 			'fileInfo.filePresent' => '파일 있음',
 			'fileInfo.fileReadable' => '서버에서 읽기 가능',
 			'fileInfo.streamPath' => '스트림 경로',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => '스트리밍 최적화',
 			'fileInfo.has64bitOffsets' => '64비트 오프셋',
 			'fileInfo.protocol' => '프로토콜',
 			'fileInfo.mediaType' => '미디어 유형',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => '소스 종류',
 			'fileInfo.optimizedVersion' => '최적화 버전',
 			'fileInfo.optimizationTarget' => '최적화 대상',
@@ -3502,8 +3502,6 @@ extension on TranslationsKo {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy가 어떤 파일이 삭제될지 확인하지 못해 위 항목보다 더 많은 파일이 삭제될 수 있습니다. 취소하고 다시 시도하거나 그래도 삭제하세요.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => '서버가 이 항목의 파일 정보를 제공하지 않아 Plezy가 어떤 파일이 삭제될지 확인할 수 없습니다. 위 항목보다 더 많은 파일이 삭제될 수 있습니다.',
 			'mediaMenu.mediaDeletedSuccessfully' => '미디어 항목이 성공적으로 삭제되었습니다',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => '미디어 항목 삭제 실패',
 			'mediaMenu.rate' => '평가',
 			'mediaMenu.playFromBeginning' => '처음부터 재생',
@@ -3959,12 +3957,12 @@ extension on TranslationsKo {
 			'libraries.groupings.tracks' => '트랙',
 			'libraries.groupings.folders' => '폴더',
 			'libraries.filterCategories.genre' => '장르',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => '연도',
 			'libraries.filterCategories.contentRating' => '시청 등급',
 			'libraries.filterCategories.tag' => '태그',
 			'libraries.filterCategories.unwatched' => '미시청',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => '재생하지 않음',
 			'libraries.filterCategories.favorites' => '즐겨찾기',
 			'libraries.sortLabels.title' => '제목',
@@ -4072,8 +4070,6 @@ extension on TranslationsKo {
 			'explore.watchlistNoMatch' => '이 항목을 관심 목록과 연결할 수 없습니다',
 			'explore.notInLibrary' => '라이브러리에 없음',
 			'explore.inTheseLibraries' => '이 라이브러리에 있음',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => '라이브러리 확인 중...',
 			'explore.emptyTitle' => '아직 아무것도 없습니다',
 			'explore.emptyMessage' => ({required Object source}) => '${source}에 콘텐츠가 추가되면 여기에 표시됩니다.',
@@ -4475,12 +4471,12 @@ extension on TranslationsKo {
 			'downloads.syncRuleUpdated' => '동기화 규칙 업데이트됨',
 			'downloads.syncRuleRemoved' => '동기화 규칙 제거됨',
 			'downloads.syncRuleAndDownloadsRemoved' => '동기화 규칙과 연결된 다운로드가 삭제되었습니다',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => '동기화 규칙이 현재 업데이트 중입니다. 잠시 후 다시 시도하세요.',
 			'downloads.syncRuleCleanupUnavailable' => '연결된 다운로드를 안전하게 확인할 수 없습니다. 서버에 다시 연결한 후 시도하거나, 다운로드를 삭제하지 않고 규칙만 제거하세요.',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '${title}의 새 에피소드 ${count}개 동기화됨',
 			'downloads.activeSyncRules' => '동기화 규칙',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => '동기화 규칙 없음',
 			'downloads.manageSyncRule' => '동기화 관리',
 			'downloads.editEpisodeCount' => '에피소드 수',
@@ -4610,8 +4606,6 @@ extension on TranslationsKo {
 			'companionRemote.errors.failedToConnectAnyAddress' => '어떤 주소에도 연결하지 못했습니다',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts}회 시도 후 연결이 끊어졌습니다',
 			'companionRemote.errors.connectionLost' => '연결이 끊어졌습니다',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '인증 전에 연결이 종료되었습니다',
 			'videoSettings.playbackSpeed' => '재생 속도',
 			'videoSettings.normalSpeed' => '보통',

--- a/lib/i18n/strings_nb.g.dart
+++ b/lib/i18n/strings_nb.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$nb extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Per bibliotek';
 	@override String get playerScopeTitle => 'Per serie eller film';
 	@override String get exportDialogTitle => 'Eksporter Plezy-innstillinger';
+	@override String get linuxVideoRenderMode => 'Video-gjengivelsesmodus';
+	@override String get linuxVideoRenderModeDescription => 'Automatisk foretrekker det native Wayland-planet (HDR-kompatibelt); Texture tvinger SDR-fallback-stien.';
+	@override String get linuxVideoRenderModeAuto => 'Automatisk';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsNb {
 			'settings.playerScopeLibrary' => 'Per bibliotek',
 			'settings.playerScopeTitle' => 'Per serie eller film',
 			'settings.exportDialogTitle' => 'Eksporter Plezy-innstillinger',
+			'settings.linuxVideoRenderMode' => 'Video-gjengivelsesmodus',
+			'settings.linuxVideoRenderModeDescription' => 'Automatisk foretrekker det native Wayland-planet (HDR-kompatibelt); Texture tvinger SDR-fallback-stien.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatisk',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Søk i filmer, serier, musikk...',
 			'search.tryDifferentTerm' => 'Prøv et annet søkeord',
 			'search.searchYourMedia' => 'Søk i mediene dine',
@@ -3504,6 +3512,8 @@ extension on TranslationsNb {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kunne ikke sjekke hvilke filer dette vil fjerne, så det kan slette mer enn elementet som er nevnt ovenfor. Avbryt og prøv igjen, eller slett likevel.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Serveren din ga ikke fildetaljer for dette elementet, så Plezy kan ikke sjekke hvilke filer dette vil fjerne. Det kan slette mer enn elementet som er nevnt ovenfor.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medieelement slettet',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Kunne ikke slette medieelement',
 			'mediaMenu.rate' => 'Vurder',
 			'mediaMenu.playFromBeginning' => 'Spill fra begynnelsen',
@@ -4072,6 +4082,8 @@ extension on TranslationsNb {
 			'explore.watchlistNoMatch' => 'Kunne ikke koble dette elementet til en overvåkningsliste',
 			'explore.notInLibrary' => 'Ikke i biblioteket ditt',
 			'explore.inTheseLibraries' => 'I disse bibliotekene',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Sjekker biblioteket ditt...',
 			'explore.emptyTitle' => 'Ingenting her ennå',
 			'explore.emptyMessage' => ({required Object source}) => 'Rader fra ${source} vises her når de har innhold.',
@@ -4608,6 +4620,8 @@ extension on TranslationsNb {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Kunne ikke koble til noen adresse',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Tilkobling mistet etter ${attempts} forsøk',
 			'companionRemote.errors.connectionLost' => 'Tilkobling mistet',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Tilkoblingen ble lukket før autentisering',
 			'videoSettings.playbackSpeed' => 'Avspillingshastighet',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_nb.g.dart
+++ b/lib/i18n/strings_nb.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsNb {
 			'fileInfo.filePresent' => 'Fil til stede',
 			'fileInfo.fileReadable' => 'Lesbar for serveren',
 			'fileInfo.streamPath' => 'Strømbane',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Optimalisert for strømming',
 			'fileInfo.has64bitOffsets' => '64-biters forskyvninger',
 			'fileInfo.protocol' => 'Protokoll',
 			'fileInfo.mediaType' => 'Mediatype',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Kildetype',
 			'fileInfo.optimizedVersion' => 'Optimalisert versjon',
 			'fileInfo.optimizationTarget' => 'Optimaliseringsmål',
@@ -3512,8 +3512,6 @@ extension on TranslationsNb {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kunne ikke sjekke hvilke filer dette vil fjerne, så det kan slette mer enn elementet som er nevnt ovenfor. Avbryt og prøv igjen, eller slett likevel.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Serveren din ga ikke fildetaljer for dette elementet, så Plezy kan ikke sjekke hvilke filer dette vil fjerne. Det kan slette mer enn elementet som er nevnt ovenfor.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medieelement slettet',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Kunne ikke slette medieelement',
 			'mediaMenu.rate' => 'Vurder',
 			'mediaMenu.playFromBeginning' => 'Spill fra begynnelsen',
@@ -3969,12 +3967,12 @@ extension on TranslationsNb {
 			'libraries.groupings.tracks' => 'Spor',
 			'libraries.groupings.folders' => 'Mapper',
 			'libraries.filterCategories.genre' => 'Sjanger',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'År',
 			'libraries.filterCategories.contentRating' => 'Aldersgrense',
 			'libraries.filterCategories.tag' => 'Tagg',
 			'libraries.filterCategories.unwatched' => 'Usette',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Ikke avspilt',
 			'libraries.filterCategories.favorites' => 'Favoritter',
 			'libraries.sortLabels.title' => 'Tittel',
@@ -4082,8 +4080,6 @@ extension on TranslationsNb {
 			'explore.watchlistNoMatch' => 'Kunne ikke koble dette elementet til en overvåkningsliste',
 			'explore.notInLibrary' => 'Ikke i biblioteket ditt',
 			'explore.inTheseLibraries' => 'I disse bibliotekene',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Sjekker biblioteket ditt...',
 			'explore.emptyTitle' => 'Ingenting her ennå',
 			'explore.emptyMessage' => ({required Object source}) => 'Rader fra ${source} vises her når de har innhold.',
@@ -4485,12 +4481,12 @@ extension on TranslationsNb {
 			'downloads.syncRuleUpdated' => 'Synkroniseringsregel oppdatert',
 			'downloads.syncRuleRemoved' => 'Synkroniseringsregel fjernet',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Synkroniseringsregel og tilknyttede nedlastinger fjernet',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Synkroniseringsreglene oppdateres for øyeblikket. Prøv igjen om et øyeblikk.',
 			'downloads.syncRuleCleanupUnavailable' => 'Tilknyttede nedlastinger kunne ikke identifiseres på en trygg måte. Koble til serveren på nytt og prøv igjen, eller fjern regelen uten å slette nedlastingene.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => 'Synkroniserte ${count} nye episoder for ${title}',
 			'downloads.activeSyncRules' => 'Synkroniseringsregler',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Ingen synkroniseringsregler',
 			'downloads.manageSyncRule' => 'Administrer synkronisering',
 			'downloads.editEpisodeCount' => 'Antall episoder',
@@ -4620,8 +4616,6 @@ extension on TranslationsNb {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Kunne ikke koble til noen adresse',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Tilkobling mistet etter ${attempts} forsøk',
 			'companionRemote.errors.connectionLost' => 'Tilkobling mistet',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Tilkoblingen ble lukket før autentisering',
 			'videoSettings.playbackSpeed' => 'Avspillingshastighet',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_nl.g.dart
+++ b/lib/i18n/strings_nl.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$nl extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Per bibliotheek';
 	@override String get playerScopeTitle => 'Per serie of film';
 	@override String get exportDialogTitle => 'Plezy-instellingen exporteren';
+	@override String get linuxVideoRenderMode => 'Videoweergavemodus';
+	@override String get linuxVideoRenderModeDescription => 'Automatisch geeft de voorkeur aan het native Wayland-vlak (HDR-compatibel); Texture dwingt het SDR-reservepad af.';
+	@override String get linuxVideoRenderModeAuto => 'Automatisch';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsNl {
 			'settings.playerScopeLibrary' => 'Per bibliotheek',
 			'settings.playerScopeTitle' => 'Per serie of film',
 			'settings.exportDialogTitle' => 'Plezy-instellingen exporteren',
+			'settings.linuxVideoRenderMode' => 'Videoweergavemodus',
+			'settings.linuxVideoRenderModeDescription' => 'Automatisch geeft de voorkeur aan het native Wayland-vlak (HDR-compatibel); Texture dwingt het SDR-reservepad af.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatisch',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Zoek films, series, muziek...',
 			'search.tryDifferentTerm' => 'Probeer een andere zoekterm',
 			'search.searchYourMedia' => 'Zoek in je media',
@@ -3504,6 +3512,8 @@ extension on TranslationsNl {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kon niet controleren welke bestanden hiermee worden verwijderd, dus het kan meer verwijderen dan het hierboven genoemde item. Annuleer en probeer het opnieuw, of verwijder toch.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Je server heeft geen bestandsgegevens voor dit item verstrekt, dus Plezy kan niet controleren welke bestanden hiermee worden verwijderd. Het kan meer verwijderen dan het hierboven genoemde item.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media-item succesvol verwijderd',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Verwijderen van media-item mislukt',
 			'mediaMenu.rate' => 'Beoordelen',
 			'mediaMenu.playFromBeginning' => 'Afspelen vanaf het begin',
@@ -4072,6 +4082,8 @@ extension on TranslationsNl {
 			'explore.watchlistNoMatch' => 'Kon dit item niet aan een kijklijst koppelen',
 			'explore.notInLibrary' => 'Niet in je bibliotheek',
 			'explore.inTheseLibraries' => 'In deze bibliotheken',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Je bibliotheek controleren...',
 			'explore.emptyTitle' => 'Hier is nog niets',
 			'explore.emptyMessage' => ({required Object source}) => 'Rijen van ${source} verschijnen hier zodra ze inhoud hebben.',
@@ -4608,6 +4620,8 @@ extension on TranslationsNl {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Er kon met geen enkel adres verbinding worden gemaakt',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Verbinding verbroken na ${attempts} pogingen',
 			'companionRemote.errors.connectionLost' => 'Verbinding verloren',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'De verbinding is vóór de authenticatie gesloten',
 			'videoSettings.playbackSpeed' => 'Afspeelsnelheid',
 			'videoSettings.normalSpeed' => 'Normaal',

--- a/lib/i18n/strings_nl.g.dart
+++ b/lib/i18n/strings_nl.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsNl {
 			'fileInfo.filePresent' => 'Bestand aanwezig',
 			'fileInfo.fileReadable' => 'Leesbaar door server',
 			'fileInfo.streamPath' => 'Streampad',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Geoptimaliseerd voor streaming',
 			'fileInfo.has64bitOffsets' => '64-bits offsets',
 			'fileInfo.protocol' => 'Protocol',
 			'fileInfo.mediaType' => 'Mediatype',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Soort bron',
 			'fileInfo.optimizedVersion' => 'Geoptimaliseerde versie',
 			'fileInfo.optimizationTarget' => 'Optimalisatiedoel',
@@ -3512,8 +3512,6 @@ extension on TranslationsNl {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kon niet controleren welke bestanden hiermee worden verwijderd, dus het kan meer verwijderen dan het hierboven genoemde item. Annuleer en probeer het opnieuw, of verwijder toch.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Je server heeft geen bestandsgegevens voor dit item verstrekt, dus Plezy kan niet controleren welke bestanden hiermee worden verwijderd. Het kan meer verwijderen dan het hierboven genoemde item.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media-item succesvol verwijderd',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Verwijderen van media-item mislukt',
 			'mediaMenu.rate' => 'Beoordelen',
 			'mediaMenu.playFromBeginning' => 'Afspelen vanaf het begin',
@@ -3969,12 +3967,12 @@ extension on TranslationsNl {
 			'libraries.groupings.tracks' => 'Nummers',
 			'libraries.groupings.folders' => 'Mappen',
 			'libraries.filterCategories.genre' => 'Genre',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Jaar',
 			'libraries.filterCategories.contentRating' => 'Leeftijdsclassificatie',
 			'libraries.filterCategories.tag' => 'Tag',
 			'libraries.filterCategories.unwatched' => 'Onbekeken',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Niet afgespeeld',
 			'libraries.filterCategories.favorites' => 'Favorieten',
 			'libraries.sortLabels.title' => 'Titel',
@@ -4082,8 +4080,6 @@ extension on TranslationsNl {
 			'explore.watchlistNoMatch' => 'Kon dit item niet aan een kijklijst koppelen',
 			'explore.notInLibrary' => 'Niet in je bibliotheek',
 			'explore.inTheseLibraries' => 'In deze bibliotheken',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Je bibliotheek controleren...',
 			'explore.emptyTitle' => 'Hier is nog niets',
 			'explore.emptyMessage' => ({required Object source}) => 'Rijen van ${source} verschijnen hier zodra ze inhoud hebben.',
@@ -4485,12 +4481,12 @@ extension on TranslationsNl {
 			'downloads.syncRuleUpdated' => 'Synchronisatieregel bijgewerkt',
 			'downloads.syncRuleRemoved' => 'Synchronisatieregel verwijderd',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Synchronisatieregel en gekoppelde downloads verwijderd',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Synchronisatieregels worden momenteel bijgewerkt. Probeer het over een moment opnieuw.',
 			'downloads.syncRuleCleanupUnavailable' => 'Gekoppelde downloads konden niet veilig worden geïdentificeerd. Maak opnieuw verbinding met de server en probeer het opnieuw, of verwijder de regel zonder de downloads te verwijderen.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} nieuwe afleveringen gesynchroniseerd voor ${title}',
 			'downloads.activeSyncRules' => 'Synchronisatieregels',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Geen synchronisatieregels',
 			'downloads.manageSyncRule' => 'Synchronisatie beheren',
 			'downloads.editEpisodeCount' => 'Aantal afleveringen',
@@ -4620,8 +4616,6 @@ extension on TranslationsNl {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Er kon met geen enkel adres verbinding worden gemaakt',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Verbinding verbroken na ${attempts} pogingen',
 			'companionRemote.errors.connectionLost' => 'Verbinding verloren',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'De verbinding is vóór de authenticatie gesloten',
 			'videoSettings.playbackSpeed' => 'Afspeelsnelheid',
 			'videoSettings.normalSpeed' => 'Normaal',

--- a/lib/i18n/strings_pl.g.dart
+++ b/lib/i18n/strings_pl.g.dart
@@ -3473,12 +3473,12 @@ extension on TranslationsPl {
 			'fileInfo.filePresent' => 'Plik obecny',
 			'fileInfo.fileReadable' => 'Czytelny dla serwera',
 			'fileInfo.streamPath' => 'Ścieżka strumienia',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Zoptymalizowane do strumieniowania',
 			'fileInfo.has64bitOffsets' => 'Przesunięcia 64-bitowe',
 			'fileInfo.protocol' => 'Protokół',
 			'fileInfo.mediaType' => 'Typ multimediów',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Rodzaj źródła',
 			'fileInfo.optimizedVersion' => 'Zoptymalizowana wersja',
 			'fileInfo.optimizationTarget' => 'Cel optymalizacji',
@@ -3532,8 +3532,6 @@ extension on TranslationsPl {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy nie mogło sprawdzić, które pliki zostaną usunięte, więc może usunąć więcej niż element wymieniony powyżej. Anuluj i spróbuj ponownie albo usuń mimo to.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Twój serwer nie podał informacji o plikach tego elementu, więc Plezy nie może sprawdzić, które pliki zostaną usunięte. Może usunąć więcej niż element wymieniony powyżej.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Usunięto element multimedialny',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Nie udało się usunąć elementu multimedialnego',
 			'mediaMenu.rate' => 'Oceń',
 			'mediaMenu.playFromBeginning' => 'Odtwórz od początku',
@@ -3989,12 +3987,12 @@ extension on TranslationsPl {
 			'libraries.groupings.tracks' => 'Utwory',
 			'libraries.groupings.folders' => 'Foldery',
 			'libraries.filterCategories.genre' => 'Gatunek',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Rok',
 			'libraries.filterCategories.contentRating' => 'Klasyfikacja wiekowa',
 			'libraries.filterCategories.tag' => 'Tag',
 			'libraries.filterCategories.unwatched' => 'Nieobejrzane',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Nieodtworzone',
 			'libraries.filterCategories.favorites' => 'Ulubione',
 			'libraries.sortLabels.title' => 'Tytuł',
@@ -4102,8 +4100,6 @@ extension on TranslationsPl {
 			'explore.watchlistNoMatch' => 'Nie udało się dopasować tej pozycji do listy do obejrzenia',
 			'explore.notInLibrary' => 'Nie ma tego w Twojej bibliotece',
 			'explore.inTheseLibraries' => 'W tych bibliotekach',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Sprawdzanie Twojej biblioteki...',
 			'explore.emptyTitle' => 'Jeszcze nic tu nie ma',
 			'explore.emptyMessage' => ({required Object source}) => 'Wiersze z ${source} pojawią się tutaj, gdy będą zawierać treści.',
@@ -4505,12 +4501,12 @@ extension on TranslationsPl {
 			'downloads.syncRuleUpdated' => 'Reguła synchronizacji zaktualizowana',
 			'downloads.syncRuleRemoved' => 'Reguła synchronizacji usunięta',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Usunięto regułę synchronizacji i powiązane pobrania',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Reguły synchronizacji są aktualnie aktualizowane. Spróbuj ponownie za chwilę.',
 			'downloads.syncRuleCleanupUnavailable' => 'Nie udało się bezpiecznie zidentyfikować powiązanych pobrań. Połącz się ponownie z serwerem i spróbuj ponownie albo usuń regułę bez usuwania pobrań.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => 'Zsynchronizowano ${count} nowych odcinków dla ${title}',
 			'downloads.activeSyncRules' => 'Reguły synchronizacji',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Brak reguł synchronizacji',
 			'downloads.manageSyncRule' => 'Zarządzaj synchronizacją',
 			'downloads.editEpisodeCount' => 'Liczba odcinków',
@@ -4640,8 +4636,6 @@ extension on TranslationsPl {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Nie udało się połączyć z żadnym adresem',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Połączenie utracone po ${attempts} próbach',
 			'companionRemote.errors.connectionLost' => 'Połączenie utracone',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Połączenie zostało zamknięte przed uwierzytelnieniem',
 			'videoSettings.playbackSpeed' => 'Prędkość odtwarzania',
 			'videoSettings.normalSpeed' => 'Normalna',

--- a/lib/i18n/strings_pl.g.dart
+++ b/lib/i18n/strings_pl.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$pl extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Na bibliotekę';
 	@override String get playerScopeTitle => 'Na serial lub film';
 	@override String get exportDialogTitle => 'Eksport ustawień Plezy';
+	@override String get linuxVideoRenderMode => 'Tryb renderowania wideo';
+	@override String get linuxVideoRenderModeDescription => 'Automatyczny preferuje natywną płaszczyznę Wayland (zgodną z HDR); Texture wymusza ścieżkę zapasową SDR.';
+	@override String get linuxVideoRenderModeAuto => 'Automatyczny';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3343,6 +3347,10 @@ extension on TranslationsPl {
 			'settings.playerScopeLibrary' => 'Na bibliotekę',
 			'settings.playerScopeTitle' => 'Na serial lub film',
 			'settings.exportDialogTitle' => 'Eksport ustawień Plezy',
+			'settings.linuxVideoRenderMode' => 'Tryb renderowania wideo',
+			'settings.linuxVideoRenderModeDescription' => 'Automatyczny preferuje natywną płaszczyznę Wayland (zgodną z HDR); Texture wymusza ścieżkę zapasową SDR.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatyczny',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Szukaj filmów, seriali, muzyki...',
 			'search.tryDifferentTerm' => 'Spróbuj innego wyszukiwania',
 			'search.searchYourMedia' => 'Przeszukaj swoje media',
@@ -3524,6 +3532,8 @@ extension on TranslationsPl {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy nie mogło sprawdzić, które pliki zostaną usunięte, więc może usunąć więcej niż element wymieniony powyżej. Anuluj i spróbuj ponownie albo usuń mimo to.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Twój serwer nie podał informacji o plikach tego elementu, więc Plezy nie może sprawdzić, które pliki zostaną usunięte. Może usunąć więcej niż element wymieniony powyżej.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Usunięto element multimedialny',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Nie udało się usunąć elementu multimedialnego',
 			'mediaMenu.rate' => 'Oceń',
 			'mediaMenu.playFromBeginning' => 'Odtwórz od początku',
@@ -4092,6 +4102,8 @@ extension on TranslationsPl {
 			'explore.watchlistNoMatch' => 'Nie udało się dopasować tej pozycji do listy do obejrzenia',
 			'explore.notInLibrary' => 'Nie ma tego w Twojej bibliotece',
 			'explore.inTheseLibraries' => 'W tych bibliotekach',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Sprawdzanie Twojej biblioteki...',
 			'explore.emptyTitle' => 'Jeszcze nic tu nie ma',
 			'explore.emptyMessage' => ({required Object source}) => 'Wiersze z ${source} pojawią się tutaj, gdy będą zawierać treści.',
@@ -4628,6 +4640,8 @@ extension on TranslationsPl {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Nie udało się połączyć z żadnym adresem',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Połączenie utracone po ${attempts} próbach',
 			'companionRemote.errors.connectionLost' => 'Połączenie utracone',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Połączenie zostało zamknięte przed uwierzytelnieniem',
 			'videoSettings.playbackSpeed' => 'Prędkość odtwarzania',
 			'videoSettings.normalSpeed' => 'Normalna',

--- a/lib/i18n/strings_pt.g.dart
+++ b/lib/i18n/strings_pt.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$pt extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Por biblioteca';
 	@override String get playerScopeTitle => 'Por série ou filme';
 	@override String get exportDialogTitle => 'Exportar configurações do Plezy';
+	@override String get linuxVideoRenderMode => 'Modo de renderização de vídeo';
+	@override String get linuxVideoRenderModeDescription => 'Automático prefere o plano Wayland nativo (compatível com HDR); Texture força o caminho de reserva SDR.';
+	@override String get linuxVideoRenderModeAuto => 'Automático';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsPt {
 			'settings.playerScopeLibrary' => 'Por biblioteca',
 			'settings.playerScopeTitle' => 'Por série ou filme',
 			'settings.exportDialogTitle' => 'Exportar configurações do Plezy',
+			'settings.linuxVideoRenderMode' => 'Modo de renderização de vídeo',
+			'settings.linuxVideoRenderModeDescription' => 'Automático prefere o plano Wayland nativo (compatível com HDR); Texture força o caminho de reserva SDR.',
+			'settings.linuxVideoRenderModeAuto' => 'Automático',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Buscar filmes, séries, músicas...',
 			'search.tryDifferentTerm' => 'Tente um termo de busca diferente',
 			'search.searchYourMedia' => 'Buscar suas mídias',
@@ -3504,6 +3512,8 @@ extension on TranslationsPt {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'O Plezy não conseguiu verificar quais arquivos serão removidos, então pode excluir mais do que o item acima. Cancele e tente novamente, ou exclua mesmo assim.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Seu servidor não forneceu detalhes do arquivo para este item, então o Plezy não pode verificar quais arquivos serão removidos. Pode excluir mais do que o item acima.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Item de mídia excluído com sucesso',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Falha ao excluir item de mídia',
 			'mediaMenu.rate' => 'Avaliar',
 			'mediaMenu.playFromBeginning' => 'Reproduzir do início',
@@ -4072,6 +4082,8 @@ extension on TranslationsPt {
 			'explore.watchlistNoMatch' => 'Não foi possível associar este item a uma lista de interesses',
 			'explore.notInLibrary' => 'Não está na sua biblioteca',
 			'explore.inTheseLibraries' => 'Nestas bibliotecas',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Verificando sua biblioteca...',
 			'explore.emptyTitle' => 'Ainda não há nada aqui',
 			'explore.emptyMessage' => ({required Object source}) => 'As linhas de ${source} aparecerão aqui quando tiverem conteúdo.',
@@ -4608,6 +4620,8 @@ extension on TranslationsPt {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Falha ao conectar a qualquer endereço',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Conexão perdida após ${attempts} tentativas',
 			'companionRemote.errors.connectionLost' => 'Conexão perdida',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'A conexão foi encerrada antes da autenticação',
 			'videoSettings.playbackSpeed' => 'Velocidade de Reprodução',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_pt.g.dart
+++ b/lib/i18n/strings_pt.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsPt {
 			'fileInfo.filePresent' => 'Arquivo presente',
 			'fileInfo.fileReadable' => 'Legível pelo servidor',
 			'fileInfo.streamPath' => 'Caminho do fluxo',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Otimizado para transmissão',
 			'fileInfo.has64bitOffsets' => 'Deslocamentos de 64 bits',
 			'fileInfo.protocol' => 'Protocolo',
 			'fileInfo.mediaType' => 'Tipo de mídia',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Tipo de origem',
 			'fileInfo.optimizedVersion' => 'Versão otimizada',
 			'fileInfo.optimizationTarget' => 'Alvo de otimização',
@@ -3512,8 +3512,6 @@ extension on TranslationsPt {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'O Plezy não conseguiu verificar quais arquivos serão removidos, então pode excluir mais do que o item acima. Cancele e tente novamente, ou exclua mesmo assim.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Seu servidor não forneceu detalhes do arquivo para este item, então o Plezy não pode verificar quais arquivos serão removidos. Pode excluir mais do que o item acima.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Item de mídia excluído com sucesso',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Falha ao excluir item de mídia',
 			'mediaMenu.rate' => 'Avaliar',
 			'mediaMenu.playFromBeginning' => 'Reproduzir do início',
@@ -3969,12 +3967,12 @@ extension on TranslationsPt {
 			'libraries.groupings.tracks' => 'Faixas',
 			'libraries.groupings.folders' => 'Pastas',
 			'libraries.filterCategories.genre' => 'Gênero',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Ano',
 			'libraries.filterCategories.contentRating' => 'Classificação indicativa',
 			'libraries.filterCategories.tag' => 'Tag',
 			'libraries.filterCategories.unwatched' => 'Não assistidos',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Não reproduzidos',
 			'libraries.filterCategories.favorites' => 'Favoritos',
 			'libraries.sortLabels.title' => 'Título',
@@ -4082,8 +4080,6 @@ extension on TranslationsPt {
 			'explore.watchlistNoMatch' => 'Não foi possível associar este item a uma lista de interesses',
 			'explore.notInLibrary' => 'Não está na sua biblioteca',
 			'explore.inTheseLibraries' => 'Nestas bibliotecas',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Verificando sua biblioteca...',
 			'explore.emptyTitle' => 'Ainda não há nada aqui',
 			'explore.emptyMessage' => ({required Object source}) => 'As linhas de ${source} aparecerão aqui quando tiverem conteúdo.',
@@ -4485,12 +4481,12 @@ extension on TranslationsPt {
 			'downloads.syncRuleUpdated' => 'Regra de sincronização atualizada',
 			'downloads.syncRuleRemoved' => 'Regra de sincronização removida',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Regra de sincronização e downloads associados removidos',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'As regras de sincronização estão sendo atualizadas. Tente novamente em instantes.',
 			'downloads.syncRuleCleanupUnavailable' => 'Os downloads associados não puderam ser identificados com segurança. Reconecte o servidor e tente novamente, ou remova a regra sem excluir os downloads.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => '${count} novos episódios sincronizados para ${title}',
 			'downloads.activeSyncRules' => 'Regras de sincronização',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Nenhuma regra de sincronização',
 			'downloads.manageSyncRule' => 'Gerenciar sincronização',
 			'downloads.editEpisodeCount' => 'Número de episódios',
@@ -4620,8 +4616,6 @@ extension on TranslationsPt {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Falha ao conectar a qualquer endereço',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Conexão perdida após ${attempts} tentativas',
 			'companionRemote.errors.connectionLost' => 'Conexão perdida',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'A conexão foi encerrada antes da autenticação',
 			'videoSettings.playbackSpeed' => 'Velocidade de Reprodução',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_ru.g.dart
+++ b/lib/i18n/strings_ru.g.dart
@@ -3473,12 +3473,12 @@ extension on TranslationsRu {
 			'fileInfo.filePresent' => 'Файл присутствует',
 			'fileInfo.fileReadable' => 'Доступен для чтения сервером',
 			'fileInfo.streamPath' => 'Путь потока',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Оптимизировано для потоковой передачи',
 			'fileInfo.has64bitOffsets' => '64-битные смещения',
 			'fileInfo.protocol' => 'Протокол',
 			'fileInfo.mediaType' => 'Тип медиа',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Тип источника',
 			'fileInfo.optimizedVersion' => 'Оптимизированная версия',
 			'fileInfo.optimizationTarget' => 'Цель оптимизации',
@@ -3532,8 +3532,6 @@ extension on TranslationsRu {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy не смог проверить, какие файлы будут удалены, поэтому может быть удалено больше, чем указанный выше элемент. Отмените и попробуйте снова либо удалите в любом случае.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Ваш сервер не предоставил сведения о файлах для этого элемента, поэтому Plezy не может проверить, какие файлы будут удалены. Может быть удалено больше, чем указанный выше элемент.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Медиаэлемент успешно удалён',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Не удалось удалить медиаэлемент',
 			'mediaMenu.rate' => 'Оценить',
 			'mediaMenu.playFromBeginning' => 'Воспроизвести сначала',
@@ -3989,12 +3987,12 @@ extension on TranslationsRu {
 			'libraries.groupings.tracks' => 'Треки',
 			'libraries.groupings.folders' => 'Папки',
 			'libraries.filterCategories.genre' => 'Жанр',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Год',
 			'libraries.filterCategories.contentRating' => 'Возрастной рейтинг',
 			'libraries.filterCategories.tag' => 'Тег',
 			'libraries.filterCategories.unwatched' => 'Непросмотренные',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Не прослушано',
 			'libraries.filterCategories.favorites' => 'Избранное',
 			'libraries.sortLabels.title' => 'Название',
@@ -4102,8 +4100,6 @@ extension on TranslationsRu {
 			'explore.watchlistNoMatch' => 'Не удалось сопоставить этот элемент со списком просмотра',
 			'explore.notInLibrary' => 'Нет в вашей библиотеке',
 			'explore.inTheseLibraries' => 'В этих библиотеках',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Проверка вашей библиотеки...',
 			'explore.emptyTitle' => 'Здесь пока ничего нет',
 			'explore.emptyMessage' => ({required Object source}) => 'Разделы из ${source} появятся здесь, когда в них появится контент.',
@@ -4505,12 +4501,12 @@ extension on TranslationsRu {
 			'downloads.syncRuleUpdated' => 'Правило синхронизации обновлено',
 			'downloads.syncRuleRemoved' => 'Правило синхронизации удалено',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Правило синхронизации и связанные загрузки удалены',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Правила синхронизации сейчас обновляются. Попробуйте снова чуть позже.',
 			'downloads.syncRuleCleanupUnavailable' => 'Не удалось надёжно определить связанные загрузки. Переподключите сервер и повторите попытку либо удалите правило без удаления загрузок.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => 'Синхронизировано ${count} новых эпизодов для ${title}',
 			'downloads.activeSyncRules' => 'Правила синхронизации',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Нет правил синхронизации',
 			'downloads.manageSyncRule' => 'Управление синхронизацией',
 			'downloads.editEpisodeCount' => 'Количество эпизодов',
@@ -4640,8 +4636,6 @@ extension on TranslationsRu {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Не удалось подключиться ни к одному адресу',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Соединение потеряно после ${attempts} попыток',
 			'companionRemote.errors.connectionLost' => 'Соединение потеряно',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Соединение было закрыто до аутентификации',
 			'videoSettings.playbackSpeed' => 'Скорость воспроизведения',
 			'videoSettings.normalSpeed' => 'Обычная',

--- a/lib/i18n/strings_ru.g.dart
+++ b/lib/i18n/strings_ru.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$ru extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Для библиотеки';
 	@override String get playerScopeTitle => 'Для сериала или фильма';
 	@override String get exportDialogTitle => 'Экспорт настроек Plezy';
+	@override String get linuxVideoRenderMode => 'Режим рендеринга видео';
+	@override String get linuxVideoRenderModeDescription => 'Автоматический режим предпочитает нативную плоскость Wayland (поддержка HDR); Texture принудительно использует запасной путь SDR.';
+	@override String get linuxVideoRenderModeAuto => 'Автоматически';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3343,6 +3347,10 @@ extension on TranslationsRu {
 			'settings.playerScopeLibrary' => 'Для библиотеки',
 			'settings.playerScopeTitle' => 'Для сериала или фильма',
 			'settings.exportDialogTitle' => 'Экспорт настроек Plezy',
+			'settings.linuxVideoRenderMode' => 'Режим рендеринга видео',
+			'settings.linuxVideoRenderModeDescription' => 'Автоматический режим предпочитает нативную плоскость Wayland (поддержка HDR); Texture принудительно использует запасной путь SDR.',
+			'settings.linuxVideoRenderModeAuto' => 'Автоматически',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Поиск фильмов, сериалов, музыки...',
 			'search.tryDifferentTerm' => 'Попробуйте другой запрос',
 			'search.searchYourMedia' => 'Поиск в вашей медиатеке',
@@ -3524,6 +3532,8 @@ extension on TranslationsRu {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy не смог проверить, какие файлы будут удалены, поэтому может быть удалено больше, чем указанный выше элемент. Отмените и попробуйте снова либо удалите в любом случае.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Ваш сервер не предоставил сведения о файлах для этого элемента, поэтому Plezy не может проверить, какие файлы будут удалены. Может быть удалено больше, чем указанный выше элемент.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Медиаэлемент успешно удалён',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Не удалось удалить медиаэлемент',
 			'mediaMenu.rate' => 'Оценить',
 			'mediaMenu.playFromBeginning' => 'Воспроизвести сначала',
@@ -4092,6 +4102,8 @@ extension on TranslationsRu {
 			'explore.watchlistNoMatch' => 'Не удалось сопоставить этот элемент со списком просмотра',
 			'explore.notInLibrary' => 'Нет в вашей библиотеке',
 			'explore.inTheseLibraries' => 'В этих библиотеках',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Проверка вашей библиотеки...',
 			'explore.emptyTitle' => 'Здесь пока ничего нет',
 			'explore.emptyMessage' => ({required Object source}) => 'Разделы из ${source} появятся здесь, когда в них появится контент.',
@@ -4628,6 +4640,8 @@ extension on TranslationsRu {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Не удалось подключиться ни к одному адресу',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Соединение потеряно после ${attempts} попыток',
 			'companionRemote.errors.connectionLost' => 'Соединение потеряно',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Соединение было закрыто до аутентификации',
 			'videoSettings.playbackSpeed' => 'Скорость воспроизведения',
 			'videoSettings.normalSpeed' => 'Обычная',

--- a/lib/i18n/strings_sv.g.dart
+++ b/lib/i18n/strings_sv.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsSv {
 			'fileInfo.filePresent' => 'Fil finns',
 			'fileInfo.fileReadable' => 'Läsbar av servern',
 			'fileInfo.streamPath' => 'Strömsökväg',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Optimerad för streaming',
 			'fileInfo.has64bitOffsets' => '64-bitars offsetvärden',
 			'fileInfo.protocol' => 'Protokoll',
 			'fileInfo.mediaType' => 'Mediatyp',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Källtyp',
 			'fileInfo.optimizedVersion' => 'Optimerad version',
 			'fileInfo.optimizationTarget' => 'Optimeringsmål',
@@ -3512,8 +3512,6 @@ extension on TranslationsSv {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kunde inte kontrollera vilka filer detta tar bort, så det kan ta bort mer än objektet ovan. Avbryt och försök igen, eller ta bort ändå.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Din server tillhandahöll inte filinformation för detta objekt, så Plezy kan inte kontrollera vilka filer detta tar bort. Det kan ta bort mer än objektet ovan.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medieobjektet har tagits bort',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Det gick inte att ta bort medieobjektet',
 			'mediaMenu.rate' => 'Betygsätt',
 			'mediaMenu.playFromBeginning' => 'Spela från början',
@@ -3969,12 +3967,12 @@ extension on TranslationsSv {
 			'libraries.groupings.tracks' => 'Låtar',
 			'libraries.groupings.folders' => 'Mappar',
 			'libraries.filterCategories.genre' => 'Genre',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'År',
 			'libraries.filterCategories.contentRating' => 'Åldersgräns',
 			'libraries.filterCategories.tag' => 'Tagg',
 			'libraries.filterCategories.unwatched' => 'Osedda',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Ospelat',
 			'libraries.filterCategories.favorites' => 'Favoriter',
 			'libraries.sortLabels.title' => 'Titel',
@@ -4082,8 +4080,6 @@ extension on TranslationsSv {
 			'explore.watchlistNoMatch' => 'Det gick inte att matcha det här objektet mot en bevakningslista',
 			'explore.notInLibrary' => 'Finns inte i ditt bibliotek',
 			'explore.inTheseLibraries' => 'I dessa bibliotek',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kontrollerar ditt bibliotek...',
 			'explore.emptyTitle' => 'Inget här ännu',
 			'explore.emptyMessage' => ({required Object source}) => 'Rader från ${source} visas här när de har innehåll.',
@@ -4485,12 +4481,12 @@ extension on TranslationsSv {
 			'downloads.syncRuleUpdated' => 'Synkregel uppdaterad',
 			'downloads.syncRuleRemoved' => 'Synkregel borttagen',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Synkregel och associerade nedladdningar borttagna',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Synkregler uppdateras just nu. Försök igen om en liten stund.',
 			'downloads.syncRuleCleanupUnavailable' => 'Associerade nedladdningar kunde inte identifieras på ett säkert sätt. Återanslut servern och försök igen, eller ta bort regeln utan att ta bort nedladdningar.',
 			'downloads.syncedNewEpisodes' => ({required Object count, required Object title}) => 'Synkroniserade ${count} nya avsnitt för ${title}',
 			'downloads.activeSyncRules' => 'Synkregler',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Inga synkregler',
 			'downloads.manageSyncRule' => 'Hantera synkronisering',
 			'downloads.editEpisodeCount' => 'Antal avsnitt',
@@ -4620,8 +4616,6 @@ extension on TranslationsSv {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Det gick inte att ansluta till någon adress',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Anslutningen bröts efter ${attempts} försök',
 			'companionRemote.errors.connectionLost' => 'Anslutningen bröts',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Anslutningen stängdes före autentiseringen',
 			'videoSettings.playbackSpeed' => 'Uppspelningshastighet',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_sv.g.dart
+++ b/lib/i18n/strings_sv.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$sv extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Per bibliotek';
 	@override String get playerScopeTitle => 'Per serie eller film';
 	@override String get exportDialogTitle => 'Exportera Plezy-inställningar';
+	@override String get linuxVideoRenderMode => 'Videorenderingsläge';
+	@override String get linuxVideoRenderModeDescription => 'Automatiskt föredrar det inbyggda Wayland-planet (HDR-kompatibelt); Texture tvingar SDR-reservvägen.';
+	@override String get linuxVideoRenderModeAuto => 'Automatiskt';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsSv {
 			'settings.playerScopeLibrary' => 'Per bibliotek',
 			'settings.playerScopeTitle' => 'Per serie eller film',
 			'settings.exportDialogTitle' => 'Exportera Plezy-inställningar',
+			'settings.linuxVideoRenderMode' => 'Videorenderingsläge',
+			'settings.linuxVideoRenderModeDescription' => 'Automatiskt föredrar det inbyggda Wayland-planet (HDR-kompatibelt); Texture tvingar SDR-reservvägen.',
+			'settings.linuxVideoRenderModeAuto' => 'Automatiskt',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Sök filmer, serier, musik...',
 			'search.tryDifferentTerm' => 'Prova en annan sökterm',
 			'search.searchYourMedia' => 'Sök i dina media',
@@ -3504,6 +3512,8 @@ extension on TranslationsSv {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy kunde inte kontrollera vilka filer detta tar bort, så det kan ta bort mer än objektet ovan. Avbryt och försök igen, eller ta bort ändå.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Din server tillhandahöll inte filinformation för detta objekt, så Plezy kan inte kontrollera vilka filer detta tar bort. Det kan ta bort mer än objektet ovan.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medieobjektet har tagits bort',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Det gick inte att ta bort medieobjektet',
 			'mediaMenu.rate' => 'Betygsätt',
 			'mediaMenu.playFromBeginning' => 'Spela från början',
@@ -4072,6 +4082,8 @@ extension on TranslationsSv {
 			'explore.watchlistNoMatch' => 'Det gick inte att matcha det här objektet mot en bevakningslista',
 			'explore.notInLibrary' => 'Finns inte i ditt bibliotek',
 			'explore.inTheseLibraries' => 'I dessa bibliotek',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kontrollerar ditt bibliotek...',
 			'explore.emptyTitle' => 'Inget här ännu',
 			'explore.emptyMessage' => ({required Object source}) => 'Rader från ${source} visas här när de har innehåll.',
@@ -4608,6 +4620,8 @@ extension on TranslationsSv {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Det gick inte att ansluta till någon adress',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => 'Anslutningen bröts efter ${attempts} försök',
 			'companionRemote.errors.connectionLost' => 'Anslutningen bröts',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Anslutningen stängdes före autentiseringen',
 			'videoSettings.playbackSpeed' => 'Uppspelningshastighet',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_tr.g.dart
+++ b/lib/i18n/strings_tr.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$tr extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Kitaplık başına';
 	@override String get playerScopeTitle => 'Dizi veya film başına';
 	@override String get exportDialogTitle => 'Plezy ayarlarını dışa aktar';
+	@override String get linuxVideoRenderMode => 'Video işleme modu';
+	@override String get linuxVideoRenderModeDescription => 'Otomatik, yerel Wayland düzlemini tercih eder (HDR destekli); Texture, SDR yedek yolunu zorlar.';
+	@override String get linuxVideoRenderModeAuto => 'Otomatik';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsTr {
 			'settings.playerScopeLibrary' => 'Kitaplık başına',
 			'settings.playerScopeTitle' => 'Dizi veya film başına',
 			'settings.exportDialogTitle' => 'Plezy ayarlarını dışa aktar',
+			'settings.linuxVideoRenderMode' => 'Video işleme modu',
+			'settings.linuxVideoRenderModeDescription' => 'Otomatik, yerel Wayland düzlemini tercih eder (HDR destekli); Texture, SDR yedek yolunu zorlar.',
+			'settings.linuxVideoRenderModeAuto' => 'Otomatik',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Film, dizi, müzik ara...',
 			'search.tryDifferentTerm' => 'Farklı bir arama terimi deneyin',
 			'search.searchYourMedia' => 'Medyanızda arayın',
@@ -3504,6 +3512,8 @@ extension on TranslationsTr {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy bunun hangi dosyaları sileceğini kontrol edemedi, bu yüzden yukarıda adı geçen ögeden daha fazlasını silebilir. İptal edip tekrar deneyin veya yine de silin.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Sunucunuz bu öge için dosya ayrıntıları sağlamadı, bu yüzden Plezy bunun hangi dosyaları sileceğini kontrol edemiyor. Yukarıda adı geçen ögeden daha fazlasını silebilir.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medya ögesi başarıyla silindi',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Medya ögesi silinemedi',
 			'mediaMenu.rate' => 'Oyla',
 			'mediaMenu.playFromBeginning' => 'Baştan Oynat',
@@ -4072,6 +4082,8 @@ extension on TranslationsTr {
 			'explore.watchlistNoMatch' => 'Bu öğe bir izleme listesiyle eşleştirilemedi',
 			'explore.notInLibrary' => 'Kitaplığınızda yok',
 			'explore.inTheseLibraries' => 'Bu kitaplıklarda var',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kitaplığınız kontrol ediliyor...',
 			'explore.emptyTitle' => 'Henüz burada bir şey yok',
 			'explore.emptyMessage' => ({required Object source}) => '${source} kaynağındaki satırlar içerik bulunduğunda burada görünecektir.',
@@ -4608,6 +4620,8 @@ extension on TranslationsTr {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Hiçbir adrese bağlanılamadı',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} denemeden sonra bağlantı kesildi',
 			'companionRemote.errors.connectionLost' => 'Bağlantı kesildi',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Bağlantı, kimlik doğrulamadan önce kapandı',
 			'videoSettings.playbackSpeed' => 'Oynatma Hızı',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_tr.g.dart
+++ b/lib/i18n/strings_tr.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsTr {
 			'fileInfo.filePresent' => 'Dosya Mevcut',
 			'fileInfo.fileReadable' => 'Sunucu Tarafından Okunabilir',
 			'fileInfo.streamPath' => 'Akış Yolu',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Akış İçin Optimize Edilmiş',
 			'fileInfo.has64bitOffsets' => '64-bit Ofsetler',
 			'fileInfo.protocol' => 'Protokol',
 			'fileInfo.mediaType' => 'Medya Türü',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Kaynak Türü',
 			'fileInfo.optimizedVersion' => 'Optimize Edilmiş Sürüm',
 			'fileInfo.optimizationTarget' => 'Optimizasyon Hedefi',
@@ -3512,8 +3512,6 @@ extension on TranslationsTr {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy bunun hangi dosyaları sileceğini kontrol edemedi, bu yüzden yukarıda adı geçen ögeden daha fazlasını silebilir. İptal edip tekrar deneyin veya yine de silin.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Sunucunuz bu öge için dosya ayrıntıları sağlamadı, bu yüzden Plezy bunun hangi dosyaları sileceğini kontrol edemiyor. Yukarıda adı geçen ögeden daha fazlasını silebilir.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Medya ögesi başarıyla silindi',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Medya ögesi silinemedi',
 			'mediaMenu.rate' => 'Oyla',
 			'mediaMenu.playFromBeginning' => 'Baştan Oynat',
@@ -3969,12 +3967,12 @@ extension on TranslationsTr {
 			'libraries.groupings.tracks' => 'Parçalar',
 			'libraries.groupings.folders' => 'Klasörler',
 			'libraries.filterCategories.genre' => 'Tür',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Yıl',
 			'libraries.filterCategories.contentRating' => 'İçerik Derecelendirmesi',
 			'libraries.filterCategories.tag' => 'Etiket',
 			'libraries.filterCategories.unwatched' => 'İzlenmemiş',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Oynatılmamış',
 			'libraries.filterCategories.favorites' => 'Favoriler',
 			'libraries.sortLabels.title' => 'Başlık',
@@ -4082,8 +4080,6 @@ extension on TranslationsTr {
 			'explore.watchlistNoMatch' => 'Bu öğe bir izleme listesiyle eşleştirilemedi',
 			'explore.notInLibrary' => 'Kitaplığınızda yok',
 			'explore.inTheseLibraries' => 'Bu kitaplıklarda var',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kitaplığınız kontrol ediliyor...',
 			'explore.emptyTitle' => 'Henüz burada bir şey yok',
 			'explore.emptyMessage' => ({required Object source}) => '${source} kaynağındaki satırlar içerik bulunduğunda burada görünecektir.',
@@ -4485,12 +4481,12 @@ extension on TranslationsTr {
 			'downloads.syncRuleUpdated' => 'Eşitleme kuralı güncellendi',
 			'downloads.syncRuleRemoved' => 'Eşitleme kuralı kaldırıldı',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Eşitleme kuralı ve ilişkili indirmeler kaldırıldı',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Eşitleme kuralları şu anda güncelleniyor. Birazdan tekrar deneyin.',
 			'downloads.syncRuleCleanupUnavailable' => 'İlişkili indirmeler güvenli biçimde belirlenemedi. Sunucuya yeniden bağlanıp tekrar deneyin veya kuralı indirmeleri silmeden kaldırın.',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '${title} için ${count} yeni bölüm eşitlendi',
 			'downloads.activeSyncRules' => 'Eşitleme kuralları',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Eşitleme kuralı yok',
 			'downloads.manageSyncRule' => 'Eşitlemeyi yönet',
 			'downloads.editEpisodeCount' => 'Bölüm sayısı',
@@ -4620,8 +4616,6 @@ extension on TranslationsTr {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Hiçbir adrese bağlanılamadı',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} denemeden sonra bağlantı kesildi',
 			'companionRemote.errors.connectionLost' => 'Bağlantı kesildi',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Bağlantı, kimlik doğrulamadan önce kapandı',
 			'videoSettings.playbackSpeed' => 'Oynatma Hızı',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_uz.g.dart
+++ b/lib/i18n/strings_uz.g.dart
@@ -509,6 +509,10 @@ class _Translations$settings$uz extends Translations$settings$en {
 	@override String get playerScopeLibrary => 'Kutubxona boʻyicha';
 	@override String get playerScopeTitle => 'Serial yoki film boʻyicha';
 	@override String get exportDialogTitle => 'Plezy sozlamalarini eksport qilish';
+	@override String get linuxVideoRenderMode => 'Video ko\'rsatish rejimi';
+	@override String get linuxVideoRenderModeDescription => 'Avtomatik rejim mahalliy Wayland tekisligini afzal ko\'radi (HDR qo\'llab-quvvatlaydi); Texture SDR zaxira yo\'lini majbur qiladi.';
+	@override String get linuxVideoRenderModeAuto => 'Avtomatik';
+	@override String get linuxVideoRenderModeTexture => 'Texture (SDR)';
 }
 
 // Path: search
@@ -3323,6 +3327,10 @@ extension on TranslationsUz {
 			'settings.playerScopeLibrary' => 'Kutubxona boʻyicha',
 			'settings.playerScopeTitle' => 'Serial yoki film boʻyicha',
 			'settings.exportDialogTitle' => 'Plezy sozlamalarini eksport qilish',
+			'settings.linuxVideoRenderMode' => 'Video ko\'rsatish rejimi',
+			'settings.linuxVideoRenderModeDescription' => 'Avtomatik rejim mahalliy Wayland tekisligini afzal ko\'radi (HDR qo\'llab-quvvatlaydi); Texture SDR zaxira yo\'lini majbur qiladi.',
+			'settings.linuxVideoRenderModeAuto' => 'Avtomatik',
+			'settings.linuxVideoRenderModeTexture' => 'Texture (SDR)',
 			'search.hint' => 'Filmlar, seriallar, musiqa qidirish...',
 			'search.tryDifferentTerm' => 'Boshqa qidiruv soʻzini kiriting',
 			'search.searchYourMedia' => 'Medialaringizdan qidiring',
@@ -3504,6 +3512,8 @@ extension on TranslationsUz {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy qaysi fayllar olib tashlanishini tekshira olmadi, shuning uchun u yuqorida koʻrsatilgan elementdan koʻproq narsani oʻchirishi mumkin. Bekor qilib qaytadan urining yoki baribir oʻchiring.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Serveringiz ushbu element uchun fayl tafsilotlarini taqdim etmadi, shuning uchun Plezy qaysi fayllar olib tashlanishini tekshira olmaydi. U yuqorida koʻrsatilgan elementdan koʻproq narsani oʻchirishi mumkin.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media elementi muvaffaqiyatli oʻchirildi',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Media elementini oʻchirib boʻlmadi',
 			'mediaMenu.rate' => 'Baho berish',
 			'mediaMenu.playFromBeginning' => 'Boshidan ijro etish',
@@ -4072,6 +4082,8 @@ extension on TranslationsUz {
 			'explore.watchlistNoMatch' => 'Bu elementni tomosha roʻyxatiga moslab boʻlmadi',
 			'explore.notInLibrary' => 'Kutubxonangizda yoʻq',
 			'explore.inTheseLibraries' => 'Ushbu kutubxonalarda bor',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kutubxona tekshirilmoqda...',
 			'explore.emptyTitle' => 'Hali bu yerda hech narsa yoʻq',
 			'explore.emptyMessage' => ({required Object source}) => '${source} manbasidan olingan qatorlar bu yerda koʻrinadi.',
@@ -4608,6 +4620,8 @@ extension on TranslationsUz {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Hech bir manzilga ulanib boʻlmadi',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} urinishdan keyin aloqa uzildi',
 			'companionRemote.errors.connectionLost' => 'Aloqa uzildi',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Ulanish autentifikatsiyadan oldin yopildi',
 			'videoSettings.playbackSpeed' => 'Ijro tezligi',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_uz.g.dart
+++ b/lib/i18n/strings_uz.g.dart
@@ -3453,12 +3453,12 @@ extension on TranslationsUz {
 			'fileInfo.filePresent' => 'Fayl mavjud',
 			'fileInfo.fileReadable' => 'Server tomonidan oʻqiladigan',
 			'fileInfo.streamPath' => 'Oqim yoʻli',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => 'Oqimli uzatish uchun optimallashtirilgan',
 			'fileInfo.has64bitOffsets' => '64-bitli siljishlar',
 			'fileInfo.protocol' => 'Protokol',
 			'fileInfo.mediaType' => 'Media turi',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => 'Manba turi',
 			'fileInfo.optimizedVersion' => 'Optimallashtirilgan versiya',
 			'fileInfo.optimizationTarget' => 'Optimallashtirish maqsadi',
@@ -3512,8 +3512,6 @@ extension on TranslationsUz {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy qaysi fayllar olib tashlanishini tekshira olmadi, shuning uchun u yuqorida koʻrsatilgan elementdan koʻproq narsani oʻchirishi mumkin. Bekor qilib qaytadan urining yoki baribir oʻchiring.',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => 'Serveringiz ushbu element uchun fayl tafsilotlarini taqdim etmadi, shuning uchun Plezy qaysi fayllar olib tashlanishini tekshira olmaydi. U yuqorida koʻrsatilgan elementdan koʻproq narsani oʻchirishi mumkin.',
 			'mediaMenu.mediaDeletedSuccessfully' => 'Media elementi muvaffaqiyatli oʻchirildi',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => 'Media elementini oʻchirib boʻlmadi',
 			'mediaMenu.rate' => 'Baho berish',
 			'mediaMenu.playFromBeginning' => 'Boshidan ijro etish',
@@ -3969,12 +3967,12 @@ extension on TranslationsUz {
 			'libraries.groupings.tracks' => 'Taronalar',
 			'libraries.groupings.folders' => 'Jildlar',
 			'libraries.filterCategories.genre' => 'Janr',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => 'Yil',
 			'libraries.filterCategories.contentRating' => 'Kontent reytingi',
 			'libraries.filterCategories.tag' => 'Teg',
 			'libraries.filterCategories.unwatched' => 'Koʻrilmagan',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => 'Eshitilmagan',
 			'libraries.filterCategories.favorites' => 'Tanlanganlar',
 			'libraries.sortLabels.title' => 'Nomi',
@@ -4082,8 +4080,6 @@ extension on TranslationsUz {
 			'explore.watchlistNoMatch' => 'Bu elementni tomosha roʻyxatiga moslab boʻlmadi',
 			'explore.notInLibrary' => 'Kutubxonangizda yoʻq',
 			'explore.inTheseLibraries' => 'Ushbu kutubxonalarda bor',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => 'Kutubxona tekshirilmoqda...',
 			'explore.emptyTitle' => 'Hali bu yerda hech narsa yoʻq',
 			'explore.emptyMessage' => ({required Object source}) => '${source} manbasidan olingan qatorlar bu yerda koʻrinadi.',
@@ -4485,12 +4481,12 @@ extension on TranslationsUz {
 			'downloads.syncRuleUpdated' => 'Sinxronlash qoidasi yangilandi',
 			'downloads.syncRuleRemoved' => 'Sinxronlash qoidasi oʻchirildi',
 			'downloads.syncRuleAndDownloadsRemoved' => 'Sinxronlash qoidasi va bogʻliq yuklamalar oʻchirildi',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => 'Sinxronlash qoidalari hozir yangilanmoqda. Bir ozdan soʻng qayta urinib koʻring.',
 			'downloads.syncRuleCleanupUnavailable' => 'Bogʻliq yuklamalarni xavfsiz aniqlab boʻlmadi. Serverga qayta ulanib koʻring yoki yuklamalarni oʻchirmasdan qoidani olib tashlang.',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '${title} uchun ${count} yangi qism sinxronlandi',
 			'downloads.activeSyncRules' => 'Faol sinxronlash qoidalari',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => 'Sinxronlash qoidalari yoʻq',
 			'downloads.manageSyncRule' => 'Sinxronlashni boshqarish',
 			'downloads.editEpisodeCount' => 'Qismlar soni',
@@ -4620,8 +4616,6 @@ extension on TranslationsUz {
 			'companionRemote.errors.failedToConnectAnyAddress' => 'Hech bir manzilga ulanib boʻlmadi',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} urinishdan keyin aloqa uzildi',
 			'companionRemote.errors.connectionLost' => 'Aloqa uzildi',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => 'Ulanish autentifikatsiyadan oldin yopildi',
 			'videoSettings.playbackSpeed' => 'Ijro tezligi',
 			'videoSettings.normalSpeed' => 'Normal',

--- a/lib/i18n/strings_zh.g.dart
+++ b/lib/i18n/strings_zh.g.dart
@@ -509,6 +509,10 @@ class Translations$settings$zh extends Translations$settings$en {
 	@override String get playerScopeLibrary => '按媒体库';
 	@override String get playerScopeTitle => '按剧集或电影';
 	@override String get exportDialogTitle => '导出 Plezy 设置';
+	@override String get linuxVideoRenderMode => '视频渲染模式';
+	@override String get linuxVideoRenderModeDescription => '自动优先使用原生 Wayland 平面（支持 HDR）；纹理强制使用 SDR 回退路径。';
+	@override String get linuxVideoRenderModeAuto => '自动';
+	@override String get linuxVideoRenderModeTexture => '纹理（SDR）';
 }
 
 // Path: search
@@ -3313,6 +3317,10 @@ extension on TranslationsZh {
 			'settings.playerScopeLibrary' => '按媒体库',
 			'settings.playerScopeTitle' => '按剧集或电影',
 			'settings.exportDialogTitle' => '导出 Plezy 设置',
+			'settings.linuxVideoRenderMode' => '视频渲染模式',
+			'settings.linuxVideoRenderModeDescription' => '自动优先使用原生 Wayland 平面（支持 HDR）；纹理强制使用 SDR 回退路径。',
+			'settings.linuxVideoRenderModeAuto' => '自动',
+			'settings.linuxVideoRenderModeTexture' => '纹理（SDR）',
 			'search.hint' => '搜索电影、剧集、音乐…',
 			'search.tryDifferentTerm' => '尝试不同的搜索词',
 			'search.searchYourMedia' => '搜索媒体',
@@ -3494,6 +3502,8 @@ extension on TranslationsZh {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy 无法确认此操作会删除哪些文件，因此删除范围可能超出上面提到的项目。请取消后重试，或仍然删除。',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => '你的服务器没有提供此项目的文件详情，因此 Plezy 无法确认此操作会删除哪些文件。删除范围可能超出上面提到的项目。',
 			'mediaMenu.mediaDeletedSuccessfully' => '媒体项已成功删除',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => '删除媒体项失败',
 			'mediaMenu.rate' => '评分',
 			'mediaMenu.playFromBeginning' => '从头播放',
@@ -4062,6 +4072,8 @@ extension on TranslationsZh {
 			'explore.watchlistNoMatch' => '无法将此项目与待看列表匹配',
 			'explore.notInLibrary' => '不在你的媒体库中',
 			'explore.inTheseLibraries' => '在这些媒体库中',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => '正在检查你的媒体库…',
 			'explore.emptyTitle' => '这里还什么都没有',
 			'explore.emptyMessage' => ({required Object source}) => '当 ${source} 有内容时，相关内容将显示在这里。',
@@ -4598,6 +4610,8 @@ extension on TranslationsZh {
 			'companionRemote.errors.failedToConnectAnyAddress' => '无法连接到任何地址',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} 次尝试后连接丢失',
 			'companionRemote.errors.connectionLost' => '连接丢失',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '连接在身份验证前已关闭',
 			'videoSettings.playbackSpeed' => '播放速度',
 			'videoSettings.normalSpeed' => '正常',

--- a/lib/i18n/strings_zh.g.dart
+++ b/lib/i18n/strings_zh.g.dart
@@ -3443,12 +3443,12 @@ extension on TranslationsZh {
 			'fileInfo.filePresent' => '文件存在',
 			'fileInfo.fileReadable' => '服务器可读',
 			'fileInfo.streamPath' => '流路径',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => '已针对流式传输优化',
 			'fileInfo.has64bitOffsets' => '64 位偏移量',
 			'fileInfo.protocol' => '协议',
 			'fileInfo.mediaType' => '媒体类型',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => '来源类型',
 			'fileInfo.optimizedVersion' => '优化版本',
 			'fileInfo.optimizationTarget' => '优化目标',
@@ -3502,8 +3502,6 @@ extension on TranslationsZh {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy 无法确认此操作会删除哪些文件，因此删除范围可能超出上面提到的项目。请取消后重试，或仍然删除。',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => '你的服务器没有提供此项目的文件详情，因此 Plezy 无法确认此操作会删除哪些文件。删除范围可能超出上面提到的项目。',
 			'mediaMenu.mediaDeletedSuccessfully' => '媒体项已成功删除',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => '删除媒体项失败',
 			'mediaMenu.rate' => '评分',
 			'mediaMenu.playFromBeginning' => '从头播放',
@@ -3959,12 +3957,12 @@ extension on TranslationsZh {
 			'libraries.groupings.tracks' => '曲目',
 			'libraries.groupings.folders' => '文件夹',
 			'libraries.filterCategories.genre' => '类型',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => '年份',
 			'libraries.filterCategories.contentRating' => '内容分级',
 			'libraries.filterCategories.tag' => '标签',
 			'libraries.filterCategories.unwatched' => '未观看',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => '未播放',
 			'libraries.filterCategories.favorites' => '收藏夹',
 			'libraries.sortLabels.title' => '标题',
@@ -4072,8 +4070,6 @@ extension on TranslationsZh {
 			'explore.watchlistNoMatch' => '无法将此项目与待看列表匹配',
 			'explore.notInLibrary' => '不在你的媒体库中',
 			'explore.inTheseLibraries' => '在这些媒体库中',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => '正在检查你的媒体库…',
 			'explore.emptyTitle' => '这里还什么都没有',
 			'explore.emptyMessage' => ({required Object source}) => '当 ${source} 有内容时，相关内容将显示在这里。',
@@ -4475,12 +4471,12 @@ extension on TranslationsZh {
 			'downloads.syncRuleUpdated' => '同步规则已更新',
 			'downloads.syncRuleRemoved' => '同步规则已删除',
 			'downloads.syncRuleAndDownloadsRemoved' => '同步规则及相关下载已删除',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => '同步规则正在更新中，请稍后再试。',
 			'downloads.syncRuleCleanupUnavailable' => '无法安全识别相关下载。请重新连接服务器后再试，或在不删除下载的情况下移除规则。',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '已为 ${title} 同步 ${count} 个新剧集',
 			'downloads.activeSyncRules' => '同步规则',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => '没有同步规则',
 			'downloads.manageSyncRule' => '管理同步',
 			'downloads.editEpisodeCount' => '剧集数量',
@@ -4610,8 +4606,6 @@ extension on TranslationsZh {
 			'companionRemote.errors.failedToConnectAnyAddress' => '无法连接到任何地址',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '${attempts} 次尝试后连接丢失',
 			'companionRemote.errors.connectionLost' => '连接丢失',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '连接在身份验证前已关闭',
 			'videoSettings.playbackSpeed' => '播放速度',
 			'videoSettings.normalSpeed' => '正常',

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -3444,12 +3444,12 @@ extension on TranslationsZhHant {
 			'fileInfo.filePresent' => '檔案存在',
 			'fileInfo.fileReadable' => '伺服器可讀取',
 			'fileInfo.streamPath' => '串流路徑',
+			_ => null,
+		} ?? switch (path) {
 			'fileInfo.optimizedForStreaming' => '已最佳化串流播放',
 			'fileInfo.has64bitOffsets' => '具 64 位元偏移量',
 			'fileInfo.protocol' => '通訊協定',
 			'fileInfo.mediaType' => '媒體類型',
-			_ => null,
-		} ?? switch (path) {
 			'fileInfo.sourceKind' => '來源類型',
 			'fileInfo.optimizedVersion' => '最佳化版本',
 			'fileInfo.optimizationTarget' => '最佳化目標',
@@ -3503,8 +3503,6 @@ extension on TranslationsZhHant {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy 無法確認此操作會刪除哪些檔案，因此刪除範圍可能超出上方所列的項目。請取消後重試，或仍要刪除。',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => '您的伺服器未提供此項目的檔案資訊，因此 Plezy 無法確認此操作會刪除哪些檔案。刪除範圍可能超出上方所列的項目。',
 			'mediaMenu.mediaDeletedSuccessfully' => '媒體已成功刪除',
-			_ => null,
-		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => '刪除媒體失敗',
 			'mediaMenu.rate' => '評分',
 			'mediaMenu.playFromBeginning' => '從頭播放',
@@ -3960,12 +3958,12 @@ extension on TranslationsZhHant {
 			'libraries.groupings.tracks' => '曲目',
 			'libraries.groupings.folders' => '資料夾',
 			'libraries.filterCategories.genre' => '類型',
+			_ => null,
+		} ?? switch (path) {
 			'libraries.filterCategories.year' => '年份',
 			'libraries.filterCategories.contentRating' => '分級',
 			'libraries.filterCategories.tag' => '標籤',
 			'libraries.filterCategories.unwatched' => '未觀看',
-			_ => null,
-		} ?? switch (path) {
 			'libraries.filterCategories.unplayed' => '未播放',
 			'libraries.filterCategories.favorites' => '我的最愛',
 			'libraries.sortLabels.title' => '標題',
@@ -4073,8 +4071,6 @@ extension on TranslationsZhHant {
 			'explore.watchlistNoMatch' => '無法將此項目與待看清單配對',
 			'explore.notInLibrary' => '不在您的媒體庫中',
 			'explore.inTheseLibraries' => '在這些媒體庫中',
-			_ => null,
-		} ?? switch (path) {
 			'explore.checkingLibrary' => '正在檢查您的媒體庫…',
 			'explore.emptyTitle' => '這裡還沒有任何內容',
 			'explore.emptyMessage' => ({required Object source}) => '當 ${source} 有內容時，相關資訊將顯示在此處。',
@@ -4476,12 +4472,12 @@ extension on TranslationsZhHant {
 			'downloads.syncRuleUpdated' => '同步規則已更新',
 			'downloads.syncRuleRemoved' => '同步規則已刪除',
 			'downloads.syncRuleAndDownloadsRemoved' => '同步規則與相關的下載內容已刪除',
+			_ => null,
+		} ?? switch (path) {
 			'downloads.syncRuleCleanupBusy' => '同步規則正在更新中。請稍後再試。',
 			'downloads.syncRuleCleanupUnavailable' => '無法安全地識別相關的下載內容。請重新連線伺服器後再試，或在不刪除下載內容的情況下移除規則。',
 			'downloads.syncedNewEpisodes' => ({required Object title, required Object count}) => '已為 ${title} 同步 ${count} 個新單集',
 			'downloads.activeSyncRules' => '同步規則',
-			_ => null,
-		} ?? switch (path) {
 			'downloads.noSyncRules' => '沒有同步規則',
 			'downloads.manageSyncRule' => '管理同步',
 			'downloads.editEpisodeCount' => '單集數量',
@@ -4611,8 +4607,6 @@ extension on TranslationsZhHant {
 			'companionRemote.errors.failedToConnectAnyAddress' => '無法連線至任何位址',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '嘗試 ${attempts} 次後連線中斷',
 			'companionRemote.errors.connectionLost' => '連線已中斷',
-			_ => null,
-		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '連線在驗證前已關閉',
 			'videoSettings.playbackSpeed' => '播放速度',
 			'videoSettings.normalSpeed' => '正常速度',

--- a/lib/i18n/strings_zh_Hant.g.dart
+++ b/lib/i18n/strings_zh_Hant.g.dart
@@ -510,6 +510,10 @@ class _Translations$settings$zh_Hant extends Translations$settings$zh {
 	@override String get playerScopeLibrary => '依媒體庫';
 	@override String get playerScopeTitle => '依影集或電影';
 	@override String get exportDialogTitle => '匯出 Plezy 設定';
+	@override String get linuxVideoRenderMode => '影片轉譯模式';
+	@override String get linuxVideoRenderModeDescription => '自動偏好原生 Wayland 平面（支援 HDR）；紋理強制使用 SDR 備援路徑。';
+	@override String get linuxVideoRenderModeAuto => '自動';
+	@override String get linuxVideoRenderModeTexture => '紋理（SDR）';
 }
 
 // Path: search
@@ -3314,6 +3318,10 @@ extension on TranslationsZhHant {
 			'settings.playerScopeLibrary' => '依媒體庫',
 			'settings.playerScopeTitle' => '依影集或電影',
 			'settings.exportDialogTitle' => '匯出 Plezy 設定',
+			'settings.linuxVideoRenderMode' => '影片轉譯模式',
+			'settings.linuxVideoRenderModeDescription' => '自動偏好原生 Wayland 平面（支援 HDR）；紋理強制使用 SDR 備援路徑。',
+			'settings.linuxVideoRenderModeAuto' => '自動',
+			'settings.linuxVideoRenderModeTexture' => '紋理（SDR）',
 			'search.hint' => '搜尋電影、影集、音樂…',
 			'search.tryDifferentTerm' => '嘗試不同的關鍵字',
 			'search.searchYourMedia' => '搜尋媒體庫',
@@ -3495,6 +3503,8 @@ extension on TranslationsZhHant {
 			'mediaMenu.deleteScopeUnverifiedProbeFailed' => 'Plezy 無法確認此操作會刪除哪些檔案，因此刪除範圍可能超出上方所列的項目。請取消後重試，或仍要刪除。',
 			'mediaMenu.deleteScopeUnverifiedNoFileInfo' => '您的伺服器未提供此項目的檔案資訊，因此 Plezy 無法確認此操作會刪除哪些檔案。刪除範圍可能超出上方所列的項目。',
 			'mediaMenu.mediaDeletedSuccessfully' => '媒體已成功刪除',
+			_ => null,
+		} ?? switch (path) {
 			'mediaMenu.mediaFailedToDelete' => '刪除媒體失敗',
 			'mediaMenu.rate' => '評分',
 			'mediaMenu.playFromBeginning' => '從頭播放',
@@ -4063,6 +4073,8 @@ extension on TranslationsZhHant {
 			'explore.watchlistNoMatch' => '無法將此項目與待看清單配對',
 			'explore.notInLibrary' => '不在您的媒體庫中',
 			'explore.inTheseLibraries' => '在這些媒體庫中',
+			_ => null,
+		} ?? switch (path) {
 			'explore.checkingLibrary' => '正在檢查您的媒體庫…',
 			'explore.emptyTitle' => '這裡還沒有任何內容',
 			'explore.emptyMessage' => ({required Object source}) => '當 ${source} 有內容時，相關資訊將顯示在此處。',
@@ -4599,6 +4611,8 @@ extension on TranslationsZhHant {
 			'companionRemote.errors.failedToConnectAnyAddress' => '無法連線至任何位址',
 			'companionRemote.errors.connectionLostAfterAttempts' => ({required Object attempts}) => '嘗試 ${attempts} 次後連線中斷',
 			'companionRemote.errors.connectionLost' => '連線已中斷',
+			_ => null,
+		} ?? switch (path) {
 			'companionRemote.closedBeforeAuth' => '連線在驗證前已關閉',
 			'videoSettings.playbackSpeed' => '播放速度',
 			'videoSettings.normalSpeed' => '正常速度',

--- a/lib/i18n/sv.i18n.json
+++ b/lib/i18n/sv.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Överallt",
     "playerScopeLibrary": "Per bibliotek",
     "playerScopeTitle": "Per serie eller film",
-    "exportDialogTitle": "Exportera Plezy-inställningar"
+    "exportDialogTitle": "Exportera Plezy-inställningar",
+    "linuxVideoRenderMode": "Videorenderingsläge",
+    "linuxVideoRenderModeDescription": "Automatiskt föredrar det inbyggda Wayland-planet (HDR-kompatibelt); Texture tvingar SDR-reservvägen.",
+    "linuxVideoRenderModeAuto": "Automatiskt",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Sök filmer, serier, musik...",

--- a/lib/i18n/tr.i18n.json
+++ b/lib/i18n/tr.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Her yerde",
     "playerScopeLibrary": "Kitaplık başına",
     "playerScopeTitle": "Dizi veya film başına",
-    "exportDialogTitle": "Plezy ayarlarını dışa aktar"
+    "exportDialogTitle": "Plezy ayarlarını dışa aktar",
+    "linuxVideoRenderMode": "Video işleme modu",
+    "linuxVideoRenderModeDescription": "Otomatik, yerel Wayland düzlemini tercih eder (HDR destekli); Texture, SDR yedek yolunu zorlar.",
+    "linuxVideoRenderModeAuto": "Otomatik",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Film, dizi, müzik ara...",

--- a/lib/i18n/uz.i18n.json
+++ b/lib/i18n/uz.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "Hamma joyda",
     "playerScopeLibrary": "Kutubxona boʻyicha",
     "playerScopeTitle": "Serial yoki film boʻyicha",
-    "exportDialogTitle": "Plezy sozlamalarini eksport qilish"
+    "exportDialogTitle": "Plezy sozlamalarini eksport qilish",
+    "linuxVideoRenderMode": "Video ko'rsatish rejimi",
+    "linuxVideoRenderModeDescription": "Avtomatik rejim mahalliy Wayland tekisligini afzal ko'radi (HDR qo'llab-quvvatlaydi); Texture SDR zaxira yo'lini majbur qiladi.",
+    "linuxVideoRenderModeAuto": "Avtomatik",
+    "linuxVideoRenderModeTexture": "Texture (SDR)"
   },
   "search": {
     "hint": "Filmlar, seriallar, musiqa qidirish...",

--- a/lib/i18n/zh-Hant.i18n.json
+++ b/lib/i18n/zh-Hant.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "全部",
     "playerScopeLibrary": "依媒體庫",
     "playerScopeTitle": "依影集或電影",
-    "exportDialogTitle": "匯出 Plezy 設定"
+    "exportDialogTitle": "匯出 Plezy 設定",
+    "linuxVideoRenderMode": "影片轉譯模式",
+    "linuxVideoRenderModeDescription": "自動偏好原生 Wayland 平面（支援 HDR）；紋理強制使用 SDR 備援路徑。",
+    "linuxVideoRenderModeAuto": "自動",
+    "linuxVideoRenderModeTexture": "紋理（SDR）"
   },
   "search": {
     "hint": "搜尋電影、影集、音樂…",

--- a/lib/i18n/zh.i18n.json
+++ b/lib/i18n/zh.i18n.json
@@ -403,7 +403,11 @@
     "playerScopeGlobal": "所有位置",
     "playerScopeLibrary": "按媒体库",
     "playerScopeTitle": "按剧集或电影",
-    "exportDialogTitle": "导出 Plezy 设置"
+    "exportDialogTitle": "导出 Plezy 设置",
+    "linuxVideoRenderMode": "视频渲染模式",
+    "linuxVideoRenderModeDescription": "自动优先使用原生 Wayland 平面（支持 HDR）；纹理强制使用 SDR 回退路径。",
+    "linuxVideoRenderModeAuto": "自动",
+    "linuxVideoRenderModeTexture": "纹理（SDR）"
   },
   "search": {
     "hint": "搜索电影、剧集、音乐…",

--- a/lib/mpv/player/player_base.dart
+++ b/lib/mpv/player/player_base.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
-import 'package:flutter/foundation.dart' show listEquals, protected, visibleForTesting;
+import 'package:flutter/foundation.dart' show ValueListenable, ValueNotifier, listEquals, protected, visibleForTesting;
 import 'package:flutter/services.dart';
 
 import '../../media/media_display_criteria.dart';
@@ -29,6 +29,22 @@ import 'player_streams.dart';
 /// - Common lifecycle methods
 abstract class PlayerBase with PlayerStreamControllersMixin implements Player {
   PlayerState _state = const PlayerState();
+
+  /// The Flutter GL texture id published by the platform when video is
+  /// composited as a texture (the Linux SDR fallback path). Null everywhere
+  /// else and before publication; [video.dart] keys its render surface off it.
+  final ValueNotifier<int?> _textureId = ValueNotifier<int?>(null);
+
+  int? get textureId => _textureId.value;
+
+  /// Listenable form of [textureId] for widgets that rebuild on publication.
+  ValueListenable<int?> get textureIdListenable => _textureId;
+
+  /// Publishes (or clears) the Flutter texture id backing this player.
+  @protected
+  void setTextureId(int? value) {
+    if (!_disposed) _textureId.value = value;
+  }
 
   @override
   PlayerState get state => _state;
@@ -1464,6 +1480,10 @@ abstract class PlayerBase with PlayerStreamControllersMixin implements Player {
   Future<void> dispose({bool preserveDisplayMode = false}) async {
     if (_disposed) return;
     _disposed = true;
+    // The texture is going away with the player; clear the id first so a
+    // still-mounted Video widget stops keying off it before the notifier is
+    // disposed below.
+    _textureId.value = null;
 
     final channelName = eventChannel.name;
     if (identical(_eventChannelOwners[channelName], this)) {
@@ -1521,6 +1541,7 @@ abstract class PlayerBase with PlayerStreamControllersMixin implements Player {
       );
     }
     await closeStreamControllers();
+    _textureId.dispose();
   }
 }
 

--- a/lib/mpv/player/player_base.dart
+++ b/lib/mpv/player/player_base.dart
@@ -32,12 +32,13 @@ abstract class PlayerBase with PlayerStreamControllersMixin implements Player {
 
   /// The Flutter GL texture id published by the platform when video is
   /// composited as a texture (the Linux SDR fallback path). Null everywhere
-  /// else and before publication; [video.dart] keys its render surface off it.
+  /// else and before publication; video.dart keys its render surface off it,
+  /// and so does the screen's provisional bootstrap surface.
   final ValueNotifier<int?> _textureId = ValueNotifier<int?>(null);
 
-  int? get textureId => _textureId.value;
-
-  /// Listenable form of [textureId] for widgets that rebuild on publication.
+  /// The id, for widgets that rebuild on publication. Exposed only as a
+  /// listenable: every reader has to rebuild when it lands, because it is
+  /// published partway through initialization rather than before it.
   ValueListenable<int?> get textureIdListenable => _textureId;
 
   /// Publishes (or clears) the Flutter texture id backing this player.

--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -79,6 +79,15 @@ class PlayerNative extends PlayerBase {
   /// tests agree on which path is live without reading a test-only field.
   static bool get usesLinuxVideoPlane => debugUseLinuxVideoPlane ?? Platform.isLinux;
 
+  /// Whether the UI must mount this player's texture while initialization is
+  /// still running. True on Linux, where `initialize` may fall back to the
+  /// Flutter-texture path and then wait on a GPU bootstrap that Flutter only
+  /// drives for a texture in the layer tree. Asked before initialize has
+  /// chosen a path, so it cannot be narrower than "Linux, with video": on the
+  /// plane path no texture id is ever published and the provisional surface
+  /// mounts nothing.
+  bool get requiresProvisionalTextureSurface => !audioOnly && usesLinuxVideoPlane;
+
   /// First successful (positive) [getHeapSize] result; the device heap is
   /// immutable per process, so one channel round trip serves every caller.
   static int? _cachedHeapSizeMB;

--- a/lib/mpv/player/player_native.dart
+++ b/lib/mpv/player/player_native.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 
 import '../../media/media_display_criteria.dart';
+import '../../services/settings_service.dart';
 import '../../utils/app_logger.dart';
 import '../models.dart';
 import 'audio_rendering_mode.dart';
@@ -262,11 +263,27 @@ class PlayerNative extends PlayerBase {
       // choose its vo before mpv_initialize. `instanceId` names this Dart
       // instance so a later `dispose` that lost the ownership race is
       // provably stale; handlers that predate either argument ignore them.
+      //
+      // Linux additionally carries a render-mode preference: 'texture' forces
+      // the SDR Flutter-texture fallback (the user-visible workaround for
+      // plane-only trouble, and the only path a session without a Wayland
+      // compositor - X11 or XWayland - can use); anything else prefers the
+      // Wayland plane and falls back when the plane cannot be brought up.
       final result = await invoke<Object>('initialize', {
         if (!audioOnly) 'hardwareDecoding': _hardwareDecoding,
         'instanceId': nativeInstanceId,
+        if (usesLinuxVideoPlane) 'renderMode': SettingsService.instance.read(SettingsService.linuxVideoRenderMode),
       });
-      if (result != true) {
+      if (result is int) {
+        // Linux texture path: the native side registers the texture and
+        // returns its id immediately, but the GPU bootstrap (Flutter invoking
+        // FlTextureGL::populate, which creates the render context and the
+        // shared EGL image) completes asynchronously. Playback must not start
+        // against an unusable texture, so initialization stays gated until
+        // waitForVideoReady reports the texture usable.
+        setTextureId(result);
+        await invoke('waitForVideoReady');
+      } else if (result != true) {
         throw const PlayerInitializationException();
       }
       if (_nativeCoreUnavailable) throw StateError('Player was disposed during initialization');
@@ -311,6 +328,10 @@ class PlayerNative extends PlayerBase {
       if (_nativeCoreUnavailable) throw StateError('Player was disposed during initialization');
       initialized = true;
     } catch (e) {
+      // A texture published provisionally (Linux fallback) is not usable if
+      // initialization aborted; drop it so the Video widget stops keying off
+      // it and falls back to its other surface path.
+      setTextureId(null);
       _initFuture = null;
       if (!_nativeCoreUnavailable) {
         errorController.add(PlayerError(e.toString(), cause: PlayerError.playerInitFailed));

--- a/lib/mpv/video.dart
+++ b/lib/mpv/video.dart
@@ -123,6 +123,26 @@ class _VideoState extends State<Video> {
   }
 
   Widget _buildVideoSurface() {
+    final player = widget.player;
+    if (player is PlayerBase) {
+      // The texture id can appear after the widget is built (the Linux SDR
+      // fallback publishes it once the native side registers the texture), so
+      // the surface must rebuild on publication.
+      return ValueListenableBuilder<int?>(
+        valueListenable: player.textureIdListenable,
+        builder: (context, textureId, _) => _buildVideoSurfaceForId(textureId),
+      );
+    }
+    // Every backend that can publish a texture id is a PlayerBase; anything
+    // else presents through its own surface.
+    return _buildVideoSurfaceForId(null);
+  }
+
+  Widget _buildVideoSurfaceForId(int? textureId) {
+    if (textureId != null) {
+      // Linux SDR fallback: video arrives as a GL texture Flutter composites.
+      return Texture(textureId: textureId);
+    }
     if (widget.player is VideoRectSupport) {
       return LayoutBuilder(
         builder: (context, constraints) {

--- a/lib/screens/settings/playback_settings_screen.dart
+++ b/lib/screens/settings/playback_settings_screen.dart
@@ -79,6 +79,7 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
                 _hardwareDecodingTile(),
                 if (exoActive) _playbackBufferTile(),
                 if (exoActive) _tunneledPlaybackTile(),
+                if (Platform.isLinux) _linuxVideoRenderModeTile(),
                 if (PlatformDetector.supportsPictureInPicture()) _autoPipTile(),
               ],
             ),
@@ -566,6 +567,19 @@ class _PlaybackSettingsScreenState extends State<PlaybackSettingsScreen> {
     DvConversionModePreference.dv81 => t.settings.dvConversionDv81,
     DvConversionModePreference.hevcStrip => t.settings.dvConversionHevcStrip,
   };
+
+  Widget _linuxVideoRenderModeTile() => SettingSelectionTile<String>(
+    pref: SettingsService.linuxVideoRenderMode,
+    icon: Symbols.video_settings_rounded,
+    title: t.settings.linuxVideoRenderMode,
+    subtitleBuilder: (mode) =>
+        '${mode == 'texture' ? t.settings.linuxVideoRenderModeTexture : t.settings.linuxVideoRenderModeAuto}'
+        ' · ${t.settings.linuxVideoRenderModeDescription}',
+    options: [
+      DialogOption(value: 'auto', title: t.settings.linuxVideoRenderModeAuto),
+      DialogOption(value: 'texture', title: t.settings.linuxVideoRenderModeTexture),
+    ],
+  );
 
   Widget _playbackBufferTile() => SettingSelectionTile<PlaybackBufferTier>(
     pref: SettingsService.playbackBufferTier,

--- a/lib/screens/video_player/parts/build.dart
+++ b/lib/screens/video_player/parts/build.dart
@@ -96,6 +96,42 @@ extension _VideoPlayerBuildMethods on VideoPlayerScreenState {
     );
   }
 
+  /// The surface shown while the player initializes.
+  ///
+  /// On the Linux texture fallback this is load-bearing rather than cosmetic.
+  /// `initialize` registers the texture and returns its id immediately, then
+  /// blocks on `waitForVideoReady` until the GPU bootstrap settles - and that
+  /// bootstrap runs inside FlTextureGL::populate, which Flutter only calls for
+  /// a texture that is in the layer tree. With nothing mounted the two wait on
+  /// each other and initialization dies on its five-second deadline
+  /// ("Video texture did not become ready before the initialization
+  /// deadline"), which is exactly what a Steam Deck saw from 2.14.0.
+  ///
+  /// Mounting the texture here breaks the cycle. The Wayland plane publishes
+  /// no texture id, so on that path this mounts nothing and the loading cover
+  /// is all there is.
+  Widget _buildPlayerInitializationSurface() {
+    final bootstrapPlayer = _bootstrapPlayer;
+    if (bootstrapPlayer is! PlayerBase) return _buildLoadingSpinner();
+
+    // Framed exactly like _buildLoadingSpinner so the cover looks identical
+    // either way and the Stack gets the bounded constraints it expands into.
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          ValueListenableBuilder<int?>(
+            valueListenable: bootstrapPlayer.textureIdListenable,
+            builder: (context, textureId, _) =>
+                textureId == null ? const SizedBox.shrink() : Texture(textureId: textureId),
+          ),
+          const Center(child: PlayerLoadingIndicator()),
+        ],
+      ),
+    );
+  }
+
   Widget _buildInitializationError(String message) {
     return Scaffold(
       backgroundColor: Colors.black,

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -428,6 +428,10 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
   static bool isNavigationActive(VideoPlayerLaunchIdentity identity) => _activeRouteGuard.blocks(identity);
 
   Player? player;
+  /// The player being initialized, while it still is. Only set on the Linux
+  /// texture path, whose bootstrap needs its texture on screen before
+  /// initialization can finish — see [_buildPlayerInitializationSurface].
+  Player? _bootstrapPlayer;
   VideoVolumeController? _volumeController;
   bool _isPlayerInitialized = false;
   String? _playerInitializationError;
@@ -1144,6 +1148,9 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
     if (identical(player, attemptPlayer)) {
       player = null;
     }
+    if (identical(_bootstrapPlayer, attemptPlayer)) {
+      _bootstrapPlayer = null;
+    }
     try {
       await _tearDownFailedPlayerAttempt(attemptPlayer);
     } catch (e, st) {
@@ -1289,6 +1296,9 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
       final currentPlayer = Player(useExoPlayer: useExoPlayer, hardwareDecoding: enableHardwareDecoding);
       attemptPlayer = currentPlayer;
       if (!mounted || generation != _playerInitializationGeneration) return;
+      if (currentPlayer is PlayerNative && currentPlayer.requiresProvisionalTextureSurface) {
+        setState(() => _bootstrapPlayer = currentPlayer);
+      }
       if (Platform.isAndroid && useExoPlayer) {
         await currentPlayer.setLogLevel(debugLoggingEnabled ? 'v' : 'warn');
         if (!mounted || generation != _playerInitializationGeneration) return;
@@ -1591,7 +1601,10 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
       if (!_ownsPlayerInitializationAttempt(generation, currentPlayer)) return;
 
       if (mounted) {
-        setState(() => _isPlayerInitialized = true);
+        setState(() {
+          _isPlayerInitialized = true;
+          _bootstrapPlayer = null;
+        });
 
         // Restart sleep timer if we're starting a new playback session
         SleepTimerService().restartIfNeeded(() => unawaited(_pauseWithPlaybackIntent(currentPlayer)));
@@ -2369,7 +2382,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
               ? _buildVideoPlayer(sheetContext)
               : (_playerInitializationError != null
                     ? _buildInitializationError(_playerInitializationError!)
-                    : _buildLoadingSpinner()),
+                    : _buildPlayerInitializationSurface()),
         ),
       ),
     );

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -428,6 +428,7 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
   static bool isNavigationActive(VideoPlayerLaunchIdentity identity) => _activeRouteGuard.blocks(identity);
 
   Player? player;
+
   /// The player being initialized, while it still is. Only set on the Linux
   /// texture path, whose bootstrap needs its texture on screen before
   /// initialization can finish — see [_buildPlayerInitializationSurface].

--- a/lib/screens/video_player_screen.dart
+++ b/lib/screens/video_player_screen.dart
@@ -1959,8 +1959,19 @@ class VideoPlayerScreenState extends State<VideoPlayerScreen> with WidgetsBindin
     final volumeController = _volumeController;
     _volumeController = null;
     volumeController?.dispose();
-    final playerToDispose = player;
+    // `player` is only assigned once initialization commits, so leaving during
+    // startup would otherwise dispose nothing here and leave the in-flight core
+    // to the rollback in _initializePlayer's finally. On the Linux texture path
+    // that finally is parked behind `waitForVideoReady`, whose bootstrap can no
+    // longer finish - the provisional surface just unmounted, so Flutter will
+    // never populate the texture again - so it would wait out the native
+    // five-second deadline holding an mpv core, and PlaybackCoordinator would
+    // make the next video wait behind it. Disposing the bootstrap player here
+    // answers that pending call at once ("Video initialization was cancelled");
+    // the rollback's own dispose is a no-op afterwards.
+    final playerToDispose = player ?? _bootstrapPlayer;
     player = null;
+    _bootstrapPlayer = null;
     if (playerToDispose != null) {
       // Keep the native display mode (tvOS HDMI criteria) across a
       // player→player handoff; the replacement screen primes its own.

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -450,6 +450,14 @@ class SettingsService extends BaseSharedPreferencesService {
   static const audioSyncOffset = IntPref('audio_sync_offset');
   static const subtitleSyncOffset = IntPref('subtitle_sync_offset');
   static const subtitleSearchLanguage = NullableStringPref('subtitle_search_language');
+
+  /// Linux video rendering mode. 'auto' prefers the native Wayland plane and
+  /// falls back to the Flutter-texture path when the plane cannot be brought
+  /// up (X11/XWayland sessions, failed plane bootstrap); 'texture' forces the
+  /// texture path (SDR only) — the user-visible workaround for plane-only
+  /// trouble, and the exact environment hardware decode worked in before the
+  /// plane existed.
+  static const linuxVideoRenderMode = StringPref('linux_video_render_mode', defaultValue: 'auto');
   static const volume = DoublePref('volume', defaultValue: 100.0);
   static const rotationLocked = BoolPref('rotation_locked', defaultValue: true);
   static const subtitleFontSize = IntPref('subtitle_font_size', defaultValue: 38);
@@ -1171,6 +1179,7 @@ class SettingsService extends BaseSharedPreferencesService {
     audioNormalization,
     audioDownmix,
     audioDownmixNormalize,
+    linuxVideoRenderMode,
     appLocale,
     autoPip,
     maxVolume,

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -4,8 +4,10 @@ project(runner LANGUAGES CXX)
 add_executable(${BINARY_NAME}
   "main.cc"
   "my_application.cc"
+  "mpv/mpv_gpu_bootstrap.cc"
   "mpv/mpv_player.cc"
   "mpv/mpv_plugin.cc"
+  "mpv/mpv_texture.cc"
   "mpv/plane_render_executor.cc"
   "mpv/wayland_video_surface.cc"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"

--- a/linux/runner/mpv/mpv_gpu_bootstrap.cc
+++ b/linux/runner/mpv/mpv_gpu_bootstrap.cc
@@ -1,0 +1,129 @@
+#include "mpv_gpu_bootstrap.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace mpv {
+namespace {
+
+bool HasExtension(const char* extensions, const char* requested) {
+  if (!extensions || !requested || requested[0] == '\0' || std::strchr(requested, ' ')) return false;
+  const size_t requested_length = std::strlen(requested);
+  const char* current = extensions;
+  while ((current = std::strstr(current, requested)) != nullptr) {
+    const bool starts_token = current == extensions || current[-1] == ' ';
+    const char following = current[requested_length];
+    if (starts_token && (following == '\0' || following == ' ')) return true;
+    current += requested_length;
+  }
+  return false;
+}
+
+bool ParseEglVersion(const char* version, int* major, int* minor) {
+  if (!version || !major || !minor) return false;
+  char* end = nullptr;
+  const long parsed_major = std::strtol(version, &end, 10);
+  if (end == version || *end != '.') return false;
+  const char* minor_start = end + 1;
+  const long parsed_minor = std::strtol(minor_start, &end, 10);
+  if (end == minor_start || parsed_major < 0 || parsed_minor < 0) return false;
+  *major = static_cast<int>(parsed_major);
+  *minor = static_cast<int>(parsed_minor);
+  return true;
+}
+
+bool AtLeastEgl15(const GpuBootstrapProbe& probe) {
+  return probe.egl_major > 1 || (probe.egl_major == 1 && probe.egl_minor >= 5);
+}
+
+bool Fail(std::string* error, const char* message) {
+  if (error) *error = message;
+  return false;
+}
+
+}  // namespace
+
+EGLImageKHR GpuImageDispatch::Create(EGLDisplay display, EGLContext context, EGLClientBuffer buffer) const {
+  if (uses_core) {
+    if (!create_image_core) return EGL_NO_IMAGE_KHR;
+    const EGLAttrib attributes[] = {EGL_NONE};
+    return reinterpret_cast<EGLImageKHR>(
+        create_image_core(display, context, EGL_GL_TEXTURE_2D_KHR, buffer, attributes));
+  }
+  if (!create_image_khr) return EGL_NO_IMAGE_KHR;
+  const EGLint attributes[] = {EGL_NONE};
+  return create_image_khr(display, context, EGL_GL_TEXTURE_2D_KHR, buffer, attributes);
+}
+
+bool GpuImageDispatch::Destroy(EGLDisplay display, EGLImageKHR image) const {
+  if (image == EGL_NO_IMAGE_KHR) return true;
+  if (uses_core) {
+    return destroy_image_core && destroy_image_core(display, reinterpret_cast<EGLImage>(image)) == EGL_TRUE;
+  }
+  return destroy_image_khr && destroy_image_khr(display, image) == EGL_TRUE;
+}
+
+GpuImageDispatch::operator bool() const {
+  const bool image_functions =
+      uses_core ? create_image_core && destroy_image_core : create_image_khr && destroy_image_khr;
+  return image_functions && image_target_texture;
+}
+
+bool ValidateGpuBootstrapProbe(const GpuBootstrapProbe& probe, std::string* error) {
+  const bool egl15 = AtLeastEgl15(probe);
+  if (!egl15 && !HasExtension(probe.egl_extensions, "EGL_KHR_surfaceless_context")) {
+    return Fail(error, "EGL surfaceless contexts are unavailable");
+  }
+
+  const bool core_images = egl15 && probe.create_image_core && probe.destroy_image_core;
+  const bool has_khr_image_extension =
+      HasExtension(probe.egl_extensions, "EGL_KHR_image") || HasExtension(probe.egl_extensions, "EGL_KHR_image_base");
+  const bool khr_images = has_khr_image_extension && probe.create_image_khr && probe.destroy_image_khr;
+  if (!core_images && !khr_images) {
+    return Fail(error, "EGL image creation is unavailable");
+  }
+  if (!HasExtension(probe.gl_extensions, "GL_OES_EGL_image")) {
+    return Fail(error, "OpenGL EGL image binding is unavailable");
+  }
+  if (!probe.image_target_texture) {
+    return Fail(error, "OpenGL EGL image entry point is unavailable");
+  }
+  if (error) error->clear();
+  return true;
+}
+
+bool ResolveGpuImageDispatch(EGLDisplay display, GpuImageDispatch* dispatch, std::string* error) {
+  if (!dispatch || display == EGL_NO_DISPLAY || eglGetCurrentContext() == EGL_NO_CONTEXT) {
+    return Fail(error, "No current EGL context is available");
+  }
+
+  GpuBootstrapProbe probe;
+  if (!ParseEglVersion(eglQueryString(display, EGL_VERSION), &probe.egl_major, &probe.egl_minor)) {
+    return Fail(error, "EGL version is unavailable");
+  }
+  probe.egl_extensions = eglQueryString(display, EGL_EXTENSIONS);
+  probe.gl_extensions = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
+  probe.create_image_core = reinterpret_cast<void*>(eglGetProcAddress("eglCreateImage"));
+  probe.destroy_image_core = reinterpret_cast<void*>(eglGetProcAddress("eglDestroyImage"));
+  probe.create_image_khr = reinterpret_cast<void*>(eglGetProcAddress("eglCreateImageKHR"));
+  probe.destroy_image_khr = reinterpret_cast<void*>(eglGetProcAddress("eglDestroyImageKHR"));
+  probe.image_target_texture = reinterpret_cast<void*>(eglGetProcAddress("glEGLImageTargetTexture2DOES"));
+  if (!ValidateGpuBootstrapProbe(probe, error)) return false;
+
+  GpuImageDispatch resolved;
+  const bool egl15 = AtLeastEgl15(probe);
+  if (egl15 && probe.create_image_core && probe.destroy_image_core) {
+    resolved.uses_core = true;
+    resolved.create_image_core = reinterpret_cast<EglCreateImageCoreProc>(probe.create_image_core);
+    resolved.destroy_image_core = reinterpret_cast<EglDestroyImageCoreProc>(probe.destroy_image_core);
+  } else {
+    resolved.create_image_khr = reinterpret_cast<EglCreateImageKhrProc>(probe.create_image_khr);
+    resolved.destroy_image_khr = reinterpret_cast<EglDestroyImageKhrProc>(probe.destroy_image_khr);
+  }
+  resolved.image_target_texture = reinterpret_cast<GlImageTargetTextureProc>(probe.image_target_texture);
+  if (!resolved) return Fail(error, "GPU image dispatch is incomplete");
+  *dispatch = resolved;
+  return true;
+}
+
+}  // namespace mpv

--- a/linux/runner/mpv/mpv_gpu_bootstrap.h
+++ b/linux/runner/mpv/mpv_gpu_bootstrap.h
@@ -1,0 +1,47 @@
+#ifndef MPV_GPU_BOOTSTRAP_H_
+#define MPV_GPU_BOOTSTRAP_H_
+
+#include <epoxy/egl.h>
+#include <epoxy/gl.h>
+
+#include <string>
+
+namespace mpv {
+
+using EglCreateImageCoreProc = EGLImage (*)(EGLDisplay, EGLContext, EGLenum, EGLClientBuffer, const EGLAttrib*);
+using EglDestroyImageCoreProc = EGLBoolean (*)(EGLDisplay, EGLImage);
+using EglCreateImageKhrProc = EGLImageKHR (*)(EGLDisplay, EGLContext, EGLenum, EGLClientBuffer, const EGLint*);
+using EglDestroyImageKhrProc = EGLBoolean (*)(EGLDisplay, EGLImageKHR);
+using GlImageTargetTextureProc = void (*)(GLenum, GLeglImageOES);
+
+struct GpuBootstrapProbe {
+  int egl_major = 0;
+  int egl_minor = 0;
+  const char* egl_extensions = nullptr;
+  const char* gl_extensions = nullptr;
+  void* create_image_core = nullptr;
+  void* destroy_image_core = nullptr;
+  void* create_image_khr = nullptr;
+  void* destroy_image_khr = nullptr;
+  void* image_target_texture = nullptr;
+};
+
+struct GpuImageDispatch {
+  bool uses_core = false;
+  EglCreateImageCoreProc create_image_core = nullptr;
+  EglDestroyImageCoreProc destroy_image_core = nullptr;
+  EglCreateImageKhrProc create_image_khr = nullptr;
+  EglDestroyImageKhrProc destroy_image_khr = nullptr;
+  GlImageTargetTextureProc image_target_texture = nullptr;
+
+  EGLImageKHR Create(EGLDisplay display, EGLContext context, EGLClientBuffer buffer) const;
+  bool Destroy(EGLDisplay display, EGLImageKHR image) const;
+  explicit operator bool() const;
+};
+
+bool ValidateGpuBootstrapProbe(const GpuBootstrapProbe& probe, std::string* error);
+bool ResolveGpuImageDispatch(EGLDisplay display, GpuImageDispatch* dispatch, std::string* error);
+
+}  // namespace mpv
+
+#endif  // MPV_GPU_BOOTSTRAP_H_

--- a/linux/runner/mpv/mpv_player.cc
+++ b/linux/runner/mpv/mpv_player.cc
@@ -8,6 +8,9 @@
 #ifdef GDK_WINDOWING_WAYLAND
 #include <gdk/gdkwayland.h>
 #endif
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
 #include <locale.h>
 
 // EGL 1.5 names; EGL_KHR_create_context introduced the same values earlier.
@@ -605,6 +608,190 @@ bool MpvPlayer::InitRenderContextForSurface(EGLDisplay display, EGLConfig config
   }
   g_message("MPV: Render context created on the Wayland video plane");
   return true;
+}
+
+bool MpvPlayer::InitRenderContext() {
+  RetryPendingNativeTeardown();
+
+  std::lock_guard<std::mutex> lock(native_mutex_);
+  if (audio_only_ || disposed_) {
+    g_warning("MPV: Render context requested for an unavailable player");
+    return false;
+  }
+  if (mpv_gl_) return true;
+  if (!mpv_) {
+    g_warning("MPV: Cannot create render context - mpv not initialized");
+    return false;
+  }
+
+  // The texture path rides Flutter's EGL display and derives an isolated
+  // context from Flutter's config, exactly as 2.11.0 did: the mpv FBO is
+  // sampled by Flutter via an EGL image, so both sides must speak the same
+  // display's formats. The caller (FlTextureGL::populate) has Flutter's
+  // context current; capture it and restore it around every GL/EGL step
+  // below, since mpv's render context creation may bind its own.
+  const EGLDisplay flutter_display = eglGetCurrentDisplay();
+  const EGLContext flutter_context = eglGetCurrentContext();
+  const EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
+  const EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
+  const EGLenum previous_api = eglQueryAPI();
+  if (flutter_display == EGL_NO_DISPLAY || flutter_context == EGL_NO_CONTEXT || previous_api == EGL_NONE) {
+    g_warning("MPV: No Flutter EGL context available for the texture render path");
+    return false;
+  }
+
+  auto restore_flutter = [&]() {
+    const EGLBoolean api_restored = previous_api == EGL_NONE ? EGL_TRUE : eglBindAPI(previous_api);
+    const EGLBoolean restored = api_restored == EGL_TRUE
+                                    ? eglMakeCurrent(flutter_display, flutter_draw, flutter_read, flutter_context)
+                                    : EGL_FALSE;
+    return restored == EGL_TRUE && api_restored == EGL_TRUE;
+  };
+
+  EGLint config_id = 0;
+  if (!eglQueryContext(flutter_display, flutter_context, EGL_CONFIG_ID, &config_id)) {
+    g_warning("MPV: Failed to query Flutter EGL config: 0x%x", eglGetError());
+    return false;
+  }
+  EGLConfig config = nullptr;
+  EGLint num_configs = 0;
+  const EGLint config_attribs[] = {EGL_CONFIG_ID, config_id, EGL_NONE};
+  if (!eglChooseConfig(flutter_display, config_attribs, &config, 1, &num_configs) || num_configs != 1) {
+    g_warning("MPV: Failed to select Flutter EGL config: 0x%x", eglGetError());
+    return false;
+  }
+  if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+    g_warning("MPV: Failed to bind OpenGL ES API: 0x%x", eglGetError());
+    return false;
+  }
+
+  // ES 2.0, as 2.11.0 shipped: this path exists to reproduce a configuration
+  // hardware decode demonstrably worked against, not to push the driver.
+  const EGLint context_attribs[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
+  EGLContext candidate_context = eglCreateContext(flutter_display, config, EGL_NO_CONTEXT, context_attribs);
+  if (candidate_context == EGL_NO_CONTEXT) {
+    g_warning("MPV: Failed to create isolated EGL context: 0x%x", eglGetError());
+    if (previous_api != EGL_NONE && !eglBindAPI(previous_api)) {
+      g_warning("MPV: Failed to restore EGL client API: 0x%x", eglGetError());
+    }
+    return false;
+  }
+
+  auto destroy_candidate_context = [&]() {
+    const EGLenum api_before_cleanup = eglQueryAPI();
+    if (eglGetCurrentContext() == candidate_context) {
+      if (!eglBindAPI(EGL_OPENGL_ES_API) ||
+          !eglMakeCurrent(flutter_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+        g_warning("MPV: Failed to release rejected EGL context: 0x%x", eglGetError());
+        return;
+      }
+    }
+    if (!eglDestroyContext(flutter_display, candidate_context)) {
+      g_warning("MPV: Failed to destroy rejected EGL context: 0x%x", eglGetError());
+    }
+    if (api_before_cleanup != EGL_NONE && !eglBindAPI(api_before_cleanup)) {
+      g_warning("MPV: Failed to restore EGL API after context cleanup: 0x%x", eglGetError());
+    }
+  };
+
+  if (!eglMakeCurrent(flutter_display, EGL_NO_SURFACE, EGL_NO_SURFACE, candidate_context)) {
+    g_warning("MPV: Failed to activate isolated EGL context: 0x%x", eglGetError());
+    destroy_candidate_context();
+    if (previous_api != EGL_NONE && !eglBindAPI(previous_api)) {
+      g_warning("MPV: Failed to restore EGL client API: 0x%x", eglGetError());
+    }
+    return false;
+  }
+
+  mpv_opengl_init_params gl_init_params{};
+  gl_init_params.get_proc_address = get_opengl_proc_address;
+  gl_init_params.get_proc_address_ctx = nullptr;
+  mpv_render_param params[] = {
+      {MPV_RENDER_PARAM_API_TYPE, const_cast<char*>(MPV_RENDER_API_TYPE_OPENGL)},
+      {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &gl_init_params},
+      {MPV_RENDER_PARAM_INVALID, nullptr},
+      {MPV_RENDER_PARAM_INVALID, nullptr},
+  };
+
+  // The display handle for hwdec interop, whichever session this is: the
+  // texture path is display-agnostic and must work under both X11 and
+  // Wayland, so both slots are offered exactly as 2.11.0 did.
+  GdkDisplay* gdk_display = gdk_display_get_default();
+#ifdef GDK_WINDOWING_WAYLAND
+  if (gdk_display != nullptr && GDK_IS_WAYLAND_DISPLAY(gdk_display)) {
+    params[2].type = MPV_RENDER_PARAM_WL_DISPLAY;
+    params[2].data = gdk_wayland_display_get_wl_display(gdk_display);
+  }
+#endif
+#ifdef GDK_WINDOWING_X11
+  if (gdk_display != nullptr && GDK_IS_X11_DISPLAY(gdk_display)) {
+    params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
+    params[2].data = gdk_x11_display_get_xdisplay(gdk_display);
+  }
+#endif
+
+  mpv_render_context* candidate_gl = nullptr;
+  const int error = mpv_render_context_create(&candidate_gl, mpv_, params);
+  const bool restored = restore_flutter();
+  if (error < 0 || candidate_gl == nullptr || !restored) {
+    if (error < 0) {
+      g_warning("MPV: mpv_render_context_create() failed for the texture path: %s", mpv_error_string(error));
+    } else if (!restored) {
+      g_warning("MPV: Failed to restore Flutter EGL state: 0x%x", eglGetError());
+    } else {
+      g_warning("MPV: mpv returned a null render context for the texture path");
+    }
+    if (candidate_gl) mpv_render_context_free(candidate_gl);
+    destroy_candidate_context();
+    return false;
+  }
+
+  egl_display_ = flutter_display;
+  egl_context_ = candidate_context;
+  // The texture path renders into an 8-bit RGBA FBO; tell mpv the depth is 8
+  // so it dithers for the format it actually draws into.
+  surface_depth_bits_ = 8;
+  mpv_gl_ = candidate_gl;
+  mpv_render_context_set_update_callback(mpv_gl_, OnMpvRenderUpdate, callback_context_.get());
+  g_message("MPV: Render context created on the Flutter-texture path");
+  return true;
+}
+
+bool MpvPlayer::HasRenderContext() const {
+  std::lock_guard<std::mutex> lock(native_mutex_);
+  return mpv_gl_ != nullptr;
+}
+
+EGLDisplay MpvPlayer::GetEglDisplay() const {
+  std::lock_guard<std::mutex> lock(native_mutex_);
+  return egl_display_;
+}
+
+EGLContext MpvPlayer::GetEglContext() const {
+  std::lock_guard<std::mutex> lock(native_mutex_);
+  return egl_context_;
+}
+
+void MpvPlayer::Render(int width, int height, int fbo) {
+  std::lock_guard<std::mutex> lock(native_mutex_);
+  if (disposed_ || !mpv_gl_) return;
+
+  mpv_opengl_fbo mpv_fbo{};
+  mpv_fbo.fbo = fbo;
+  mpv_fbo.w = width;
+  mpv_fbo.h = height;
+  // 2.11.0 shipped this path with internal_format 0 and no flip: the FBO is
+  // sampled by Flutter as a GL texture, and the orientation was correct with
+  // these exact values. Keep them.
+  mpv_fbo.internal_format = 0;
+
+  int flip_y = 0;
+  mpv_render_param params[] = {
+      {MPV_RENDER_PARAM_OPENGL_FBO, &mpv_fbo},
+      {MPV_RENDER_PARAM_FLIP_Y, &flip_y},
+      {MPV_RENDER_PARAM_INVALID, nullptr},
+  };
+  mpv_render_context_render(mpv_gl_, params);
 }
 
 bool MpvPlayer::RenderToSurface(EGLSurface surface, int width, int height) {

--- a/linux/runner/mpv/mpv_player.h
+++ b/linux/runner/mpv/mpv_player.h
@@ -98,6 +98,36 @@ class MpvPlayer {
   /// @return true if render context creation succeeded.
   bool InitRenderContextForSurface(EGLDisplay display, EGLConfig config, EGLSurface surface, int depth_bits);
 
+  /// Creates the mpv render context on an isolated ES 2.0 context derived
+  /// from Flutter's current EGL display and config — the 2.11.0 texture path,
+  /// restored as the SDR fallback for sessions that cannot host the Wayland
+  /// plane (X11, XWayland, or a plane that failed to initialize). Shares
+  /// nothing with Flutter's own context beyond the display (the isolated-
+  /// context design from 3d9c6b20), and must be called while Flutter's EGL
+  /// context is current — the texture's populate path is what guarantees
+  /// that. The texture mode also passes the X11 display handle where present,
+  /// which is what makes hwdec interop work under XWayland exactly as it did
+  /// in 2.11.0. No-op once a render context exists in either mode.
+  /// @return true if render context creation succeeded.
+  bool InitRenderContext();
+
+  /// Whether a render context exists (either mode).
+  bool HasRenderContext() const;
+
+  /// The EGL display/context backing the render context, for callers that
+  /// need to activate it (the texture path renders into an offscreen FBO
+  /// created in this context).
+  EGLDisplay GetEglDisplay() const;
+  EGLContext GetEglContext() const;
+
+  /// Renders one frame into the caller's FBO (texture mode). The caller owns
+  /// the current EGL context and FBO binding; this mirrors the 2.11.0
+  /// contract exactly — it does not make the context current and does not
+  /// consume the redraw latch (MpvTexturePopulate clears the latch first, and
+  /// the latch is what keeps Flutter's populate from being invoked
+  /// needlessly).
+  void Render(int width, int height, int fbo);
+
   /// Renders one frame into |surface|'s default framebuffer. The caller
   /// presents it (eglSwapBuffers) once this returns.
   ///

--- a/linux/runner/mpv/mpv_plugin.cc
+++ b/linux/runner/mpv/mpv_plugin.cc
@@ -8,12 +8,18 @@
 #include <new>
 #include <optional>
 
+#include "mpv_texture.h"
 #include "plane_render_executor.h"
 #include "wayland_video_surface.h"
 
 using PlayerPtr = std::unique_ptr<mpv::MpvPlayer>;
 using VideoSurfacePtr = std::unique_ptr<mpv::WaylandVideoSurface>;
 using ExecutorPtr = std::unique_ptr<mpv::PlaneRenderExecutor>;
+
+// Texture-bootstrap state machine (the SDR fallback path). kIdle means no
+// texture session exists; kPending means a texture is registered and Flutter
+// has been asked to populate it; kReady/kFailed are terminal for the session.
+enum class VideoBootstrapState { kIdle, kPending, kReady, kFailed };
 
 // One queued HDR transaction: what to apply, and who to tell when it settles.
 //
@@ -39,9 +45,24 @@ struct _MpvPlugin {
 
   PlayerPtr player;
   // The native Wayland plane every video instance renders into. Non-null once
-  // initialize() has brought it up; there is no second render path, so a null
-  // here on a video instance means initialization refused.
+  // initialize() has brought it up. Where the plane cannot be brought up -
+  // X11/XWayland sessions, a failed EGL bootstrap - the Flutter-texture path
+  // (2.11.0's renderer) takes over as the SDR fallback, and a null plane with
+  // a non-null texture means texture mode.
   VideoSurfacePtr video_surface;
+  FlTextureRegistrar* texture_registrar;
+  // The fallback render path: an FlTextureGL whose populate renders mpv into
+  // an offscreen FBO sampled by Flutter. Owned via GObject ref; the plugin
+  // keeps the player alive for it. Non-null only when a texture session has
+  // been bootstrapped.
+  MpvTexture* texture;  // owned via GObject ref
+  gboolean texture_registered;
+  VideoBootstrapState bootstrap_state;
+  gchar* bootstrap_error;
+  // The one waitForVideoReady method call outstanding, answered when the
+  // texture's GPU bootstrap settles or the 5 s deadline expires.
+  FlMethodCall* ready_call;
+  guint ready_timeout_source_id;
   // Set when the plane must be redrawn even though mpv has no new frame -
   // after a resize or after becoming visible, where the buffer on screen is
   // stale or absent. Sticky, because the render it asks for may first have to
@@ -215,6 +236,97 @@ static void send_named_event(MpvPlugin* self, const char* name) {
   send_event(self, event);
 }
 
+static gboolean handle_ready_timeout(gpointer user_data);
+static void complete_ready_call(MpvPlugin* self, gboolean success, const char* message) {
+  if (self->ready_timeout_source_id != 0) {
+    g_source_remove(self->ready_timeout_source_id);
+    self->ready_timeout_source_id = 0;
+  }
+  if (!self->ready_call) return;
+  g_autoptr(FlMethodResponse) response =
+      success ? FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr))
+              : FL_METHOD_RESPONSE(fl_method_error_response_new(
+                    "INIT_FAILED", message ? message : "Video initialization failed", nullptr));
+  fl_method_call_respond(self->ready_call, response, nullptr);
+  g_object_unref(self->ready_call);
+  self->ready_call = nullptr;
+}
+
+// The texture's populate callback runs on Flutter's raster thread, so the
+// outcome is bounced to the GTK main context before touching the plugin's
+// state.
+struct TextureReadyContext {
+  MpvPlugin* plugin;  // g_object_ref'd
+  guint64 generation;
+};
+
+struct TextureReadyResult {
+  MpvPlugin* plugin;  // owns a ref
+  guint64 generation;
+  gboolean success;
+  gchar* message;
+};
+
+static gboolean handle_texture_ready_result(gpointer data) {
+  auto* result = static_cast<TextureReadyResult*>(data);
+  MpvPlugin* self = result->plugin;
+  if (result->generation != self->generation || self->bootstrap_state != VideoBootstrapState::kPending) {
+    return G_SOURCE_REMOVE;
+  }
+
+  if (result->success) {
+    self->bootstrap_state = VideoBootstrapState::kReady;
+    self->initialized = TRUE;
+    complete_ready_call(self, TRUE, nullptr);
+  } else {
+    self->bootstrap_state = VideoBootstrapState::kFailed;
+    g_free(self->bootstrap_error);
+    self->bootstrap_error = g_strdup(result->message ? result->message : "Video initialization failed");
+    complete_ready_call(self, FALSE, self->bootstrap_error);
+    release_video_resources(self);
+  }
+  return G_SOURCE_REMOVE;
+}
+
+static void destroy_texture_ready_result(gpointer data) {
+  auto* result = static_cast<TextureReadyResult*>(data);
+  g_object_unref(result->plugin);
+  g_free(result->message);
+  delete result;
+}
+
+static void on_texture_ready(gboolean success, const gchar* message, gpointer user_data) {
+  auto* context = static_cast<TextureReadyContext*>(user_data);
+  auto* result = new TextureReadyResult{
+      MPV_PLUGIN(g_object_ref(context->plugin)),
+      context->generation,
+      success,
+      g_strdup(message),
+  };
+  g_main_context_invoke_full(
+      nullptr, G_PRIORITY_DEFAULT, handle_texture_ready_result, result, destroy_texture_ready_result);
+}
+
+static void destroy_texture_ready_context(gpointer data) {
+  auto* context = static_cast<TextureReadyContext*>(data);
+  g_object_unref(context->plugin);
+  delete context;
+}
+
+static gboolean handle_ready_timeout(gpointer user_data) {
+  MpvPlugin* self = MPV_PLUGIN(user_data);
+  self->ready_timeout_source_id = 0;
+  if (self->bootstrap_state != VideoBootstrapState::kPending || !self->ready_call) {
+    return G_SOURCE_REMOVE;
+  }
+  self->bootstrap_state = VideoBootstrapState::kFailed;
+  g_free(self->bootstrap_error);
+  self->bootstrap_error = g_strdup("Video texture did not become ready before the initialization deadline");
+  complete_ready_call(self, FALSE, self->bootstrap_error);
+  release_video_resources(self);
+  return G_SOURCE_REMOVE;
+}
+
 static void release_video_resources(MpvPlugin* self) {
   // Anything still in flight is now answering for a plane that is going away.
   ++self->generation;
@@ -224,6 +336,7 @@ static void release_video_resources(MpvPlugin* self) {
     g_source_remove(self->hdr_mpv_leg_timeout_source_);
     self->hdr_mpv_leg_timeout_source_ = 0;
   }
+  complete_ready_call(self, FALSE, "Video initialization was cancelled");
   // Queued transactions will never run, and each may be holding a reference to a
   // Dart method call that has to be answered or it is leaked along with its
   // response.
@@ -275,12 +388,25 @@ static void release_video_resources(MpvPlugin* self) {
     if (self->video_surface) self->video_surface.release();
   }
   if (self->player) {
-    // The plane is a raw callback target. Revoke every callback path before
-    // tearing it down; Dispose then drains any callback already holding a
-    // native lease.
+    // The plane and the texture are raw callback targets. Revoke every
+    // callback path before tearing either down; Dispose then drains any
+    // callback already holding a native lease.
     self->player->SetRedrawCallback(nullptr);
     self->player->SetSourceMetadataCallback(nullptr);
     self->player->SetEventCallback(nullptr);
+  }
+  if (self->texture) {
+    // Texture must be disposed BEFORE the player — mpv_texture_dispose needs
+    // the player's EGL context to clean up GL resources.
+    if (self->texture_registered && self->texture_registrar) {
+      fl_texture_registrar_unregister_texture(self->texture_registrar, FL_TEXTURE(self->texture));
+      self->texture_registered = FALSE;
+    }
+    mpv_texture_dispose(self->texture);
+    g_object_unref(self->texture);
+    self->texture = nullptr;
+  }
+  if (self->player) {
     self->player->Dispose();
     self->player.reset();
   }
@@ -294,6 +420,8 @@ static void release_video_resources(MpvPlugin* self) {
   self->initialized = FALSE;
   self->visible = FALSE;
   self->plane_needs_render = FALSE;
+  self->bootstrap_state = VideoBootstrapState::kIdle;
+  g_clear_pointer(&self->bootstrap_error, g_free);
   // All of these describe a plane and an mpv instance that no longer exist, and
   // initialize() builds both fresh: a new MpvPlayer whose applied target
   // properties are back to "auto", and a new surface with no description
@@ -1030,6 +1158,13 @@ static void mpv_plugin_init(MpvPlugin* self) {
   self->initialized = FALSE;
   self->audio_only = FALSE;
   self->generation = 0;
+  self->texture = nullptr;
+  self->texture_registered = FALSE;
+  self->texture_registrar = nullptr;
+  self->bootstrap_state = VideoBootstrapState::kIdle;
+  self->bootstrap_error = nullptr;
+  self->ready_call = nullptr;
+  self->ready_timeout_source_id = 0;
 }
 
 MpvPlugin* mpv_plugin_new(FlPluginRegistrar* registrar, const gchar* channel_name, gboolean audio_only) {
@@ -1037,6 +1172,9 @@ MpvPlugin* mpv_plugin_new(FlPluginRegistrar* registrar, const gchar* channel_nam
 
   self->registrar = FL_PLUGIN_REGISTRAR(g_object_ref(registrar));
   self->audio_only = audio_only;
+  // The audio-only core never renders; leaving the texture registrar unset
+  // makes the GL/texture path structurally unreachable for it.
+  self->texture_registrar = audio_only ? nullptr : fl_plugin_registrar_get_texture_registrar(registrar);
 
   self->player = std::make_unique<mpv::MpvPlayer>(audio_only);
 
@@ -1095,7 +1233,20 @@ static void mpv_plugin_handle_method_call(FlMethodChannel* channel, FlMethodCall
       }
     } else if (self->video_surface && self->video_surface->valid()) {
       response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(TRUE)));
+    } else if (
+        self->texture && (self->bootstrap_state == VideoBootstrapState::kPending ||
+                          self->bootstrap_state == VideoBootstrapState::kReady)) {
+      response =
+          FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_int(mpv_texture_get_id(self->texture))));
     } else {
+      // Optional 'renderMode' argument: "texture" forces the SDR
+      // Flutter-texture fallback (the user-visible workaround for plane-only
+      // trouble); anything else prefers the Wayland plane and falls back only
+      // when it cannot be brought up.
+      FlValue* render_mode_value = args != nullptr ? fl_value_lookup_string(args, "renderMode") : nullptr;
+      const bool force_texture = render_mode_value != nullptr &&
+                                 fl_value_get_type(render_mode_value) == FL_VALUE_TYPE_STRING &&
+                                 g_strcmp0(fl_value_get_string(render_mode_value), "texture") == 0;
       if (!self->player || self->player->IsDisposed()) {
         self->player = std::make_unique<mpv::MpvPlayer>();
       }
@@ -1105,22 +1256,88 @@ static void mpv_plugin_handle_method_call(FlMethodChannel* channel, FlMethodCall
         release_video_resources(self);
         response =
             FL_METHOD_RESPONSE(fl_method_error_response_new("INIT_FAILED", "Failed to initialize MPV player", nullptr));
-      } else if (start_video_plane(self, fl_plugin_registrar_get_view(self->registrar), &error)) {
-        ++self->generation;
-        self->player->SetEventCallback([self](FlValue* event) { send_event(self, event); });
-        self->initialized = TRUE;
-        response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(TRUE)));
       } else {
-        // There is no second render path. Refuse with the reason rather than
-        // presenting into something the user cannot see.
-        g_warning("MPV: no video plane: %s", error.c_str());
-        release_video_resources(self);
-        response = FL_METHOD_RESPONSE(fl_method_error_response_new("VIDEO_PLANE_UNSUPPORTED", error.c_str(), nullptr));
+        bool plane_up = false;
+        if (!force_texture) {
+          plane_up = start_video_plane(self, fl_plugin_registrar_get_view(self->registrar), &error);
+        }
+        if (plane_up) {
+          ++self->generation;
+          self->player->SetEventCallback([self](FlValue* event) { send_event(self, event); });
+          self->initialized = TRUE;
+          response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(TRUE)));
+        } else if (self->texture_registrar != nullptr) {
+          // The plane cannot host this session (X11/XWayland, or the plane
+          // bootstrap failed). Fall back to the 2.11.0 Flutter-texture path:
+          // display-agnostic, SDR only, and the exact environment hardware
+          // decode demonstrably worked in. The texture is registered
+          // immediately so Flutter can invoke FlTextureGL::populate; playback
+          // stays gated until the GPU bootstrap reports the texture usable
+          // (the Dart side awaits waitForVideoReady).
+          if (!force_texture) {
+            g_warning("MPV: no video plane (%s); falling back to the Flutter-texture path", error.c_str());
+          }
+          FlView* view = fl_plugin_registrar_get_view(self->registrar);
+          self->texture = mpv_texture_new(self->player.get(), self->texture_registrar, view);
+          ++self->generation;
+          self->bootstrap_state = VideoBootstrapState::kPending;
+          auto* ready_context = new TextureReadyContext{MPV_PLUGIN(g_object_ref(self)), self->generation};
+          mpv_texture_set_ready_callback(self->texture, on_texture_ready, ready_context, destroy_texture_ready_context);
+
+          if (!fl_texture_registrar_register_texture(self->texture_registrar, FL_TEXTURE(self->texture))) {
+            // Literal message: the response is encoded when the handler
+            // responds below, after release_video_resources has run, so
+            // nothing heap-allocated may back it.
+            response = FL_METHOD_RESPONSE(
+                fl_method_error_response_new("INIT_FAILED", "Failed to register video texture", nullptr));
+            release_video_resources(self);
+          } else {
+            self->texture_registered = TRUE;
+            MpvTexture* texture = self->texture;
+            self->player->SetRedrawCallback([texture]() { mpv_texture_mark_frame_available(texture); });
+            self->player->SetEventCallback([self](FlValue* event) { send_event(self, event); });
+            mpv_texture_mark_frame_available(self->texture);
+            response =
+                FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_int(mpv_texture_get_id(self->texture))));
+          }
+        } else {
+          // No texture registrar at all: refuse with the plane's reason
+          // rather than presenting into something the user cannot see.
+          g_warning("MPV: no video plane: %s", error.c_str());
+          release_video_resources(self);
+          response =
+              FL_METHOD_RESPONSE(fl_method_error_response_new("VIDEO_PLANE_UNSUPPORTED", error.c_str(), nullptr));
+        }
       }
     }
   } else if (strcmp(method, "dispose") == 0) {
     release_video_resources(self);
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+  } else if (strcmp(method, "waitForVideoReady") == 0) {
+    // Texture-path only: initialize returns the texture id as soon as the
+    // texture is registered, but the GPU bootstrap (FlTextureGL::populate,
+    // which creates the render context and the shared EGL image) completes
+    // asynchronously. Playback must not start against an unusable texture.
+    if (self->audio_only) {
+      response = FL_METHOD_RESPONSE(
+          fl_method_error_response_new("INIT_FAILED", "Audio players have no video readiness state", nullptr));
+    } else if (self->bootstrap_state == VideoBootstrapState::kReady && self->initialized) {
+      response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+    } else if (self->bootstrap_state == VideoBootstrapState::kFailed) {
+      response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+          "INIT_FAILED", self->bootstrap_error ? self->bootstrap_error : "Video initialization failed", nullptr));
+    } else if (self->bootstrap_state != VideoBootstrapState::kPending || !self->texture) {
+      response = FL_METHOD_RESPONSE(
+          fl_method_error_response_new("INIT_FAILED", "Video initialization is not pending", nullptr));
+    } else if (self->ready_call) {
+      response = FL_METHOD_RESPONSE(
+          fl_method_error_response_new("INIT_IN_PROGRESS", "Video readiness is already being awaited", nullptr));
+    } else {
+      self->ready_call = FL_METHOD_CALL(g_object_ref(method_call));
+      self->ready_timeout_source_id =
+          g_timeout_add_seconds_full(G_PRIORITY_DEFAULT, 5, handle_ready_timeout, g_object_ref(self), g_object_unref);
+      return;
+    }
   } else if (strcmp(method, "command") == 0) {
     if (!self->player || !self->initialized) {
       response = FL_METHOD_RESPONSE(fl_method_error_response_new("NOT_INITIALIZED", "Player not initialized", nullptr));
@@ -1280,6 +1497,20 @@ static void mpv_plugin_handle_method_call(FlMethodChannel* channel, FlMethodCall
           return;
         }
       } else if (
+          !self->video_surface && !self->audio_only &&
+          g_strcmp0(fl_value_get_string(name_value), "hdr-tone-mapping") == 0) {
+        // Texture-fallback mode has no plane and no description machinery, so
+        // the tone-map owner is meaningless. Answered success so the startup
+        // preference push does not read a refusal.
+        response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
+      } else if (
+          !self->video_surface && !self->audio_only && g_strcmp0(fl_value_get_string(name_value), "hdr-enabled") == 0) {
+        // No plane, no HDR. Honest refusal; Dart swallows it on Linux and
+        // reconciles the stored preference down, so the settings switch
+        // agrees with the session.
+        response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+            "HDR_UNSUPPORTED", "This session has no video plane and cannot carry HDR", nullptr));
+      } else if (
           !self->audio_only && g_strcmp0(fl_value_get_string(name_value), "vo") == 0 &&
           g_strcmp0(fl_value_get_string(value_value), "libmpv") != 0) {
         // Embedded rendering is authoritative: the render context was created
@@ -1415,6 +1646,10 @@ static void mpv_plugin_handle_method_call(FlMethodChannel* channel, FlMethodCall
           // consumed (or suppressed) while hidden, so no callback is pending.
           if (self->visible) render_video_plane(self, TRUE);
         }
+      } else if (self->visible && self->texture) {
+        // Texture path: becoming visible has to kick Flutter's populate, for
+        // the same reason the plane renders explicitly above.
+        mpv_texture_mark_frame_available(self->texture);
       }
 
       response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
@@ -1501,8 +1736,12 @@ static void mpv_plugin_handle_method_call(FlMethodChannel* channel, FlMethodCall
   } else if (strcmp(method, "updateFrame") == 0) {
     // The cross-platform "kick the video output" call. On the plane that means
     // forcing a render: mpv may have no new frame, but the caller is asking
-    // because what is on screen is stale.
-    if (self->visible) render_video_plane(self, TRUE);
+    // because what is on screen is stale. On the texture path the same kick
+    // marks the texture available.
+    if (self->visible) {
+      if (self->video_surface) render_video_plane(self, TRUE);
+      if (self->texture) mpv_texture_mark_frame_available(self->texture);
+    }
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
   } else if (strcmp(method, "isInitialized") == 0) {
     gboolean initialized = self->player && self->initialized;

--- a/linux/runner/mpv/mpv_texture.cc
+++ b/linux/runner/mpv/mpv_texture.cc
@@ -1,0 +1,540 @@
+#include "mpv_texture.h"
+
+#include <epoxy/egl.h>
+#include <epoxy/gl.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "mpv_gpu_bootstrap.h"
+
+namespace {
+
+GQuark TextureErrorDomain() { return g_quark_from_static_string("plezy-mpv-texture"); }
+
+struct TextureResources {
+  GLuint mpv_fbo = 0;
+  GLuint mpv_texture = 0;
+  GLuint flutter_texture = 0;
+  EGLImageKHR egl_image = EGL_NO_IMAGE_KHR;
+  int32_t width = 0;
+  int32_t height = 0;
+
+  bool complete() const {
+    return mpv_fbo != 0 && mpv_texture != 0 && flutter_texture != 0 && egl_image != EGL_NO_IMAGE_KHR;
+  }
+};
+
+bool SetError(GError** error, const char* message) {
+  g_set_error_literal(error, TextureErrorDomain(), 1, message);
+  return false;
+}
+
+void ClearGlErrors() {
+  while (glGetError() != GL_NO_ERROR) {
+  }
+}
+
+}  // namespace
+
+struct _MpvTexture {
+  FlTextureGL parent_instance;
+
+  mpv::MpvPlayer* player;
+  FlTextureRegistrar* registrar;
+  FlView* view;
+
+  GMutex mutex;
+  bool disposed;
+  TextureResources* active;
+  std::vector<TextureResources>* retired;
+  mpv::GpuImageDispatch* image_dispatch;
+  EGLDisplay flutter_display;
+  EGLContext flutter_share_context;
+  EGLContext flutter_cleanup_context;
+
+  GMutex bootstrap_mutex;
+  gint bootstrap_state;
+  gchar* bootstrap_error;
+  MpvTextureReadyCallback ready_callback;
+  gpointer ready_user_data;
+  GDestroyNotify ready_destroy_notify;
+};
+
+G_DEFINE_TYPE(MpvTexture, mpv_texture, fl_texture_gl_get_type())
+
+namespace {
+
+void SignalBootstrap(MpvTexture* self, gboolean success, const char* message) {
+  MpvTextureReadyCallback callback = nullptr;
+  gpointer user_data = nullptr;
+  g_mutex_lock(&self->bootstrap_mutex);
+  if (self->bootstrap_state == 0) {
+    self->bootstrap_state = success ? 1 : 2;
+    if (!success) self->bootstrap_error = g_strdup(message ? message : "Video initialization failed");
+    callback = self->ready_callback;
+    user_data = self->ready_user_data;
+  }
+  g_mutex_unlock(&self->bootstrap_mutex);
+  if (callback) callback(success, message, user_data);
+}
+
+bool RestoreContext(
+    EGLDisplay display, EGLSurface draw, EGLSurface read, EGLContext context, EGLenum api, GError** error) {
+  if (api != EGL_NONE && !eglBindAPI(api)) {
+    g_warning("MPV texture: failed to restore Flutter EGL API: 0x%x", eglGetError());
+    return SetError(error, "Failed to restore Flutter EGL API");
+  }
+  if (eglMakeCurrent(display, draw, read, context)) return true;
+  g_warning("MPV texture: failed to restore EGL context: 0x%x", eglGetError());
+  return SetError(error, "Failed to restore Flutter EGL context");
+}
+
+void RestoreOrReleaseContext(
+    EGLDisplay flutter_display, EGLSurface flutter_draw, EGLSurface flutter_read, EGLContext flutter_context,
+    EGLenum flutter_api, EGLDisplay mpv_display) {
+  if (flutter_display != EGL_NO_DISPLAY && flutter_context != EGL_NO_CONTEXT) {
+    const bool api_restored = flutter_api == EGL_NONE || eglBindAPI(flutter_api);
+    if (api_restored && eglMakeCurrent(flutter_display, flutter_draw, flutter_read, flutter_context)) return;
+    g_warning("MPV texture: failed to restore EGL state during cleanup: 0x%x", eglGetError());
+  }
+
+  if (mpv_display != EGL_NO_DISPLAY) {
+    if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+      g_warning("MPV texture: failed to bind OpenGL while releasing cleanup context: 0x%x", eglGetError());
+    } else if (!eglMakeCurrent(mpv_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+      g_warning("MPV texture: failed to release EGL context during cleanup: 0x%x", eglGetError());
+    }
+  }
+  if (flutter_api != EGL_NONE && !eglBindAPI(flutter_api)) {
+    g_warning("MPV texture: failed to restore Flutter EGL API after cleanup: 0x%x", eglGetError());
+  }
+}
+
+bool ResourceSetEmpty(const TextureResources& resources) {
+  return resources.mpv_fbo == 0 && resources.mpv_texture == 0 && resources.flutter_texture == 0 &&
+         resources.egl_image == EGL_NO_IMAGE_KHR;
+}
+
+bool EnsureFlutterCleanupContext(
+    MpvTexture* self, EGLDisplay flutter_display, EGLContext flutter_context, EGLenum flutter_api, GError** error) {
+  if (self->flutter_cleanup_context != EGL_NO_CONTEXT) {
+    if (self->flutter_display == flutter_display && self->flutter_share_context == flutter_context) return true;
+    return SetError(error, "Flutter EGL context changed while video textures were active");
+  }
+  if (flutter_api != EGL_OPENGL_ES_API) {
+    return SetError(error, "Flutter is not using an OpenGL ES context");
+  }
+
+  EGLint config_id = 0;
+  EGLint client_version = 0;
+  if (!eglQueryContext(flutter_display, flutter_context, EGL_CONFIG_ID, &config_id) ||
+      !eglQueryContext(flutter_display, flutter_context, EGL_CONTEXT_CLIENT_VERSION, &client_version)) {
+    g_warning("MPV texture: failed to query Flutter EGL context: 0x%x", eglGetError());
+    return SetError(error, "Failed to query Flutter EGL context");
+  }
+  EGLConfig config = nullptr;
+  EGLint num_configs = 0;
+  const EGLint config_attribs[] = {EGL_CONFIG_ID, config_id, EGL_NONE};
+  if (!eglChooseConfig(flutter_display, config_attribs, &config, 1, &num_configs) || num_configs != 1) {
+    g_warning("MPV texture: failed to select Flutter EGL config: 0x%x", eglGetError());
+    return SetError(error, "Failed to select Flutter EGL config");
+  }
+
+  if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+    g_warning("MPV texture: failed to bind OpenGL ES for cleanup context creation: 0x%x", eglGetError());
+    return SetError(error, "Failed to bind OpenGL ES for video cleanup");
+  }
+  const EGLint context_attribs[] = {EGL_CONTEXT_CLIENT_VERSION, client_version, EGL_NONE};
+  const EGLContext cleanup_context = eglCreateContext(flutter_display, config, flutter_context, context_attribs);
+  const bool api_restored = eglBindAPI(flutter_api) == EGL_TRUE;
+  if (cleanup_context == EGL_NO_CONTEXT || !api_restored) {
+    if (cleanup_context != EGL_NO_CONTEXT && !eglDestroyContext(flutter_display, cleanup_context)) {
+      g_warning("MPV texture: failed to destroy rejected cleanup context: 0x%x", eglGetError());
+    }
+    if (!api_restored) {
+      g_warning("MPV texture: failed to restore Flutter EGL API after cleanup context creation: 0x%x", eglGetError());
+    }
+    return SetError(error, "Failed to create video cleanup context");
+  }
+
+  self->flutter_display = flutter_display;
+  self->flutter_share_context = flutter_context;
+  self->flutter_cleanup_context = cleanup_context;
+  return true;
+}
+
+void DestroyFlutterCleanupContext(MpvTexture* self) {
+  if (self->flutter_cleanup_context == EGL_NO_CONTEXT || self->flutter_display == EGL_NO_DISPLAY) return;
+
+  const EGLenum previous_api = eglQueryAPI();
+  if (eglGetCurrentContext() == self->flutter_cleanup_context) {
+    if (!eglBindAPI(EGL_OPENGL_ES_API) ||
+        !eglMakeCurrent(self->flutter_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT)) {
+      g_warning("MPV texture: failed to release Flutter cleanup context: 0x%x", eglGetError());
+    }
+  }
+  if (!eglDestroyContext(self->flutter_display, self->flutter_cleanup_context)) {
+    g_warning("MPV texture: failed to destroy Flutter cleanup context: 0x%x", eglGetError());
+  }
+  if (previous_api != EGL_NONE && !eglBindAPI(previous_api)) {
+    g_warning("MPV texture: failed to restore EGL API after cleanup context destruction: 0x%x", eglGetError());
+  }
+  self->flutter_cleanup_context = EGL_NO_CONTEXT;
+  self->flutter_share_context = EGL_NO_CONTEXT;
+  self->flutter_display = EGL_NO_DISPLAY;
+}
+
+void RetireIncompleteCandidate(MpvTexture* self, const TextureResources& candidate) {
+  if (!ResourceSetEmpty(candidate)) self->retired->push_back(candidate);
+}
+
+void CleanupResourceSet(
+    MpvTexture* self, TextureResources* resources, EGLDisplay flutter_display, EGLSurface flutter_draw,
+    EGLSurface flutter_read, EGLContext flutter_context, EGLenum flutter_api) {
+  const EGLDisplay mpv_display = self->player ? self->player->GetEglDisplay() : EGL_NO_DISPLAY;
+  const EGLContext mpv_context = self->player ? self->player->GetEglContext() : EGL_NO_CONTEXT;
+
+  if (resources->egl_image != EGL_NO_IMAGE_KHR && mpv_display != EGL_NO_DISPLAY && self->image_dispatch &&
+      *self->image_dispatch) {
+    if (self->image_dispatch->Destroy(mpv_display, resources->egl_image)) {
+      resources->egl_image = EGL_NO_IMAGE_KHR;
+    } else {
+      g_warning("MPV texture: failed to destroy EGL image: 0x%x", eglGetError());
+    }
+  }
+
+  if (resources->flutter_texture) {
+    const bool flutter_current = flutter_display == self->flutter_display &&
+                                 flutter_context == self->flutter_share_context && flutter_context != EGL_NO_CONTEXT &&
+                                 eglGetCurrentContext() == self->flutter_share_context;
+    const bool cleanup_current =
+        !flutter_current && self->flutter_display != EGL_NO_DISPLAY &&
+        self->flutter_cleanup_context != EGL_NO_CONTEXT && eglBindAPI(EGL_OPENGL_ES_API) &&
+        eglMakeCurrent(self->flutter_display, EGL_NO_SURFACE, EGL_NO_SURFACE, self->flutter_cleanup_context);
+    if (flutter_current || cleanup_current) {
+      glDeleteTextures(1, &resources->flutter_texture);
+      resources->flutter_texture = 0;
+    } else {
+      g_warning("MPV texture: failed to activate Flutter cleanup context: 0x%x", eglGetError());
+    }
+    if (cleanup_current) {
+      RestoreOrReleaseContext(
+          flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, self->flutter_display);
+    }
+  }
+
+  if (resources->mpv_fbo || resources->mpv_texture) {
+    const bool mpv_current = mpv_display != EGL_NO_DISPLAY && mpv_context != EGL_NO_CONTEXT &&
+                             eglBindAPI(EGL_OPENGL_ES_API) &&
+                             eglMakeCurrent(mpv_display, EGL_NO_SURFACE, EGL_NO_SURFACE, mpv_context);
+    if (mpv_current) {
+      if (resources->mpv_fbo) glDeleteFramebuffers(1, &resources->mpv_fbo);
+      if (resources->mpv_texture) glDeleteTextures(1, &resources->mpv_texture);
+      resources->mpv_fbo = 0;
+      resources->mpv_texture = 0;
+    } else {
+      g_warning("MPV texture: failed to activate EGL context during cleanup: 0x%x", eglGetError());
+    }
+    RestoreOrReleaseContext(flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, mpv_display);
+  }
+}
+
+void CleanupRetired(MpvTexture* self) {
+  if (!self->retired || self->retired->empty() || !self->player) return;
+  const EGLDisplay flutter_display = eglGetCurrentDisplay();
+  const EGLContext flutter_context = eglGetCurrentContext();
+  const EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
+  const EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
+  const EGLenum flutter_api = eglQueryAPI();
+  for (auto& resources : *self->retired) {
+    CleanupResourceSet(self, &resources, flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api);
+  }
+  auto& retired = *self->retired;
+  retired.erase(
+      std::remove_if(
+          retired.begin(), retired.end(),
+          [](const TextureResources& resources) { return ResourceSetEmpty(resources); }),
+      retired.end());
+}
+
+bool EnsureTextures(MpvTexture* self, int32_t width, int32_t height, GError** error) {
+  if (self->active->complete() && self->active->width == width && self->active->height == height) return true;
+
+  const EGLDisplay flutter_display = eglGetCurrentDisplay();
+  const EGLContext flutter_context = eglGetCurrentContext();
+  const EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
+  const EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
+  const EGLenum flutter_api = eglQueryAPI();
+  const EGLDisplay mpv_display = self->player->GetEglDisplay();
+  const EGLContext mpv_context = self->player->GetEglContext();
+  if (flutter_display == EGL_NO_DISPLAY || flutter_context == EGL_NO_CONTEXT || mpv_display == EGL_NO_DISPLAY ||
+      mpv_context == EGL_NO_CONTEXT) {
+    return SetError(error, "Video EGL contexts are unavailable");
+  }
+
+  if (!EnsureFlutterCleanupContext(self, flutter_display, flutter_context, flutter_api, error)) return false;
+
+  if (!*self->image_dispatch) {
+    std::string dispatch_error;
+    if (!mpv::ResolveGpuImageDispatch(flutter_display, self->image_dispatch, &dispatch_error)) {
+      g_warning("MPV texture: GPU bootstrap rejected: %s", dispatch_error.c_str());
+      return SetError(error, dispatch_error.c_str());
+    }
+  }
+
+  TextureResources candidate;
+  candidate.width = width;
+  candidate.height = height;
+  if (!eglBindAPI(EGL_OPENGL_ES_API) || !eglMakeCurrent(mpv_display, EGL_NO_SURFACE, EGL_NO_SURFACE, mpv_context)) {
+    RestoreOrReleaseContext(flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, mpv_display);
+    return SetError(error, "Failed to activate video EGL context");
+  }
+
+  ClearGlErrors();
+  glGenTextures(1, &candidate.mpv_texture);
+  glBindTexture(GL_TEXTURE_2D, candidate.mpv_texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glGenFramebuffers(1, &candidate.mpv_fbo);
+  glBindFramebuffer(GL_FRAMEBUFFER, candidate.mpv_fbo);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, candidate.mpv_texture, 0);
+  bool framebuffer_complete = candidate.mpv_texture != 0 && candidate.mpv_fbo != 0 &&
+                              glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE &&
+                              glGetError() == GL_NO_ERROR;
+  if (framebuffer_complete) {
+    candidate.egl_image = self->image_dispatch->Create(
+        mpv_display, mpv_context, reinterpret_cast<EGLClientBuffer>(static_cast<uintptr_t>(candidate.mpv_texture)));
+  }
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glFlush();
+  framebuffer_complete = framebuffer_complete && glGetError() == GL_NO_ERROR;
+
+  if (!RestoreContext(flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, error)) {
+    CleanupResourceSet(self, &candidate, flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api);
+    RetireIncompleteCandidate(self, candidate);
+    return false;
+  }
+  if (!framebuffer_complete || candidate.egl_image == EGL_NO_IMAGE_KHR) {
+    CleanupResourceSet(self, &candidate, flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api);
+    RetireIncompleteCandidate(self, candidate);
+    return SetError(error, "Failed to create a complete video framebuffer");
+  }
+
+  ClearGlErrors();
+  glGenTextures(1, &candidate.flutter_texture);
+  glBindTexture(GL_TEXTURE_2D, candidate.flutter_texture);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  self->image_dispatch->image_target_texture(GL_TEXTURE_2D, reinterpret_cast<GLeglImageOES>(candidate.egl_image));
+  const bool flutter_texture_complete = candidate.flutter_texture != 0 && glGetError() == GL_NO_ERROR;
+  glBindTexture(GL_TEXTURE_2D, 0);
+  if (!flutter_texture_complete) {
+    CleanupResourceSet(self, &candidate, flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api);
+    RetireIncompleteCandidate(self, candidate);
+    return SetError(error, "Failed to bind the shared video image");
+  }
+
+  if (self->active->complete()) self->retired->push_back(*self->active);
+  *self->active = candidate;
+  CleanupRetired(self);
+  return true;
+}
+
+static gboolean MpvTexturePopulate(
+    FlTextureGL* texture, uint32_t* target, uint32_t* name, uint32_t* width, uint32_t* height, GError** error) {
+  MpvTexture* self = MPV_TEXTURE(texture);
+  g_mutex_lock(&self->mutex);
+  if (self->disposed || !self->player) {
+    g_object_ref(self);
+    g_mutex_unlock(&self->mutex);
+    SignalBootstrap(self, FALSE, "Video texture was disposed");
+    g_object_unref(self);
+    return SetError(error, "Video texture was disposed");
+  }
+  if (!self->player->HasRenderContext() && !self->player->InitRenderContext()) {
+    g_mutex_unlock(&self->mutex);
+    return SetError(error, "Failed to create video render context");
+  }
+
+  GtkAllocation allocation;
+  gtk_widget_get_allocation(GTK_WIDGET(self->view), &allocation);
+  const int scale = gtk_widget_get_scale_factor(GTK_WIDGET(self->view));
+  const int32_t requested_width = allocation.width * scale;
+  const int32_t requested_height = allocation.height * scale;
+  if (requested_width <= 0 || requested_height <= 0) {
+    g_mutex_unlock(&self->mutex);
+    return SetError(error, "Video surface has no drawable size");
+  }
+  // GL/EGL failures during the first populate are not terminal. Flutter may
+  // call populate again while waitForVideoReady owns the bounded deadline.
+  if (!EnsureTextures(self, requested_width, requested_height, error)) {
+    g_mutex_unlock(&self->mutex);
+    return FALSE;
+  }
+
+  const EGLDisplay flutter_display = eglGetCurrentDisplay();
+  const EGLContext flutter_context = eglGetCurrentContext();
+  const EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
+  const EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
+  const EGLenum flutter_api = eglQueryAPI();
+  const EGLDisplay mpv_display = self->player->GetEglDisplay();
+  const EGLContext mpv_context = self->player->GetEglContext();
+  if (!eglBindAPI(EGL_OPENGL_ES_API) || !eglMakeCurrent(mpv_display, EGL_NO_SURFACE, EGL_NO_SURFACE, mpv_context)) {
+    RestoreOrReleaseContext(flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, mpv_display);
+    g_mutex_unlock(&self->mutex);
+    return SetError(error, "Failed to activate video EGL context");
+  }
+
+  ClearGlErrors();
+  glBindFramebuffer(GL_FRAMEBUFFER, self->active->mpv_fbo);
+  self->player->ClearRedrawFlag();
+  self->player->Render(requested_width, requested_height, static_cast<int>(self->active->mpv_fbo));
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glFlush();
+  const bool render_succeeded = glGetError() == GL_NO_ERROR;
+  if (!RestoreContext(flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, error)) {
+    RestoreOrReleaseContext(flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api, mpv_display);
+    g_mutex_unlock(&self->mutex);
+    return FALSE;
+  }
+  if (!render_succeeded) {
+    g_mutex_unlock(&self->mutex);
+    return SetError(error, "Video render operation failed");
+  }
+
+  *target = GL_TEXTURE_2D;
+  *name = self->active->flutter_texture;
+  *width = static_cast<uint32_t>(requested_width);
+  *height = static_cast<uint32_t>(requested_height);
+  g_object_ref(self);
+  g_mutex_unlock(&self->mutex);
+  SignalBootstrap(self, TRUE, nullptr);
+  g_object_unref(self);
+  return TRUE;
+}
+
+static void MpvTextureFinalize(GObject* object) {
+  MpvTexture* self = MPV_TEXTURE(object);
+  if (self->ready_destroy_notify && self->ready_user_data) {
+    self->ready_destroy_notify(self->ready_user_data);
+  }
+  g_free(self->bootstrap_error);
+  delete self->active;
+  delete self->retired;
+  delete self->image_dispatch;
+  g_mutex_clear(&self->bootstrap_mutex);
+  g_mutex_clear(&self->mutex);
+  G_OBJECT_CLASS(mpv_texture_parent_class)->finalize(object);
+}
+
+}  // namespace
+
+static void mpv_texture_class_init(MpvTextureClass* klass) {
+  FL_TEXTURE_GL_CLASS(klass)->populate = MpvTexturePopulate;
+  G_OBJECT_CLASS(klass)->finalize = MpvTextureFinalize;
+}
+
+static void mpv_texture_init(MpvTexture* self) {
+  self->player = nullptr;
+  self->registrar = nullptr;
+  self->view = nullptr;
+  g_mutex_init(&self->mutex);
+  self->disposed = false;
+  self->active = new TextureResources();
+  self->retired = new std::vector<TextureResources>();
+  self->image_dispatch = new mpv::GpuImageDispatch();
+  self->flutter_display = EGL_NO_DISPLAY;
+  self->flutter_share_context = EGL_NO_CONTEXT;
+  self->flutter_cleanup_context = EGL_NO_CONTEXT;
+  g_mutex_init(&self->bootstrap_mutex);
+  self->bootstrap_state = 0;
+  self->bootstrap_error = nullptr;
+  self->ready_callback = nullptr;
+  self->ready_user_data = nullptr;
+  self->ready_destroy_notify = nullptr;
+}
+
+MpvTexture* mpv_texture_new(mpv::MpvPlayer* player, FlTextureRegistrar* registrar, FlView* view) {
+  MpvTexture* self = MPV_TEXTURE(g_object_new(MPV_TEXTURE_TYPE, nullptr));
+  self->player = player;
+  self->registrar = registrar;
+  self->view = view;
+  return self;
+}
+
+void mpv_texture_set_ready_callback(
+    MpvTexture* self, MpvTextureReadyCallback callback, gpointer user_data, GDestroyNotify destroy_notify) {
+  gboolean success = FALSE;
+  const gchar* message = nullptr;
+  bool complete = false;
+  g_mutex_lock(&self->bootstrap_mutex);
+  self->ready_callback = callback;
+  self->ready_user_data = user_data;
+  self->ready_destroy_notify = destroy_notify;
+  if (self->bootstrap_state != 0) {
+    complete = true;
+    success = self->bootstrap_state == 1;
+    message = self->bootstrap_error;
+  }
+  g_mutex_unlock(&self->bootstrap_mutex);
+  if (complete && callback) callback(success, message, user_data);
+}
+
+void mpv_texture_mark_frame_available(MpvTexture* self) {
+  if (!self) return;
+  g_mutex_lock(&self->mutex);
+  FlTextureRegistrar* registrar = self->disposed ? nullptr : self->registrar;
+  g_mutex_unlock(&self->mutex);
+  if (registrar) {
+    fl_texture_registrar_mark_texture_frame_available(registrar, FL_TEXTURE(self));
+  }
+}
+
+void mpv_texture_dispose(MpvTexture* self) {
+  if (!self) return;
+  g_mutex_lock(&self->mutex);
+  if (self->disposed) {
+    g_mutex_unlock(&self->mutex);
+    return;
+  }
+  self->disposed = true;
+  SignalBootstrap(self, FALSE, "Video initialization was cancelled");
+
+  if (self->player) {
+    const EGLDisplay flutter_display = eglGetCurrentDisplay();
+    const EGLContext flutter_context = eglGetCurrentContext();
+    const EGLSurface flutter_draw = eglGetCurrentSurface(EGL_DRAW);
+    const EGLSurface flutter_read = eglGetCurrentSurface(EGL_READ);
+    const EGLenum flutter_api = eglQueryAPI();
+    CleanupResourceSet(self, self->active, flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api);
+    for (auto& resources : *self->retired) {
+      CleanupResourceSet(self, &resources, flutter_display, flutter_draw, flutter_read, flutter_context, flutter_api);
+    }
+    DestroyFlutterCleanupContext(self);
+    const auto leaked_sets =
+        static_cast<size_t>(!ResourceSetEmpty(*self->active)) +
+        static_cast<size_t>(std::count_if(self->retired->begin(), self->retired->end(), [](const auto& resources) {
+          return !ResourceSetEmpty(resources);
+        }));
+    if (leaked_sets != 0) {
+      g_warning("MPV texture: %zu resource set(s) could not be released before disposal", leaked_sets);
+    }
+  }
+  *self->active = TextureResources{};
+  self->retired->clear();
+  self->player = nullptr;
+  self->registrar = nullptr;
+  self->view = nullptr;
+  g_mutex_unlock(&self->mutex);
+}
+
+int64_t mpv_texture_get_id(MpvTexture* self) { return fl_texture_get_id(FL_TEXTURE(self)); }

--- a/linux/runner/mpv/mpv_texture.h
+++ b/linux/runner/mpv/mpv_texture.h
@@ -1,0 +1,34 @@
+#ifndef MPV_TEXTURE_H_
+#define MPV_TEXTURE_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+#include "mpv_player.h"
+
+G_BEGIN_DECLS
+
+#define MPV_TEXTURE_TYPE (mpv_texture_get_type())
+
+G_DECLARE_FINAL_TYPE(MpvTexture, mpv_texture, MPV, TEXTURE, FlTextureGL)
+
+/// Creates a new MpvTexture that renders mpv video to an offscreen FBO.
+MpvTexture* mpv_texture_new(mpv::MpvPlayer* player, FlTextureRegistrar* registrar, FlView* view);
+
+typedef void (*MpvTextureReadyCallback)(gboolean success, const gchar* error_message, gpointer user_data);
+
+/// Installs the one-shot video bootstrap result callback.
+void mpv_texture_set_ready_callback(
+    MpvTexture* self, MpvTextureReadyCallback callback, gpointer user_data, GDestroyNotify destroy_notify);
+
+/// Notifies Flutter that a new frame is available.
+void mpv_texture_mark_frame_available(MpvTexture* self);
+
+/// Cleans up GL resources (FBO/texture).
+void mpv_texture_dispose(MpvTexture* self);
+
+/// Returns the Flutter texture ID.
+int64_t mpv_texture_get_id(MpvTexture* self);
+
+G_END_DECLS
+
+#endif  // MPV_TEXTURE_H_

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -12,7 +12,9 @@
 // On Wayland the mpv video plane is a wl_subsurface stacked *below* this
 // window's surface, so the window needs an alpha channel for it to show
 // through. Harmless when the plane is unavailable: the Flutter UI paints
-// opaque anyway, and X11 sessions refuse video at initialize by design.
+// opaque anyway, and sessions that cannot host the plane (X11/XWayland)
+// fall back to the Flutter-texture path, which composites through Flutter
+// and needs no alpha channel.
 static void enable_video_plane_transparency(GtkWindow* window, FlView* view) {
 #ifdef GDK_WINDOWING_WAYLAND
   GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(window));
@@ -85,8 +87,9 @@ static void my_application_activate(GApplication* application) {
   // Register Flutter plugins.
   fl_register_plugins(FL_PLUGIN_REGISTRY(self->flutter_view));
 
-  // Register the MPV plugin. Video goes to the native Wayland plane; there is no other path, so a session that
-  // cannot host one is refused by name rather than played into nothing.
+  // Register the MPV plugin. Video prefers the native Wayland plane; sessions
+  // that cannot host one (X11/XWayland, or a failed plane bootstrap) fall back
+  // to the Flutter-texture path in SDR.
   FlPluginRegistrar* registrar =
       fl_plugin_registry_get_registrar_for_plugin(FL_PLUGIN_REGISTRY(self->flutter_view), "MpvPlugin");
   mpv_plugin_register_with_registrar(registrar);

--- a/test/mpv/player_native_bridge_test.dart
+++ b/test/mpv/player_native_bridge_test.dart
@@ -98,6 +98,12 @@ void main() {
   });
 
   test('initialize carries the decode intent and the instance token (#2010)', () async {
+    // Pinned off because Linux adds renderMode to the same argument map, which
+    // would make this assertion pass or fail on the host's platform rather
+    // than on what it is about. The Linux argument has its own test below.
+    PlayerNative.debugUseLinuxVideoPlane = false;
+    addTearDown(() => PlayerNative.debugUseLinuxVideoPlane = null);
+
     for (final hardwareDecoding in [true, false]) {
       final calls = <MethodCall>[];
       await withMockPlayerChannels(
@@ -514,6 +520,61 @@ void main() {
           expect(calls.map((call) => call.method), ['initialize', 'initialize']);
         } finally {
           await subscription.cancel();
+          await player.dispose();
+        }
+      },
+    );
+  });
+
+  test('a Linux initialize that answers with a texture id publishes it and waits for readiness', () async {
+    // The texture fallback's whole contract in one place, because losing any
+    // part of it is silent: initialize answers with an id instead of `true`,
+    // the id is published before the readiness wait begins - the UI has to
+    // mount the texture for the native bootstrap to be able to finish at all -
+    // and only then does waitForVideoReady run.
+    PlayerNative.debugUseLinuxVideoPlane = true;
+    addTearDown(() => PlayerNative.debugUseLinuxVideoPlane = null);
+
+    final calls = <MethodCall>[];
+    final readyGate = Completer<void>();
+    int? idAtReadyCall;
+
+    await withMockPlayerChannels(
+      methodChannelName: 'com.plezy/mpv_player',
+      eventChannelName: 'com.plezy/mpv_player/events',
+      methodHandler: (call) async {
+        calls.add(call);
+        if (call.method == 'initialize') return 7;
+        if (call.method == 'waitForVideoReady') {
+          await readyGate.future;
+          return null;
+        }
+        return null;
+      },
+      testBody: () async {
+        final player = PlayerNative();
+        try {
+          final ids = <int?>[];
+          void record() => ids.add(player.textureIdListenable.value);
+          player.textureIdListenable.addListener(record);
+
+          final pending = player.setLogLevel('warn');
+          await Future<void>.delayed(Duration.zero);
+
+          // Still parked on waitForVideoReady, and the id is already out.
+          expect(calls.map((call) => call.method), ['initialize', 'waitForVideoReady']);
+          idAtReadyCall = player.textureIdListenable.value;
+
+          readyGate.complete();
+          await pending;
+
+          expect(idAtReadyCall, 7);
+          expect(ids, [7]);
+          player.textureIdListenable.removeListener(record);
+          final init = calls.singleWhere((call) => call.method == 'initialize');
+          expect((init.arguments as Map)['renderMode'], 'auto');
+        } finally {
+          if (!readyGate.isCompleted) readyGate.complete();
           await player.dispose();
         }
       },


### PR DESCRIPTION
Restores the Flutter-texture renderer as the fallback for sessions that cannot
host the Wayland plane, and — the part 9cdfe759 was missing — the provisional
bootstrap surface without which that fallback cannot finish initializing.

Full reasoning and evidence in #2237. The short version: 2.14.0's
restore brought back the native and player layers but not the UI layer, so
`initialize` waited on a `populate` that could never be called, timed out after
five seconds, and looked like proof that the approach does not work. It was
proof that two of three layers do not work.

### What this does

**1. Reverts be863a0c, merged onto current `main` rather than applied verbatim**

- The plane and its off-main-thread `PlaneRenderExecutor` are untouched. The
  texture branch is reached only when `start_video_plane` fails or `renderMode`
  is `texture`.
- `initialize` carries `hardwareDecoding` / `instanceId` (the current contract)
  alongside `renderMode`, and treats an `int` result as the texture id.
- `textureId` lives on `PlayerBase` rather than on the `Player` interface, so
  the test fakes that `implements Player` are unaffected. Say the word if you'd
  rather have it back on the interface.
- The runner links `mpv_texture.cc` beside `plane_render_executor.cc`.

**2. Restores the provisional bootstrap surface** (2.11.0's, five pieces
removed by bcd6fe99): the `_bootstrapPlayer` field, the gated `setState` after
the player is constructed, the clear on rollback, and
`_buildPlayerInitializationSurface`. On the plane path no texture id is ever
published, so it mounts nothing and the loading cover is unchanged.

**3. Restores `player ?? _bootstrapPlayer` in `dispose`**, which is a fix in its
own right: `player` is assigned only once initialization commits, so leaving
the screen during startup disposed nothing there and left the in-flight core to
the rollback — parked on `waitForVideoReady`, whose bootstrap can no longer
finish once the surface unmounts. Five seconds holding an mpv core, an EGL
context and a registered texture, with `PlaybackCoordinator` queueing the next
video behind them. Disposing the bootstrap player answers the pending call at
once through `release_video_resources`; `PlayerBase.dispose` is idempotent, so
the rollback's own dispose is a no-op after it.

### What it does not change

No HDR on the texture path — SDR only, as in 2.11.0 — and video frames go
through Flutter compositing rather than a plane. Hardware decode is intact:
`hwdec=auto` with the display handle passed for interop, which is the
configuration hwdec worked in before the plane existed.

### Testing

Built from this branch and running on a Steam Deck (SteamOS, Gaming Mode via
Gamescope's XWayland): video plays, where 2.13.0+ refused with
`VIDEO_PLANE_UNSUPPORTED`.

I have no Wayland machine to regression-test the plane path on, so that side is
argued from the diff rather than measured — it is the reason the texture branch
is kept strictly behind a failed `start_video_plane`. Worth a look from someone
who can run it.

### CI

Ran your own `ci.yml` checks on this branch in my fork — analyze, test,
native-format, linux-native-test, dependency-check:

| Check | Result |
| --- | --- |
| Code Analysis (codegen, translation hygiene, guards, `dart format`, analyzer, unused code/files) | pass |
| Native Formatting | pass |
| Dependency Validation | pass |
| Linux native reliability (thread) | pass |
| Linux native reliability (address) | pass |
| Unit Tests | 6622 passed, 1 failed |

The one failure is `happy_eyeballs_test.dart: startHappyEyeballsConnect decodes
a percent-encoded link-local zone`. I ran the same job against unmodified
`main` on the same runner image as a baseline: 6621 passed, same single
failure. So it is pre-existing and runner-dependent, and the +1 is the new
test above.

### AI assistance

Written with Claude Opus 5, per CONTRIBUTING.md.
