### PR TITLE
fix(tv): show the focused episode's cast

### DIFF
--- a/lib/screens/media_detail/playback_tracks_status.dart
+++ b/lib/screens/media_detail/playback_tracks_status.dart
@@ -39,7 +39,10 @@ extension _MediaDetailPlaybackTracksStatus on _MediaDetailScreenState {
     _playbackProbeTimer?.cancel();
     _playbackProbeRequests.clear();
     _playbackSources.clear();
-    if (refreshItems) _probedPlaybackItems.clear();
+    if (refreshItems) {
+      _probedPlaybackItems.clear();
+      _tvDetailCastEpisodeKey = null;
+    }
     _playbackStatusRevision.value++;
   }
 
@@ -49,7 +52,12 @@ extension _MediaDetailPlaybackTracksStatus on _MediaDetailScreenState {
   void _scheduleTargetProbe(BuildContext context, MediaItem target) {
     if (!_canUseDetail) return;
     final key = target.globalKey;
-    if (_playbackSources.containsKey(key) || _playbackProbeRequests.containsKey(key)) return;
+    final needsCastSync =
+        _tvDetailFocusedEpisode.value?.globalKey == key &&
+        _tvDetailCastEpisodeKey != key &&
+        _probedPlaybackItems.containsKey(key);
+    if (_playbackProbeRequests.containsKey(key)) return;
+    if (_playbackSources.containsKey(key) && !needsCastSync) return;
     final client = widget.isOffline ? null : _getMediaClientForMetadata(context);
     if (!widget.isOffline && client == null) return;
     final downloads = widget.isOffline ? context.read<DownloadProvider>() : null;
@@ -57,6 +65,12 @@ extension _MediaDetailPlaybackTracksStatus on _MediaDetailScreenState {
     final generation = _playbackProbeGeneration;
     _playbackProbeTimer = Timer(const Duration(milliseconds: 350), () {
       if (!mounted || generation != _playbackProbeGeneration || _playbackProbeRequests.containsKey(key)) return;
+      if (_tvDetailFocusedEpisode.value?.globalKey == key &&
+          _tvDetailCastEpisodeKey != key &&
+          _probedPlaybackItems.containsKey(key)) {
+        setStateIfMounted(() => _tvDetailCastEpisodeKey = key);
+      }
+      if (_playbackSources.containsKey(key)) return;
       unawaited(_probeTarget(client, downloads, target, generation));
     });
   }
@@ -95,6 +109,12 @@ extension _MediaDetailPlaybackTracksStatus on _MediaDetailScreenState {
           serverName: target.serverName ?? fetched.serverName,
         );
         _probedPlaybackItems[key] = item;
+        // The list row deliberately omits People. Publish the full episode's
+        // mapped roles only after the debounced item fetch, and only if focus
+        // still points at this episode.
+        if (_tvDetailFocusedEpisode.value?.globalKey == key && _tvDetailCastEpisodeKey != key) {
+          setStateIfMounted(() => _tvDetailCastEpisodeKey = key);
+        }
         final selection = await resolveSavedMediaVersionFor(item);
         if (!current()) return;
         source = await client!.fetchCachedMediaSourceInfo(
@@ -166,7 +186,11 @@ extension _MediaDetailPlaybackTracksStatus on _MediaDetailScreenState {
     final videoLabels = probed?.mediaIndex == null
         ? const <String>[]
         : buildMediaVideoLabels(probed!.item, versionIndex: probed.mediaIndex!, partIndex: source?.partIndex);
-    if (probed == null) _scheduleTargetProbe(context, target);
+    final needsCastSync =
+        _tvDetailFocusedEpisode.value?.globalKey == target.globalKey &&
+        _tvDetailCastEpisodeKey != target.globalKey &&
+        _probedPlaybackItems.containsKey(target.globalKey);
+    if (probed == null || needsCastSync) _scheduleTargetProbe(context, target);
     if (preview == null && videoLabels.isEmpty) return null;
 
     final audioLabel = preview?.audio?.label;

--- a/lib/screens/media_detail_screen.dart
+++ b/lib/screens/media_detail_screen.dart
@@ -361,6 +361,9 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
   // only the foreground info panel, never the whole screen with its rail
   // (same isolation pattern as DiscoverScreen._spotlightItem).
   final ValueNotifier<MediaItem?> _tvDetailFocusedEpisode = ValueNotifier(null);
+  // Full episode metadata whose cast is currently published to the TV rail.
+  // Focus itself stays notifier-only; this changes only after the debounce.
+  String? _tvDetailCastEpisodeKey;
   bool _tvDetailActionRowHasFocus = false;
 
   // Full item snapshots are reusable across preference changes; resolved
@@ -4275,7 +4278,11 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
         );
       }
     }
-    final actors = _tvDetailActorItems(metadata);
+    final focusedEpisode = _tvDetailFocusedEpisode.value;
+    final castMetadata = focusedEpisode != null && _tvDetailCastEpisodeKey == focusedEpisode.globalKey
+        ? _probedPlaybackItems[focusedEpisode.globalKey] ?? metadata
+        : metadata;
+    final actors = _tvDetailActorItems(castMetadata);
     if (actors.isNotEmpty) {
       hubs.add(
         MediaHub(id: _tvDetailActorsHubId, title: t.discover.cast, type: 'person', items: actors, size: actors.length),
@@ -4360,6 +4367,9 @@ class _MediaDetailScreenState extends State<MediaDetailScreen>
 
   void _clearTvDetailFocusedEpisode() {
     _tvDetailFocusedEpisode.value = null;
+    if (_tvDetailCastEpisodeKey != null) {
+      setStateIfMounted(() => _tvDetailCastEpisodeKey = null);
+    }
   }
 
   void _setTvDetailActionRowFocus(bool hasFocus) {

--- a/test/screens/media_detail_screen_test.dart
+++ b/test/screens/media_detail_screen_test.dart
@@ -18,6 +18,7 @@ import 'package:plezy/media/media_hub.dart';
 import 'package:plezy/media/media_item.dart';
 import 'package:plezy/media/media_kind.dart';
 import 'package:plezy/media/media_rating.dart';
+import 'package:plezy/media/media_role.dart';
 import 'package:plezy/media/media_version.dart';
 import 'package:plezy/media/media_source_info.dart';
 import 'package:plezy/media/media_server_client.dart';
@@ -1035,7 +1036,7 @@ void main() {
     expect(find.descendant(of: find.byType(MediaCard), matching: find.text('Episode 2')), findsOneWidget);
   });
 
-  testWidgets('TV detail hero, rail cards, and Play all follow the focused episode', (tester) async {
+  testWidgets('TV detail hero, rail cards, cast, and Play all follow the focused episode', (tester) async {
     final semantics = tester.ensureSemantics();
     await SettingsService.getInstance();
     tester.view.physicalSize = const Size(1280, 720);
@@ -1050,6 +1051,7 @@ void main() {
       title: 'The Show',
       summary: 'The show summary.',
       genres: ['Drama', 'Mystery'],
+      roles: const [MediaRole(id: 'show_actor', tag: 'Show Actor', role: 'Series regular')],
       serverId: 'server_1',
       serverName: 'Server',
     );
@@ -1092,12 +1094,19 @@ void main() {
       serverId: show.serverId,
       serverName: show.serverName,
     );
+    final episodeDetail = episode.copyWith(
+      roles: const [MediaRole(id: 'episode_actor_1', tag: 'Episode One Actor', role: 'Guest')],
+    );
+    final episode2Detail = episode2.copyWith(
+      roles: const [MediaRole(id: 'episode_actor_2', tag: 'Episode Two Actor', role: 'Guest')],
+    );
     final client = _FakeMediaServerClient(
       show: show,
       childrenByParent: {
         show.id: [season],
         season.id: [episode, episode2],
       },
+      itemDetailsById: {episode.id: episodeDetail, episode2.id: episode2Detail},
     );
     final provider = testMultiServer(clients: [client]).provider;
 
@@ -1124,6 +1133,15 @@ void main() {
 
     final heroTitle = find.byKey(const ValueKey('tv_detail_episode_title'));
     final information = find.bySemanticsIdentifier('tv_detail_information');
+
+    List<String> castNames() {
+      final rail = tester.widget<TvBrowseRail>(find.byType(TvBrowseRail));
+      final castHub = rail.hubs.singleWhere((hub) => hub.id == 'detail_actors');
+      return [
+        for (final item in castHub.items)
+          if (item.title != null) item.title!,
+      ];
+    }
 
     // The hero line is the readable copy of the title (#2217).
     expect(heroTitle, findsOneWidget);
@@ -1153,15 +1171,23 @@ void main() {
     expect(find.descendant(of: cards, matching: find.text('S1 E2 · 25min')), findsOneWidget);
     expect(find.descendant(of: cards, matching: find.text('The Show')), findsNothing);
 
+    // Episode rows stay lightweight. Once the existing debounced full-item
+    // probe resolves, the cast rail follows that episode instead of the show.
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+    expect(castNames(), ['Episode One Actor']);
+
     // Play agrees with the hero: the focused episode, not a stale on-deck.
     expect(find.text('S1E1'), findsOneWidget);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowRight);
     await tester.pump();
     await tester.sendKeyUpEvent(LogicalKeyboardKey.arrowRight);
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
     expect(tester.widget<Text>(heroTitle).data, 'The One After');
     expect(find.text('S1E2'), findsOneWidget);
     expect(find.text('S1E1'), findsNothing);
+    expect(castNames(), ['Episode Two Actor']);
     semantics.dispose();
   });
 
@@ -3006,6 +3032,7 @@ class _FakeMediaServerClient implements MediaServerClient {
   final Map<String, Object> childrenPageErrors;
   final Future<List<MediaItem>>? pendingPlayableDescendants;
   final Map<String, MediaSourceInfo> mediaSourcesById;
+  final Map<String, MediaItem> itemDetailsById;
   final Map<String, Map<String, dynamic>> rawItems;
   Completer<void>? sourceGate;
   int itemReads = 0;
@@ -3035,6 +3062,7 @@ class _FakeMediaServerClient implements MediaServerClient {
     this.childrenPageErrors = const {},
     this.pendingPlayableDescendants,
     this.mediaSourcesById = const {},
+    this.itemDetailsById = const {},
     Map<String, Map<String, dynamic>>? rawItems,
   }) : rawItems = rawItems ?? {};
 
@@ -3077,6 +3105,8 @@ class _FakeMediaServerClient implements MediaServerClient {
   @override
   Future<MediaItem?> fetchItem(String id) async {
     itemReads++;
+    final detail = itemDetailsById[id];
+    if (detail != null) return detail;
     final raw = rawItems[id];
     if (raw != null) return PlexMappers.mediaItemFromCacheJson(raw, serverId: serverId);
     if (show.id == id) return show;


### PR DESCRIPTION
## Problem

On the TV show detail screen, the hero and Play target already follow the focused episode, but the Cast hub still uses the show's `metadata.roles`.

For MediaBrowser backends, episode list rows intentionally stay lightweight and omit `People`. The existing debounced full-item probe does fetch the focused episode, including its mapped roles, but that episode-specific metadata was not used by the Cast hub.

This is reproducible with Emby: a real episode contains its own episode-level Actor/GuestStar people, while Plezy's TV cast rail continues to display show-level cast.

## Fix

Reuse the existing 350 ms debounced full-item probe for the focused episode:

- keep the show cast while the full episode item is still pending
- use the probed episode's roles once it resolves
- only publish that cast while focus still points at the same episode
- update it again after the existing probe settles when focus moves to another episode

This does **not** add `People` to episode-list requests and does **not** introduce another API request.

It also stays within Plezy's current TV UX of a show detail screen with a focused episode; it does not add standalone episode detail pages or episode extras.

Related context: #2012 is the broader request for standalone episode details and specials/extras.

## Testing

Extended the existing `TV detail hero, rail cards, cast, and Play all follow the focused episode` widget regression so that two episodes have different full-item casts. The test verifies that the Cast hub follows the focused episode after the existing debounce and updates again after D-pad focus moves to the next episode.

Verified:

- `scripts/codegen.sh --check`
- `flutter analyze`
- `scripts/run_tests.sh test/screens/media_detail_screen_test.dart`
- `git diff --check`

All pass.

The server-side reproduction was also verified against a real Emby library item containing episode-specific people. The patched Plezy build has not been manually smoke-tested on a physical TV device.

## AI assistance

Implemented, reviewed, and tested with OpenAI GPT-5.6 Sol.