### PR TITLE
feat(music): add discord rpc for music player

### DIFF
--- a/lib/services/discord_rpc_service.dart
+++ b/lib/services/discord_rpc_service.dart
@@ -79,6 +79,7 @@ class DiscordRPCService {
   DateTime? _playbackStartTime;
   final PlaybackTimeline _timeline = PlaybackTimeline();
   double _playbackSpeed = 1.0;
+  DiscordActivityType _activityType = DiscordActivityType.watching;
   int _playbackRevision = 0;
   Timer? _reconnectTimer;
   DateTime? _lastPresenceUpdate;
@@ -139,7 +140,11 @@ class DiscordRPCService {
   /// Start showing presence for media playback. Works for any backend —
   /// thumbnail upload uses the neutral [MediaServerClient.thumbnailUrl] /
   /// [MediaServerClient.streamHeaders] surface.
-  Future<void> startPlayback(MediaItem metadata, MediaServerClient client) async {
+  Future<void> startPlayback(
+    MediaItem metadata,
+    MediaServerClient client, [
+    DiscordActivityType type = DiscordActivityType.watching,
+  ]) async {
     final revision = ++_playbackRevision;
     _currentMetadata = metadata;
     _currentClient = client;
@@ -147,6 +152,7 @@ class DiscordRPCService {
     _timeline.reset(duration: metadata.durationMs != null ? Duration(milliseconds: metadata.durationMs!) : null);
     _cachedThumbnailUrl = null;
     _playbackSpeed = 1.0;
+    _activityType = type;
 
     if (_isEnabled && _isConnected) {
       unawaited(_uploadThumbnailAndUpdatePresence(revision, metadata, client));
@@ -421,7 +427,7 @@ class DiscordRPCService {
 
       await _rpc!.setPresence(
         DiscordPresence(
-          type: DiscordActivityType.watching,
+          type: _activityType,
           details: details,
           state: state,
           timestamps: _buildTimestamps(),

--- a/lib/services/music/music_playback_service_impl.dart
+++ b/lib/services/music/music_playback_service_impl.dart
@@ -842,9 +842,16 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
     }
 
     if (shouldBePlaying) {
-      DiscordRPCService.instance.resumePlayback();
+      // It's assumed _currentTrack is not null here, otherwise why is it marked as playing?
+      final track = _currentTrack as MediaItem;
+      final client = _clientFor(track);
+      if (client != null) {
+        unawaited(
+          DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
+        );
+      }
     } else {
-      DiscordRPCService.instance.pausePlayback();
+      DiscordRPCService.instance.stopPlayback();
     }
   }
 

--- a/lib/services/music/music_playback_service_impl.dart
+++ b/lib/services/music/music_playback_service_impl.dart
@@ -5,6 +5,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart' show ValueListenable, visibleForTesting;
 import 'package:flutter/widgets.dart';
 import 'package:os_media_controls/os_media_controls.dart';
+import 'package:dart_discord_presence/dart_discord_presence.dart';
 
 import '../../database/app_database.dart';
 import '../../i18n/strings.g.dart';
@@ -27,6 +28,7 @@ import '../playback_coordinator.dart';
 import '../playback_launch_observer.dart';
 import '../playback_initialization_service.dart';
 import '../playback_progress_tracker.dart';
+import '../../services/discord_rpc_service.dart';
 import '../settings_service.dart';
 import 'music_hardware_transport.dart';
 import 'music_playback_service.dart';
@@ -801,6 +803,7 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
       _mediaControls?.updatePlaybackState(isPlaying: player.state.isActive, position: position, speed: 1.0);
     }
     if (_status == MusicPlaybackStatus.playing) _maybePersistPositionTick(position);
+    DiscordRPCService.instance.updatePosition(position);
   }
 
   void _onPlayingChanged(bool isPlaying) {
@@ -825,6 +828,19 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
         speed: 1.0,
         force: true,
       );
+    }
+
+    if (shouldBePlaying) {
+      // It's assumed _currentTrack is not null here, otherwise why is it marked as playing?
+      final track = _currentTrack as MediaItem;
+      final client = _clientFor(track);
+      if (client != null) {
+        unawaited(
+          DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
+        );
+      }
+    } else {
+      DiscordRPCService.instance.stopPlayback();
     }
   }
 

--- a/lib/services/music/music_playback_service_impl.dart
+++ b/lib/services/music/music_playback_service_impl.dart
@@ -768,6 +768,7 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
       ..clear()
       ..add(player.streams.position.listen(_onPosition))
       ..add(player.streams.playheadJump.listen(_playheadJumpController.add))
+      ..add(player.streams.playheadJump.listen(_onPlayheadJumped))
       ..add(player.streams.playing.listen(_onPlayingChanged))
       ..add(player.streams.trackTransition.listen(_onTrackTransition))
       ..add(player.streams.completed.listen(_onCompleted))
@@ -814,7 +815,12 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
       _mediaControls?.updatePlaybackState(isPlaying: player.state.isActive, position: position, speed: 1.0);
     }
     if (_status == MusicPlaybackStatus.playing) _maybePersistPositionTick(position);
-    DiscordRPCService.instance.updatePosition(position);
+  }
+
+  void _onPlayheadJumped(Duration? position) {
+    if(position != null) {
+      DiscordRPCService.instance.updatePosition(position);
+    }
   }
 
   void _onPlayingChanged(bool isPlaying) {
@@ -849,6 +855,9 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
         unawaited(
           DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
         );
+        if(_player != null && _player?.currentPosition != null) {
+          DiscordRPCService.instance.updatePosition(_player!.currentPosition!);
+        }
       }
     } else {
       DiscordRPCService.instance.stopPlayback();
@@ -932,6 +941,9 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
         unawaited(
           DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
         );
+        if(_player != null && _player?.currentPosition != null) {
+          DiscordRPCService.instance.updatePosition(_player!.currentPosition!);
+        }
       }
     } else {
       DiscordRPCService.instance.stopPlayback();

--- a/lib/services/music/music_playback_service_impl.dart
+++ b/lib/services/music/music_playback_service_impl.dart
@@ -924,6 +924,18 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
     }
     _bindTrackServices(_currentTrack!, adopted.source);
     _requestArmNext();
