### PR TITLE
feat(android): add in-app updates from existing release archives

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ import java.io.FileInputStream
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
+import java.util.Base64
 import java.util.Properties
 import java.util.UUID
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
@@ -311,6 +312,16 @@ android {
       path = file("src/main/cpp/CMakeLists.txt")
       version = "4.1.2"
     }
+  }
+
+  // Manifest merger directives are parsed before placeholders. Use a real
+  // release manifest overlay instead of a placeholder inside tools:node.
+  val updateChecksEnabled = (project.findProperty("dart-defines") as? String)
+    ?.split(",")
+    ?.map { String(Base64.getDecoder().decode(it), Charsets.UTF_8) }
+    ?.contains("ENABLE_UPDATE_CHECK=true") == true
+  if (updateChecksEnabled) {
+    sourceSets.getByName("release").manifest.srcFile("src/sideload/AndroidManifest.xml")
   }
 
   signingConfigs {

--- a/android/app/src/main/kotlin/com/edde746/plezy/AppUpdateChannel.kt
+++ b/android/app/src/main/kotlin/com/edde746/plezy/AppUpdateChannel.kt
@@ -1,0 +1,124 @@
+package com.edde746.plezy
+
+import android.app.Activity
+import android.content.ClipData
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.Process
+import android.provider.Settings
+import androidx.core.content.FileProvider
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+
+internal class AppUpdateChannel(private val activity: Activity) {
+  companion object {
+    private const val PERMISSION_REQUEST = 7462
+  }
+
+  private var pendingPermission: MethodChannel.Result? = null
+  private var channel: MethodChannel? = null
+  private val updateDirectory get() = File(activity.cacheDir, "app-updates")
+
+  fun attach(messenger: BinaryMessenger) {
+    channel = MethodChannel(messenger, "com.plezy/app_update").also {
+      it.setMethodCallHandler(::onMethodCall)
+    }
+  }
+
+  internal fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+    try {
+      when (call.method) {
+        "getSupportedAbis" -> result.success(
+          Build.SUPPORTED_ABIS.filter { it.contains("64") == Process.is64Bit() }
+        )
+        "requestInstallPermission" -> requestPermission(result)
+        "prepareUpdateDirectory" -> {
+          check(updateDirectory.isDirectory || updateDirectory.mkdirs()) { "Cannot create update cache" }
+          listOf("update.apk", "update.tar.gz", "update.tar.gz.part").forEach { name ->
+            val file = File(updateDirectory, name)
+            check(!file.exists() || file.delete()) { "Cannot clear previous update" }
+          }
+          result.success(updateDirectory.absolutePath)
+        }
+        "installUpdate" -> install(call.argument<String>("path"), result)
+        else -> result.notImplemented()
+      }
+    } catch (error: Exception) {
+      result.error("UPDATE_FAILED", error.message, null)
+    }
+  }
+
+  private fun canInstall(): Boolean =
+    Build.VERSION.SDK_INT < Build.VERSION_CODES.O || activity.packageManager.canRequestPackageInstalls()
+
+  private fun requestPermission(result: MethodChannel.Result) {
+    if (canInstall()) {
+      result.success(true)
+      return
+    }
+    if (pendingPermission != null) {
+      result.error("UPDATE_BUSY", "An installation permission request is already active", null)
+      return
+    }
+    pendingPermission = result
+    activity.startActivityForResult(
+      Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES, Uri.parse("package:${activity.packageName}")),
+      PERMISSION_REQUEST,
+    )
+  }
+
+  fun onActivityResult(requestCode: Int): Boolean {
+    if (requestCode != PERMISSION_REQUEST) return false
+    val result = pendingPermission
+    pendingPermission = null
+    result?.success(canInstall())
+    return true
+  }
+
+  @Suppress("DEPRECATION")
+  private fun install(path: String?, result: MethodChannel.Result) {
+    val apk = File(updateDirectory, "update.apk").canonicalFile
+    require(path != null && File(path).canonicalFile == apk && apk.isFile) { "Invalid update path" }
+    if (!canInstall()) {
+      result.error("INSTALL_PERMISSION_DENIED", "Allow installs from Plezy in Android settings", null)
+      return
+    }
+
+    val pm = activity.packageManager
+    val candidate = pm.getPackageArchiveInfo(apk.path, PackageManager.GET_SIGNATURES)
+    val installed = pm.getPackageInfo(activity.packageName, PackageManager.GET_SIGNATURES)
+    if (candidate == null || candidate.packageName != activity.packageName) {
+      result.error("INVALID_APK", "The APK is not an update for this application", null)
+      return
+    }
+    val newCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) candidate.longVersionCode else candidate.versionCode.toLong()
+    val oldCode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) installed.longVersionCode else installed.versionCode.toLong()
+    if (newCode <= oldCode) {
+      result.error("VERSION_NOT_NEWER", "The APK version code must be higher than the installed version", null)
+      return
+    }
+    if (installed.signatures?.toSet().isNullOrEmpty() || installed.signatures?.toSet() != candidate.signatures?.toSet()) {
+      result.error("SIGNATURE_MISMATCH", "The APK must use the same signing key as this installation", null)
+      return
+    }
+
+    val uri = FileProvider.getUriForFile(activity, "com.edde746.plezy.fileprovider", apk)
+    activity.startActivity(Intent(Intent.ACTION_VIEW).apply {
+      setDataAndType(uri, "application/vnd.android.package-archive")
+      clipData = ClipData.newRawUri("Plezy update", uri)
+      addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    })
+    result.success(null)
+  }
+
+  fun dispose() {
+    channel?.setMethodCallHandler(null)
+    channel = null
+    pendingPermission?.error("ACTIVITY_DESTROYED", "Activity closed during installation permission request", null)
+    pendingPermission = null
+  }
+}

