### PR TITLE
fix(livetv): let the server decide direct play under a capped preset

### DIFF
--- a/lib/services/jellyfin_client/parts/live_tv.dart
+++ b/lib/services/jellyfin_client/parts/live_tv.dart
@@ -191,18 +191,20 @@ class _JellyfinLiveTvSupport implements LiveTvSupport {
   /// without `SupportsDirectPlay`:
   ///
   /// - **DirectPlay**: no `TranscodingUrl`; the client streams the source
-  ///   through `/Videos/{id}/stream.{container}?Static=true`. Granted only
-  ///   when [quality] is `original` (the server treats an unknown live
-  ///   bitrate as 40 Mbps, so a client ceiling must stay above that estimate)
-  ///   and the source matches a `DirectPlayProfiles` entry.
+  ///   through `/Videos/{id}/stream.{container}?Static=true`. Granted when the
+  ///   source matches a `DirectPlayProfiles` entry and fits under the ceiling
+  ///   this negotiation sends, which the server checks itself — a capped preset
+  ///   is a ceiling, not a request to re-encode, so direct play is asked for on
+  ///   every preset and the server makes the call (#2306).
   /// - **Transcode**: an HLS `TranscodingUrl`, capped by the preset's
-  ///   bitrate when one is set.
+  ///   bitrate when one is set. That is what a source above the ceiling comes
+  ///   back with, and what [forceTranscode] recovery asks for outright.
   Future<LiveTvStreamResolution?> _resolveStreamUrl(
     String channelKey, {
     required TranscodeQualityPreset quality,
     bool forceTranscode = false,
   }) async {
-    final wantsDirect = quality.isOriginal && !forceTranscode;
+    final wantsDirect = !forceTranscode;
     final info = await _client.getPlaybackInfo(
       channelKey,
       isLiveTv: true,

--- a/test/services/live_tv_playback_session_test.dart
+++ b/test/services/live_tv_playback_session_test.dart
@@ -836,7 +836,7 @@ void main() {
       expect(report['LiveStreamId'], 'live-1');
     });
 
-    test('a capped preset forces a transcode at that ceiling', () async {
+    test('a capped preset transcodes a source the server keeps above the ceiling', () async {
       final negotiations = <http.Request>[];
       final client = JellyfinClient.forTesting(
         connection: conn(),
@@ -862,11 +862,47 @@ void main() {
 
       final session = await client.liveTv.startPlayback('channel-1', quality: TranscodeQualityPreset.p720_2mbps);
 
+      // Direct play is asked for on every preset: the ceiling is what the
+      // server compares the source against, and this source did not clear it,
+      // so the negotiation still comes back as a transcode (#2306).
       final body = jsonDecode(negotiations.single.body) as Map<String, dynamic>;
-      expect(body['EnableDirectPlay'], isFalse);
-      expect(body['EnableDirectStream'], isFalse);
+      expect(body['EnableDirectPlay'], isTrue);
+      expect(body['EnableDirectStream'], isTrue);
       expect(body['MaxStreamingBitrate'], 2_000_000);
       expect(Uri.parse((await session!.streamUrlAt())!).path, endsWith('.m3u8'));
+    });
+
+    test('a capped preset direct-plays a source the server clears', () async {
+      final negotiations = <http.Request>[];
+      final reports = <http.Request>[];
+      final client = JellyfinClient.forTesting(
+        connection: conn(),
+        httpClient: MockClient((request) async {
+          if (request.url.path.contains('PlaybackInfo')) {
+            negotiations.add(request);
+            return jsonResponse({
+              'PlaySessionId': 'play-1',
+              'MediaSources': [
+                {'Id': 'source-1', 'Container': 'ts', 'LiveStreamId': 'live-1', 'SupportsDirectPlay': true},
+              ],
+            });
+          }
+          if (request.url.path.contains('Sessions/Playing')) reports.add(request);
+          return jsonResponse(const {});
+        }),
+      );
+      addTearDown(client.close);
+
+      final session = await client.liveTv.startPlayback('channel-1', quality: TranscodeQualityPreset.p720_2mbps);
+
+      final body = jsonDecode(negotiations.single.body) as Map<String, dynamic>;
+      expect(body['MaxStreamingBitrate'], 2_000_000);
+      expect(body['EnableDirectPlay'], isTrue);
+      expect(Uri.parse((await session!.streamUrlAt())!).path, '/Videos/channel-1/stream.ts');
+
+      await session.reportTimeline(state: 'playing', positionMs: 1000, durationMs: 0);
+      final report = jsonDecode(reports.single.body) as Map<String, dynamic>;
+      expect(report['PlayMethod'], 'DirectPlay');
     });
 
     test('a negotiation that yields no HLS URL closes the live stream it opened', () async {


### PR DESCRIPTION
## Problem

Live TV negotiation disabled direct play whenever the quality preset was not `Original`:

```dart
final wantsDirect = quality.isOriginal && !forceTranscode;
```

A preset is a ceiling, not a request to re-encode. With direct play disabled the server answers `TranscodeReasons=DirectPlayError` and the best available outcome is a remux — one ffmpeg process, a `/cache` segment directory and HLS latency per session — even for a channel the server has already declared **below** the selected ceiling.

Observed on Jellyfin 12.0.0: source declared `8192000`, preset 20 Mbps, `TranscodeReasons=AudioCodecNotSupported,DirectPlayError`, and an `FFmpeg.Remux` job with `-codec:v:0 copy -codec:a:0 copy`. Nothing about the source prevented direct play.

Fixes #2306.

## Root cause

The ceiling comparison belongs to the server, and MediaBrowser already performs it — this is the same reasoning `directPlayCoveredQuality` (#2152) records for VOD, where the setting is documented as Plex-only precisely because MediaBrowser servers make the call server-side. Live TV pre-empted that decision client-side, so the server never got to make it.

Three `PlaybackInfo` calls on one channel with `EnableDirectPlay=true`, changing only the ceiling, show the server deciding correctly on its own:

| ceiling sent | source declared | `SupportsDirectPlay` | `TranscodingUrl` |
|---|---|---|---|
| none (server default 8 Mbps) | `8192000` | `false` | `master.m3u8` |
| `100000000` | `8192000` | `true` | `null` |

## Fix

Ask for direct play on every preset and let the server compare the source against the ceiling the negotiation already sends:

```diff
-    final wantsDirect = quality.isOriginal && !forceTranscode;
+    final wantsDirect = !forceTranscode;
```

The ceiling itself is untouched, so a capped preset still means what it says: a source above it comes back with a `TranscodingUrl`, which the existing branch adopts — that branch already gates the direct URL on `source['SupportsDirectPlay'] == true`. Forced-transcode recovery (`forceTranscode: true`) keeps disabling direct play, unchanged.

The doc comment on `_resolveStreamUrl` is updated: it described direct play as granted only on `Original`.

## Testing

`test/services/live_tv_playback_session_test.dart`:

- the capped-preset regression now asserts `EnableDirectPlay`/`EnableDirectStream` are sent as `true` and still resolves to the HLS URL, because that source does not clear the ceiling;
- a new regression covers the case this PR is about: a capped preset with a source the server clears resolves to `/Videos/channel-1/stream.ts` and heartbeats report `PlayMethod: DirectPlay`;
- the forced-transcode recovery assertions (`EnableDirectPlay` false) are unchanged, and the Plex live suite is untouched.

I could not run `dart format`, `flutter analyze` or `scripts/run_tests.sh` locally — no Flutter toolchain on the machine I filed this from — so the repository CI is the gate on this one.

## AI assistance

Claude Opus 5.