+
+    if(_status == MusicPlaybackStatus.playing) {
+      final track = _currentTrack as MediaItem;
+      final client = _clientFor(track);
+      if (client != null) {
+        unawaited(
+          DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
+        );
+      }
+    } else {
+      DiscordRPCService.instance.stopPlayback();
+    }
   }
 
   /// Completed (eof-reached) is NOT a last-entry-only signal: mpv pulses it

--- a/lib/services/music/music_playback_service_impl.dart
+++ b/lib/services/music/music_playback_service_impl.dart
@@ -573,6 +573,17 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
       committedPlayer = player;
       _setStatus(playbackStarted ? MusicPlaybackStatus.playing : MusicPlaybackStatus.paused);
       _bindTrackServices(track, source);
+
+      if(playbackStarted) {
+        final client = source.reportingClient;
+        if (client != null) {
+          unawaited(
+            DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
+          );
+        }
+      } else {
+        DiscordRPCService.instance.stopPlayback();
+      }
     } finally {
       // A stale open must never release a newer open's ownership. Only a
       // committed current open schedules its successor; an unsuccessful

--- a/lib/services/music/music_playback_service_impl.dart
+++ b/lib/services/music/music_playback_service_impl.dart
@@ -842,16 +842,9 @@ class MusicPlaybackServiceImpl extends MusicPlaybackService with WidgetsBindingO
     }
 
     if (shouldBePlaying) {
-      // It's assumed _currentTrack is not null here, otherwise why is it marked as playing?
-      final track = _currentTrack as MediaItem;
-      final client = _clientFor(track);
-      if (client != null) {
-        unawaited(
-          DiscordRPCService.instance.startPlayback(track, client as MediaServerClient, DiscordActivityType.listening),
-        );
-      }
+      DiscordRPCService.instance.resumePlayback();
     } else {
-      DiscordRPCService.instance.stopPlayback();
+      DiscordRPCService.instance.pausePlayback();
     }
   }
 


### PR DESCRIPTION
Adds Discord RPC when using the Music Player, via the same service as the Video RPC that's been slightly modified to allow for a Listening activity instead. Note this is toggled from the same setting as for Video RPC.

<img width="250" height="401" alt="image" src="https://github.com/user-attachments/assets/3db58ac6-4435-4ee8-bc61-793bdb401357" />

Tested on Linux using a Jellyfin server, not tried another media provider like Plex as I don't have it hosted myself.

Fixes #2318