--- a/android/app/src/main/kotlin/com/edde746/plezy/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/edde746/plezy/MainActivity.kt
@@ -116,6 +116,7 @@ class MainActivity : FlutterActivity() {
   private var flutterSurfaceReconnectPending = false
   private var activityStarted = false
   private val externalPlayerChannel = ExternalPlayerChannel(this)
+  private val appUpdateChannel = AppUpdateChannel(this)
   private val exitDiagnosticsRequested = AtomicBoolean(false)
 
   private inline fun logTextInputDiag(message: () -> String) {
@@ -584,12 +585,13 @@ class MainActivity : FlutterActivity() {
   }
 
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-    if (!externalPlayerChannel.onActivityResult(requestCode, resultCode, data)) {
+    if (!appUpdateChannel.onActivityResult(requestCode) && !externalPlayerChannel.onActivityResult(requestCode, resultCode, data)) {
       super.onActivityResult(requestCode, resultCode, data)
     }
   }
 
   override fun onDestroy() {
+    appUpdateChannel.dispose()
     externalPlayerChannel.dispose()
     endNativeTextInputSession()
     imeVisibilityListener?.let { window.decorView.viewTreeObserver.removeOnGlobalLayoutListener(it) }
@@ -734,6 +736,7 @@ class MainActivity : FlutterActivity() {
 
   override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
     super.configureFlutterEngine(flutterEngine)
+    appUpdateChannel.attach(flutterEngine.dartExecutor.binaryMessenger)
     flutterEngine.plugins.add(MpvPlayerPlugin())
     flutterEngine.plugins.add(ExoPlayerPlugin())
     flutterEngine.plugins.add(MpvAudioPlayerPlugin())

--- a/android/app/src/sideload/AndroidManifest.xml
+++ b/android/app/src/sideload/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Merged only into release APKs built with ENABLE_UPDATE_CHECK=true. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+</manifest>

--- a/android/app/src/test/kotlin/com/edde746/plezy/AppUpdateChannelTest.kt
+++ b/android/app/src/test/kotlin/com/edde746/plezy/AppUpdateChannelTest.kt
@@ -1,0 +1,52 @@
+package com.edde746.plezy
+
+import android.app.Activity
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [25])
+class AppUpdateChannelTest {
+  @Test
+  fun preparationOnlyDeletesUpdaterFiles() {
+    val activity = Robolectric.buildActivity(Activity::class.java).get()
+    val directory = File(activity.cacheDir, "app-updates").apply { mkdirs() }
+    listOf("update.apk", "update.tar.gz", "update.tar.gz.part").forEach { File(directory, it).writeText("old") }
+    val unrelated = File(activity.cacheDir, "other-data").apply { writeText("keep") }
+    val result = RecordingResult()
+
+    AppUpdateChannel(activity).onMethodCall(MethodCall("prepareUpdateDirectory", null), result)
+
+    assertEquals(directory.absolutePath, result.value)
+    assertTrue(directory.listFiles().isNullOrEmpty())
+    assertTrue(unrelated.exists())
+  }
+
+  @Test
+  fun refusesFilesOutsideUpdateCache() {
+    val activity = Robolectric.buildActivity(Activity::class.java).get()
+    val unrelated = File(activity.cacheDir, "untrusted.apk").apply { writeText("not an APK") }
+    val result = RecordingResult()
+
+    AppUpdateChannel(activity).onMethodCall(MethodCall("installUpdate", mapOf("path" to unrelated.path)), result)
+
+    assertEquals("UPDATE_FAILED", result.errorCode)
+    assertTrue(unrelated.exists())
+  }
+
+  private class RecordingResult : MethodChannel.Result {
+    var value: Any? = null
+    var errorCode: String? = null
+    override fun success(result: Any?) { value = result }
+    override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) { this.errorCode = errorCode }
+    override fun notImplemented() { errorCode = "NOT_IMPLEMENTED" }
+  }
+}

--- a/lib/services/android_update_service.dart
+++ b/lib/services/android_update_service.dart
@@ -1,0 +1,217 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+
+class AndroidUpdateAsset {
+  final Uri url;
+  final int size;
+  final String? sha256Digest;
+
+  const AndroidUpdateAsset({required this.url, required this.size, this.sha256Digest});
+
+  static AndroidUpdateAsset? select(List<dynamic> assets, List<String> abis) {
+    for (final name in abis.map((abi) => 'plezy-android-$abi.tar.gz')) {
+      for (final asset in assets.whereType<Map>()) {
+        if (asset['name'] != name) continue;
+        final url = Uri.tryParse(asset['browser_download_url'] as String? ?? '');
+        final size = asset['size'];
+        final digest = asset['digest'];
+        if (url == null || !isTrustedUrl(url) || size is! int || size <= 0 || size > maxArchiveSize) continue;
+        if (digest != null && (digest is! String || !RegExp(r'^sha256:[a-fA-F0-9]{64}$').hasMatch(digest))) continue;
+        return AndroidUpdateAsset(
+          url: url,
+          size: size,
+          sha256Digest: (digest as String?)?.substring(7).toLowerCase(),
+        );
+      }
+    }
+    return null;
+  }
+
+  static const maxArchiveSize = 512 * 1024 * 1024;
+  static const maxApkSize = 768 * 1024 * 1024;
+
+  static bool isTrustedUrl(Uri url) =>
+      url.scheme == 'https' &&
+      url.host == 'github.com' &&
+      url.port == 443 &&
+      url.userInfo.isEmpty &&
+      !url.hasQuery &&
+      !url.hasFragment &&
+      url.path.startsWith('/edde746/plezy/releases/download/') &&
+      url.path.endsWith('.tar.gz');
+}
+
+class UpdateDownloadCancelled implements Exception {}
+
+class AndroidUpdateService {
+  static const channel = MethodChannel('com.plezy/app_update');
+  static bool _active = false;
+  final http.Client _client;
+  bool _cancelled = false;
+
+  AndroidUpdateService({http.Client? client}) : _client = client ?? http.Client();
+
+  static Future<List<String>> supportedAbis() async =>
+      await channel.invokeListMethod<String>('getSupportedAbis') ?? <String>[];
+
+  void cancel() {
+    _cancelled = true;
+    _client.close();
+  }
+
+  void _checkCancelled() {
+    if (_cancelled) throw UpdateDownloadCancelled();
+  }
+
+  Future<void> downloadAndInstall(AndroidUpdateAsset asset, void Function(double) onProgress) async {
+    if (_active) throw StateError('An update is already in progress');
+    _active = true;
+    File? partial;
+    File? archive;
+    File? apk;
+    var installerOpened = false;
+    try {
+      final allowed = await channel.invokeMethod<bool>('requestInstallPermission');
+      if (allowed != true) throw PlatformException(code: 'INSTALL_PERMISSION_DENIED');
+      final directory = await channel.invokeMethod<String>('prepareUpdateDirectory');
+      if (directory == null) throw StateError('Update cache unavailable');
+      partial = File('$directory/update.tar.gz.part');
+      archive = File('$directory/update.tar.gz');
+      apk = File('$directory/update.apk');
+      await _download(asset, partial, onProgress);
+      _checkCancelled();
+      await partial.rename(archive.path);
+      await _extractApk(archive, apk);
+      await archive.delete();
+      _checkCancelled();
+      await channel.invokeMethod<void>('installUpdate', {'path': apk.path});
+      installerOpened = true;
+    } catch (_) {
+      if (_cancelled) throw UpdateDownloadCancelled();
+      rethrow;
+    } finally {
+      _client.close();
+      if (partial != null && await partial.exists()) await partial.delete();
+      if (archive != null && await archive.exists()) await archive.delete();
+      if (!installerOpened && apk != null && await apk.exists()) await apk.delete();
+      _active = false;
+    }
+  }
+
+  Future<void> _download(AndroidUpdateAsset asset, File target, void Function(double) onProgress) async {
+    if (!AndroidUpdateAsset.isTrustedUrl(asset.url)) throw const FormatException('Invalid update URL');
+    final response = await _client.send(http.Request('GET', asset.url)).timeout(const Duration(seconds: 30));
+    if (response.statusCode != 200) throw HttpException('Update download failed (${response.statusCode})');
+    final sink = target.openWrite();
+    var received = 0;
+    try {
+      await for (final chunk in response.stream.timeout(const Duration(seconds: 30))) {
+        _checkCancelled();
+        received += chunk.length;
+        if (received > asset.size) throw const FormatException('Update archive is too large');
+        sink.add(chunk);
+        onProgress(received / asset.size);
+      }
+    } finally {
+      await sink.close();
+    }
+    if (received != asset.size) throw const FormatException('Incomplete update download');
+    if (asset.sha256Digest != null && (await sha256.bind(target.openRead()).first).toString() != asset.sha256Digest) {
+      throw const FormatException('Update checksum mismatch');
+    }
+  }
+
+  Future<void> _extractApk(File archive, File target) async {
+    final reader = _ChunkReader(gzip.decoder.bind(archive.openRead()));
+    try {
+      final header = await reader.readExact(512);
+      _validateTarChecksum(header);
+      final name = _tarString(header, 0, 100);
+      final size = _tarOctal(header, 124, 12);
+      final type = header[156];
+      if ((name != 'plezy.apk' && name != './plezy.apk') || (type != 0 && type != 0x30)) {
+        throw const FormatException('Unexpected update archive contents');
+      }
+      if (size <= 0 || size > AndroidUpdateAsset.maxApkSize) {
+        throw const FormatException('Invalid APK size');
+      }
+      final sink = target.openWrite();
+      var remaining = size;
+      try {
+        while (remaining > 0) {
+          _checkCancelled();
+          final chunk = await reader.readExact(math.min(64 * 1024, remaining));
+          sink.add(chunk);
+          remaining -= chunk.length;
+        }
+      } finally {
+        await sink.close();
+      }
+      final padding = (512 - (size % 512)) % 512;
+      if (padding > 0) await reader.readExact(padding);
+      if (!(await reader.readExact(512)).every((byte) => byte == 0)) {
+        throw const FormatException('Unexpected extra update archive entry');
+      }
+    } catch (_) {
+      if (await target.exists()) await target.delete();
+      rethrow;
+    } finally {
+      await reader.cancel();
+    }
+  }
+
+  static String _tarString(Uint8List header, int offset, int length) {
+    final bytes = header.sublist(offset, offset + length);
+    final end = bytes.indexOf(0);
+    return utf8.decode(end < 0 ? bytes : bytes.sublist(0, end));
+  }
+
+  static int _tarOctal(Uint8List header, int offset, int length) {
+    final text = ascii.decode(header.sublist(offset, offset + length), allowInvalid: false).replaceAll('\u0000', '').trim();
+    if (!RegExp(r'^[0-7]+$').hasMatch(text)) throw const FormatException('Invalid tar header');
+    return int.parse(text, radix: 8);
+  }
+
+  static void _validateTarChecksum(Uint8List header) {
+    final expected = _tarOctal(header, 148, 8);
+    var actual = 0;
+    for (var i = 0; i < 512; i++) {
+      actual += i >= 148 && i < 156 ? 0x20 : header[i];
+    }
+    if (actual != expected) throw const FormatException('Invalid tar checksum');
+  }
+}
+
+class _ChunkReader {
+  final StreamIterator<List<int>> _iterator;
+  Uint8List _current = Uint8List(0);
+  int _offset = 0;
+
+  _ChunkReader(Stream<List<int>> stream) : _iterator = StreamIterator(stream);
+
+  Future<Uint8List> readExact(int length) async {
+    final result = Uint8List(length);
+    var written = 0;
+    while (written < length) {
+      if (_offset == _current.length) {
+        if (!await _iterator.moveNext()) throw const FormatException('Truncated update archive');
+        _current = Uint8List.fromList(_iterator.current);
+        _offset = 0;
+      }
+      final count = math.min(length - written, _current.length - _offset);
+      result.setRange(written, written + count, _current, _offset);
+      written += count;
+      _offset += count;
+    }
+    return result;
+  }
+
+  Future<void> cancel() => _iterator.cancel();
+}

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -7,12 +7,14 @@ import 'package:plezy/utils/app_logger.dart';
 import 'package:plezy/utils/media_server_http_client.dart';
 import 'package:plezy/utils/platform_detector.dart';
 import 'base_shared_preferences_service.dart';
+import 'android_update_service.dart';
 
 /// Service to check for new versions on GitHub
 /// Only enabled when ENABLE_UPDATE_CHECK build flag is set
 ///
 /// On macOS (non-Homebrew) and installed Windows: delegates to Sparkle/WinSparkle
 /// via auto_updater for native update dialogs and in-app installs.
+/// On Android: downloads the existing per-ABI release archive and opens the system installer.
 /// On all other platforms: falls back to GitHub API check + browser link dialog.
 class UpdateService {
   static const String _githubRepo = 'edde746/plezy';
@@ -171,6 +173,14 @@ class UpdateService {
             return null;
           }
 
+          AndroidUpdateAsset? androidAsset;
+          if (Platform.isAndroid) {
+            androidAsset = AndroidUpdateAsset.select(
+              data['assets'] as List<dynamic>? ?? [],
+              await AndroidUpdateService.supportedAbis(),
+            );
+          }
+
           return {
             'hasUpdate': true,
             'currentVersion': currentVersion,
@@ -179,6 +189,7 @@ class UpdateService {
             'releaseName': data['name'] as String? ?? 'Version $cleanVersion',
             'releaseNotes': data['body'] as String? ?? '',
             'publishedAt': data['published_at'] as String,
+            'androidAsset': androidAsset,
           };
         }
       }

--- a/lib/utils/update_dialog.dart
+++ b/lib/utils/update_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../i18n/strings.g.dart';
+import '../services/android_update_service.dart';
 import '../services/update_service.dart';
 import '../widgets/dialog_action_button.dart';
 import 'dialogs.dart';
@@ -13,6 +14,21 @@ Future<void> showUpdateAvailableDialog(
   required String dismissLabel,
   bool showSkipVersion = false,
 }) {
+  final androidAsset = updateInfo['androidAsset'];
+  if (androidAsset is AndroidUpdateAsset) {
+    return showScopedDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => _AndroidUpdateDialog(
+        updateInfo: updateInfo,
+        asset: androidAsset,
+        title: title,
+        dismissLabel: dismissLabel,
+        showSkipVersion: showSkipVersion,
+      ),
+    );
+  }
+
   return showScopedDialog<void>(
     context: context,
     builder: (dialogContext) {
@@ -61,4 +77,112 @@ Future<void> showUpdateAvailableDialog(
       );
     },
   );
+}
+
+class _AndroidUpdateDialog extends StatefulWidget {
+  final Map<String, dynamic> updateInfo;
+  final AndroidUpdateAsset asset;
+  final String title;
+  final String dismissLabel;
+  final bool showSkipVersion;
+
+  const _AndroidUpdateDialog({
+    required this.updateInfo,
+    required this.asset,
+    required this.title,
+    required this.dismissLabel,
+    required this.showSkipVersion,
+  });
+
+  @override
+  State<_AndroidUpdateDialog> createState() => _AndroidUpdateDialogState();
+}
+
+class _AndroidUpdateDialogState extends State<_AndroidUpdateDialog> {
+  AndroidUpdateService? _updater;
+  double? _progress;
+  bool _failed = false;
+
+  @override
+  void dispose() {
+    _updater?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _install() async {
+    final updater = AndroidUpdateService();
+    setState(() {
+      _updater = updater;
+      _progress = null;
+      _failed = false;
+    });
+    try {
+      await updater.downloadAndInstall(widget.asset, (progress) {
+        if (mounted) setState(() => _progress = progress);
+      });
+      if (mounted) Navigator.pop(context);
+    } on UpdateDownloadCancelled {
+      // Closing the dialog cancels the request intentionally.
+    } catch (_) {
+      if (mounted) setState(() => _failed = true);
+    } finally {
+      if (mounted) setState(() => _updater = null);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final busy = _updater != null;
+    final version = widget.updateInfo['latestVersion'] as String;
+    return AlertDialog(
+      title: Text(widget.title),
+      content: Column(
+        mainAxisSize: .min,
+        crossAxisAlignment: .start,
+        children: [
+          Text(t.update.versionAvailable(version: version), style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(t.update.currentVersion(version: widget.updateInfo['currentVersion']), style: Theme.of(context).textTheme.bodySmall),
+          if (busy) ...[
+            const SizedBox(height: 16),
+            LinearProgressIndicator(value: _progress),
+          ],
+          if (_failed) ...[
+            const SizedBox(height: 16),
+            Text(t.downloads.errorDownloadFailed, style: TextStyle(color: Theme.of(context).colorScheme.error)),
+          ],
+        ],
+      ),
+      actions: [
+        DialogActionButton(
+          onPressed: () {
+            _updater?.cancel();
+            Navigator.pop(context);
+          },
+          label: busy ? t.common.cancel : widget.dismissLabel,
+        ),
+        if (!busy && widget.showSkipVersion)
+          DialogActionButton(
+            onPressed: () async {
+              await UpdateService.skipVersion(version);
+              if (context.mounted) Navigator.pop(context);
+            },
+            label: t.update.skipVersion,
+          ),
+        if (!busy)
+          DialogActionButton(
+            onPressed: () async {
+              final url = Uri.parse(widget.updateInfo['releaseUrl'] as String);
+              if (await canLaunchUrl(url)) await launchUrl(url, mode: LaunchMode.externalApplication);
+            },
+            label: t.update.viewRelease,
+          ),
+        DialogActionButton(
+          onPressed: busy ? null : _install,
+          label: _failed ? t.common.retry : t.downloads.downloadNow,
+          isPrimary: true,
+        ),
+      ],
+    );
+  }
 }

--- a/test/services/android_update_service_test.dart
+++ b/test/services/android_update_service_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:plezy/services/android_update_service.dart';
+
+List<int> tarGz(List<int> apk, {String name = 'plezy.apk'}) {
+  final header = Uint8List(512);
+  void text(int offset, int length, String value) => header.setRange(offset, offset + value.length, ascii.encode(value));
+  void octal(int offset, int length, int value) => text(offset, length, '${value.toRadixString(8).padLeft(length - 1, '0')}\u0000');
+  text(0, 100, name);
+  octal(124, 12, apk.length);
+  header[156] = 0x30;
+  for (var i = 148; i < 156; i++) header[i] = 0x20;
+  final checksum = header.fold<int>(0, (sum, byte) => sum + byte);
+  text(148, 8, '${checksum.toRadixString(8).padLeft(6, '0')}\u0000 ');
+  final tar = BytesBuilder(copy: false)..add(header)..add(apk);
+  tar.add(Uint8List((512 - (apk.length % 512)) % 512));
+  tar.add(Uint8List(1024));
+  return gzip.encode(tar.takeBytes());
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final apk = [1, 2, 3, 4];
+  final archive = tarGz(apk);
+  final url = Uri.parse('https://github.com/edde746/plezy/releases/download/2.19.0/plezy-android-arm64-v8a.tar.gz');
+
+  test('selects the existing release archive for the preferred ABI', () {
+    final asset = AndroidUpdateAsset.select([
+      {
+        'name': 'plezy-android-arm64-v8a.tar.gz',
+        'browser_download_url': url.toString(),
+        'size': archive.length,
+        'digest': 'sha256:${sha256.convert(archive)}',
+      },
+    ], ['arm64-v8a']);
+    expect(asset?.url, url);
+  });
+
+  test('downloads, verifies, extracts, and passes plezy.apk to Android', () async {
+    final directory = await Directory.systemTemp.createTemp('plezy-update-');
+    addTearDown(() => directory.delete(recursive: true));
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    addTearDown(() => messenger.setMockMethodCallHandler(AndroidUpdateService.channel, null));
+    messenger.setMockMethodCallHandler(AndroidUpdateService.channel, (call) async {
+      switch (call.method) {
+        case 'requestInstallPermission':
+          return true;
+        case 'prepareUpdateDirectory':
+          return directory.path;
+        case 'installUpdate':
+          expect(await File(call.arguments['path'] as String).readAsBytes(), apk);
+          return null;
+      }
+      return null;
+    });
+
+    final asset = AndroidUpdateAsset(
+      url: url,
+      size: archive.length,
+      sha256Digest: sha256.convert(archive).toString(),
+    );
+    await AndroidUpdateService(client: MockClient((_) async => http.Response.bytes(archive, 200))).downloadAndInstall(asset, (_) {});
+    expect(await File('${directory.path}/update.apk').readAsBytes(), apk);
+    expect(await File('${directory.path}/update.tar.gz').exists(), isFalse);
+  });
+
+  test('rejects an archive that does not contain plezy.apk', () async {
+    final directory = await Directory.systemTemp.createTemp('plezy-update-');
+    addTearDown(() => directory.delete(recursive: true));
+    final messenger = TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    addTearDown(() => messenger.setMockMethodCallHandler(AndroidUpdateService.channel, null));
+    messenger.setMockMethodCallHandler(AndroidUpdateService.channel, (call) async {
+      if (call.method == 'requestInstallPermission') return true;
+      if (call.method == 'prepareUpdateDirectory') return directory.path;
+      fail('Installer must not be opened for an invalid archive');
+    });
+    final bad = tarGz(apk, name: '../plezy.apk');
+    final asset = AndroidUpdateAsset(url: url, size: bad.length, sha256Digest: sha256.convert(bad).toString());
+    await expectLater(
+      AndroidUpdateService(client: MockClient((_) async => http.Response.bytes(bad, 200))).downloadAndInstall(asset, (_) {}),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Adds in-app update support for Android builds with update checking enabled.

The updater reuses the existing per-ABI Android release archives rather than changing the release format or publishing additional APK assets. It selects the archive matching the device ABI, downloads it, extracts `plezy.apk` into the app cache, and opens Android's package installer.

## Implementation

* select the existing `plezy-android-<abi>.tar.gz` release asset for the current device
* verify the release asset size and GitHub SHA-256 digest when available
* extract the expected `plezy.apk` locally
* reject unexpected archive contents
* verify the package name, version code, and signing identity before opening the installer
* request Android's install-source permission only for updater-enabled release builds

## Scope

The Android installation path is only available when `ENABLE_UPDATE_CHECK=true`.

Other platforms and the existing desktop update paths are unchanged.

Android still handles the actual installation and requires normal user confirmation.

## Verification

Added focused tests for release asset selection, archive download/extraction, invalid archive handling, and the Android installer bridge.

AI assistance: OpenAI GPT-5.6 Sol (ChatGPT) was used for repository analysis, implementation, and review.
