### PR TITLE
fix(livetv): avoid MediaBrowser's 8 Mbps Original cap

### DIFF
--- a/lib/services/jellyfin_client/parts/live_tv.dart
+++ b/lib/services/jellyfin_client/parts/live_tv.dart
@@ -193,8 +193,8 @@ class _JellyfinLiveTvSupport implements LiveTvSupport {
   /// - **DirectPlay**: no `TranscodingUrl`; the client streams the source
   ///   through `/Videos/{id}/stream.{container}?Static=true`. Granted only
   ///   when [quality] is `original` (the server treats an unknown live
-  ///   bitrate as 40 Mbps, so any real `MaxStreamingBitrate` cap would deny
-  ///   it anyway) and the source matches a `DirectPlayProfiles` entry.
+  ///   bitrate as 40 Mbps, so a client ceiling must stay above that estimate)
+  ///   and the source matches a `DirectPlayProfiles` entry.
   /// - **Transcode**: an HLS `TranscodingUrl`, capped by the preset's
   ///   bitrate when one is set.
   Future<LiveTvStreamResolution?> _resolveStreamUrl(
@@ -206,9 +206,11 @@ class _JellyfinLiveTvSupport implements LiveTvSupport {
     final info = await _client.getPlaybackInfo(
       channelKey,
       isLiveTv: true,
-      // Original sends no ceiling, mirroring the VOD path: a cap below the
-      // assumed 40 Mbps live bitrate silently forbids direct play.
-      maxStreamingBitrate: quality.isOriginal ? null : (quality.videoBitrateKbps ?? 100_000) * 1000,
+      // A posted MediaBrowser DeviceProfile defaults an omitted
+      // MaxStreamingBitrate to 8 Mbps. Keep Original on Plezy's normal
+      // 100 Mbps negotiation ceiling: it stays above the server's 40 Mbps
+      // unknown-live estimate without inheriting that implicit 8 Mbps cap.
+      maxStreamingBitrate: quality.isOriginal ? 100_000_000 : (quality.videoBitrateKbps ?? 100_000) * 1000,
       autoOpenLiveStream: true,
       enableDirectPlay: wantsDirect,
       enableDirectStream: wantsDirect,

--- a/test/services/live_tv_playback_session_test.dart
+++ b/test/services/live_tv_playback_session_test.dart
@@ -635,12 +635,14 @@ void main() {
       final direct = (await client.liveTv.startPlayback('channel-1'))!;
       expect(Uri.parse((await direct.streamUrlAt())!).path, '/Videos/channel-1/stream.ts');
       expect(negotiations.single['EnableDirectPlay'], isTrue);
+      expect(negotiations.single['MaxStreamingBitrate'], 100_000_000);
       expect(containers(negotiations.single), liveContainers);
 
       final recovered = (await direct.recover(directStream: false, directStreamAudio: true))!;
       expect(Uri.parse((await recovered.streamUrlAt())!).path, '/Videos/channel-1/live.m3u8');
       expect(containers(negotiations[1]), liveContainers);
       expect(negotiations[1]['EnableDirectPlay'], isFalse);
+      expect(negotiations[1]['MaxStreamingBitrate'], 100_000_000);
       expect(negotiations[1]['AllowVideoStreamCopy'], isTrue);
       expect(negotiations[1]['AllowAudioStreamCopy'], isTrue);
       await recovered.reportTimeline(state: 'stopped', positionMs: 0, durationMs: 0);
@@ -805,12 +807,17 @@ void main() {
 
       final session = await client.liveTv.startPlayback('channel-1');
 
-      final body = jsonDecode(negotiations.single.body) as Map<String, dynamic>;
+      final request = negotiations.single;
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+      final deviceProfile = body['DeviceProfile'] as Map<String, dynamic>;
       expect(body['EnableDirectPlay'], isTrue);
       expect(body['EnableDirectStream'], isTrue);
-      // Original sends no ceiling: the server assumes 40 Mbps for an unknown
-      // live bitrate, so any real cap would silently deny direct play.
-      expect(body.containsKey('MaxStreamingBitrate'), isFalse);
+      // Original uses Plezy's normal high negotiation ceiling. 100 Mbps is
+      // above MediaBrowser's 40 Mbps unknown-live estimate and prevents an
+      // omitted DeviceProfile value from falling back to 8 Mbps server-side.
+      expect(request.url.queryParameters['MaxStreamingBitrate'], '100000000');
+      expect(body['MaxStreamingBitrate'], 100_000_000);
+      expect(deviceProfile['MaxStreamingBitrate'], 100_000_000);
 
       // The server-proxied direct URL jellyfin-web uses (not the raw tuner
       // Path, which needs reachability probing).
@@ -943,6 +950,7 @@ void main() {
       final retryBody = jsonDecode(negotiations[1].body) as Map<String, dynamic>;
       expect(retryBody['EnableDirectPlay'], isFalse);
       expect(retryBody['EnableDirectStream'], isFalse);
+      expect(retryBody['MaxStreamingBitrate'], 100_000_000);
 
       // …and the replaced direct session's live stream is released: the
       // player adopts the replacement without ever stop-reporting the old one.


### PR DESCRIPTION
## Problem

MediaBrowser Live TV with quality `Original` currently overrides `getPlaybackInfo`'s normal 100 Mbps negotiation ceiling with `null`.

That looks uncapped, but `getPlaybackInfo` still posts a `DeviceProfile`. MediaBrowser's device profile defaults an omitted `MaxStreamingBitrate` to 8,000,000 bit/s, so otherwise directly playable Live TV above 8 Mbps can be rejected with:

`TranscodeReasons=ContainerBitrateExceedsLimit`

This was reproduced on Emby over a LAN connection that the server explicitly classified as local. The PlaybackInfo request had DirectPlay/DirectStream enabled and no requested bitrate setting; Emby nevertheless evaluated the source against exactly 8 Mbps. After the tuner opened, the source was about 10.55 Mbps and was transcoded solely for exceeding that inherited ceiling.

This is independent of #2294: that PR fixes the `mpegts` container alias. This PR fixes the separate `Original` bitrate negotiation.

## Root cause

`getPlaybackInfo` already defaults to 100 Mbps and forwards a non-null value consistently in:

- the query parameter
- the top-level request body
- `DeviceProfile.MaxStreamingBitrate`

The Live TV path explicitly replaced that default with `null` for `Original`, exposing MediaBrowser's 8 Mbps device-profile default.

## Fix

Keep MediaBrowser Live TV `Original` on Plezy's existing 100 Mbps playback-negotiation ceiling.

This stays above the server's 40 Mbps unknown-live estimate while avoiding the implicit 8 Mbps fallback. Server-side bitrate policy can still impose a lower limit.

Capped quality presets are unchanged. VOD playback, codec profiles, Live TV HLS transport policy, and #2294's container handling are untouched.

## Testing

Extended the existing Live TV playback-session regression coverage to verify:

- both Jellyfin and Emby Original Live TV negotiations send 100 Mbps
- the value is present in the query, top-level request body, and `DeviceProfile`
- DirectPlay/DirectStream stay enabled for Original
- direct-play → forced-transcode recovery keeps the same 100 Mbps ceiling
- capped quality presets still send their selected bitrate (the existing 2 Mbps case remains unchanged)

Full repository CI is left to the pull-request checks.

## AI assistance

Implemented and reviewed with OpenAI GPT-5.6 Sol.